### PR TITLE
feat(mcp): implement MCP hot-reload with McpManager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3687,6 +3687,7 @@ dependencies = [
  "klaw-gateway",
  "klaw-heartbeat",
  "klaw-llm",
+ "klaw-mcp",
  "klaw-memory",
  "klaw-observability",
  "klaw-session",

--- a/klaw-cli/src/commands/gui.rs
+++ b/klaw-cli/src/commands/gui.rs
@@ -1,6 +1,7 @@
 use clap::Args;
 use klaw_channel::{ChannelConfigSnapshot, ChannelManager};
 use klaw_config::AppConfig;
+use klaw_mcp::McpConfigSnapshot;
 use std::{io, sync::Arc};
 use tokio::sync::watch;
 
@@ -78,6 +79,8 @@ impl GuiCommand {
                             let mut channel_manager = ChannelManager::new(Arc::clone(&adapter));
                             channel_manager.sync(channel_snapshot).await;
 
+                            let mcp_manager = runtime.mcp_init.as_ref().and_then(|h| h.try_lock().ok().map(|g| g.manager()));
+
                             let shutdown_by_signal = loop {
                                 tokio::select! {
                                     changed = shutdown_rx.changed() => {
@@ -114,6 +117,23 @@ impl GuiCommand {
                                                         }
                                                     }
                                                     Err(err) => Err(err.to_string()),
+                                                };
+                                                let _ = response.send(result);
+                                            }
+                                            Some(klaw_gui::RuntimeCommand::SyncMcp { response }) => {
+                                                let result = match &mcp_manager {
+                                                    Some(manager) => {
+                                                        match ConfigStore::open(None) {
+                                                            Ok(store) => {
+                                                                let snapshot = store.snapshot();
+                                                                let mcp_snapshot = McpConfigSnapshot::from_mcp_config(&snapshot.config.mcp);
+                                                                let mut guard = manager.lock().await;
+                                                                Ok(guard.sync(mcp_snapshot).await)
+                                                            }
+                                                            Err(err) => Err(err.to_string()),
+                                                        }
+                                                    }
+                                                    None => Err("mcp manager not initialized".to_string()),
                                                 };
                                                 let _ = response.send(result);
                                             }

--- a/klaw-cli/src/commands/startup_display.rs
+++ b/klaw-cli/src/commands/startup_display.rs
@@ -56,10 +56,15 @@ fn format_mcp_status(config: &AppConfig, report: &StartupReport) -> String {
 
     match &report.mcp_summary {
         Some(summary) => {
-            let failure_suffix = if summary.failures.is_empty() {
+            let failed_count = summary
+                .statuses
+                .iter()
+                .filter(|s| s.state == klaw_mcp::McpLifecycleState::Failed)
+                .count();
+            let failure_suffix = if failed_count == 0 {
                 String::new()
             } else {
-                format!(", failures {}", summary.failures.len())
+                format!(", failures {}", failed_count)
             };
             format!(
                 "ready, servers {}/{}, tools {}, {}{}",
@@ -86,7 +91,7 @@ fn join_or_dash(items: &[String]) -> String {
 mod tests {
     use crate::runtime::StartupReport;
     use klaw_config::{AppConfig, McpServerConfig, McpServerMode};
-    use klaw_mcp::McpBootstrapSummary;
+    use klaw_mcp::{McpLifecycleState, McpServerKey, McpServerStatus, McpSyncResult};
 
     use super::{format_mcp_status, join_or_dash, tools_for_display};
 
@@ -107,12 +112,21 @@ mod tests {
                 "web_search".to_string(),
                 "remote_browser".to_string(),
             ],
-            mcp_summary: Some(McpBootstrapSummary {
+            mcp_summary: Some(McpSyncResult {
+                keep: vec![McpServerKey::new("local")],
+                start: vec![],
+                restart: vec![],
+                stop: vec![],
+                statuses: vec![McpServerStatus {
+                    key: McpServerKey::new("local"),
+                    mode: McpServerMode::Stdio,
+                    enabled: true,
+                    state: McpLifecycleState::Running,
+                    last_error: None,
+                    tool_count: 2,
+                }],
                 active_servers: vec!["local".to_string()],
-                required_stdio_servers: vec!["local".to_string()],
-                active_stdio_servers: vec!["local".to_string()],
                 tool_count: 2,
-                failures: Vec::new(),
             }),
         };
 
@@ -142,12 +156,21 @@ mod tests {
         let report = StartupReport {
             skill_names: Vec::new(),
             tool_names: Vec::new(),
-            mcp_summary: Some(McpBootstrapSummary {
+            mcp_summary: Some(McpSyncResult {
+                keep: vec![McpServerKey::new("local")],
+                start: vec![],
+                restart: vec![],
+                stop: vec![],
+                statuses: vec![McpServerStatus {
+                    key: McpServerKey::new("local"),
+                    mode: McpServerMode::Stdio,
+                    enabled: true,
+                    state: McpLifecycleState::Running,
+                    last_error: None,
+                    tool_count: 3,
+                }],
                 active_servers: vec!["local".to_string()],
-                required_stdio_servers: vec!["local".to_string()],
-                active_stdio_servers: vec!["local".to_string()],
                 tool_count: 3,
-                failures: Vec::new(),
             }),
         };
 

--- a/klaw-cli/src/runtime/mod.rs
+++ b/klaw-cli/src/runtime/mod.rs
@@ -27,7 +27,7 @@ use klaw_core::{
 use klaw_gateway::GatewayWebhookRequest;
 use klaw_heartbeat::should_suppress_output;
 use klaw_llm::{ChatOptions, LlmError, LlmMessage, LlmProvider, LlmResponse, ToolDefinition};
-use klaw_mcp::{McpBootstrapHandle, McpBootstrapSummary, McpManager};
+use klaw_mcp::{McpConfigSnapshot, McpInitHandle, McpManager, McpSyncResult};
 use klaw_observability::{
     init_observability, ObservabilityConfig, ObservabilityHandle, OtelAgentTelemetry,
 };
@@ -66,7 +66,7 @@ const LLM_AUDIT_QUEUE_CAPACITY: usize = 1024;
 pub struct StartupReport {
     pub skill_names: Vec<String>,
     pub tool_names: Vec<String>,
-    pub mcp_summary: Option<McpBootstrapSummary>,
+    pub mcp_summary: Option<McpSyncResult>,
 }
 
 pub struct RuntimeBundle {
@@ -84,7 +84,7 @@ pub struct RuntimeBundle {
     pub circuit_breaker: InMemoryCircuitBreaker,
     pub subscription: Subscription,
     pub session_store: DefaultSessionStore,
-    pub mcp_bootstrap: Option<Mutex<McpBootstrapHandle>>,
+    pub mcp_init: Option<Mutex<McpInitHandle>>,
     pub startup_report: StartupReport,
     pub observability: Option<ObservabilityHandle>,
     pub conversation_history_limit: usize,
@@ -1200,11 +1200,9 @@ pub async fn build_runtime_bundle(config: &AppConfig) -> Result<RuntimeBundle, B
         tools.register(SubAgentTool::new(Arc::new(config.clone()), parent_tools));
     }
 
-    let mcp_bootstrap = if config.mcp.enabled && configured_mcp_servers > 0 {
-        Some(Mutex::new(McpManager::spawn_bootstrap(
-            config.mcp.clone(),
-            tools.clone(),
-        )))
+    let mcp_init = if config.mcp.enabled && configured_mcp_servers > 0 {
+        let snapshot = McpConfigSnapshot::from_mcp_config(&config.mcp);
+        Some(Mutex::new(McpManager::spawn_init(tools.clone(), snapshot)))
     } else {
         None
     };
@@ -1302,7 +1300,7 @@ pub async fn build_runtime_bundle(config: &AppConfig) -> Result<RuntimeBundle, B
             visibility_timeout: Duration::from_secs(10),
         },
         session_store,
-        mcp_bootstrap,
+        mcp_init,
         observability,
         conversation_history_limit: config.conversation_history_limit,
         llm_audit_tx,
@@ -1339,15 +1337,14 @@ fn spawn_llm_audit_writer(
 }
 
 pub async fn shutdown_runtime_bundle(runtime: &RuntimeBundle) -> Result<(), Box<dyn Error>> {
-    if let Some(handle) = &runtime.mcp_bootstrap {
+    if let Some(handle) = &runtime.mcp_init {
         info!("shutting down runtime mcp servers");
-        let mut guard = handle.lock().await;
+        let guard = handle.lock().await;
+        let manager = guard.manager();
+        let mut manager_guard = manager.lock().await;
         let shutdown_deadline = Duration::from_secs(2);
-        match timeout(shutdown_deadline, guard.shutdown()).await {
-            Ok(Ok(())) => {}
-            Ok(Err(err)) => {
-                return Err(config_err(format!("mcp shutdown failed: {err}")));
-            }
+        match timeout(shutdown_deadline, manager_guard.shutdown_all()).await {
+            Ok(()) => {}
             Err(_) => {
                 warn!(
                     timeout_seconds = shutdown_deadline.as_secs(),
@@ -2190,7 +2187,7 @@ async fn init_observability_from_config(config: &AppConfig) -> Option<Observabil
 pub async fn finalize_startup_report(
     runtime: &mut RuntimeBundle,
 ) -> Result<StartupReport, Box<dyn Error>> {
-    let mcp_summary = match &runtime.mcp_bootstrap {
+    let mcp_summary = match &runtime.mcp_init {
         Some(handle) => {
             let mut guard = handle.lock().await;
             if guard.is_ready() {
@@ -2198,7 +2195,7 @@ pub async fn finalize_startup_report(
                     guard
                         .wait_until_ready()
                         .await
-                        .map_err(|err| config_err(format!("mcp bootstrap failed: {err}")))?,
+                        .map_err(|err| config_err(format!("mcp init failed: {err}")))?,
                 )
             } else {
                 None

--- a/klaw-config/src/lib.rs
+++ b/klaw-config/src/lib.rs
@@ -389,7 +389,7 @@ pub enum McpServerMode {
     Sse,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct McpServerConfig {
     pub id: String,
     #[serde(default = "default_mcp_server_enabled")]
@@ -407,6 +407,22 @@ pub struct McpServerConfig {
     pub url: Option<String>,
     #[serde(default)]
     pub headers: BTreeMap<String, String>,
+}
+
+impl Default for McpServerConfig {
+    fn default() -> Self {
+        Self {
+            id: String::new(),
+            enabled: default_mcp_server_enabled(),
+            mode: McpServerMode::Stdio,
+            command: None,
+            args: Vec::new(),
+            env: BTreeMap::new(),
+            cwd: None,
+            url: None,
+            headers: BTreeMap::new(),
+        }
+    }
 }
 
 fn default_mcp_enabled() -> bool {

--- a/klaw-gui/Cargo.toml
+++ b/klaw-gui/Cargo.toml
@@ -23,6 +23,7 @@ klaw-archive = { workspace = true }
 klaw-cron = { workspace = true }
 klaw-gateway = { workspace = true }
 klaw-heartbeat = { workspace = true }
+klaw-mcp = { workspace = true }
 klaw-memory = { workspace = true }
 klaw-observability = { workspace = true }
 klaw-session = { workspace = true }

--- a/klaw-gui/src/lib.rs
+++ b/klaw-gui/src/lib.rs
@@ -19,7 +19,7 @@ pub use runtime_bridge::{
     install_runtime_command_sender, request_env_check, request_gateway_status,
     request_restart_gateway, request_run_cron_now, request_run_heartbeat_now,
     request_set_gateway_enabled, request_set_tailscale_mode, request_sync_channels,
-    GatewayStatusSnapshot, RuntimeCommand,
+    request_sync_mcp, GatewayStatusSnapshot, RuntimeCommand,
 };
 pub use state::workbench::{TabId, WorkbenchState, WorkbenchTab};
 pub use state::UiAction;

--- a/klaw-gui/src/runtime_bridge.rs
+++ b/klaw-gui/src/runtime_bridge.rs
@@ -1,6 +1,7 @@
 use klaw_channel::ChannelSyncResult;
 use klaw_config::TailscaleMode;
 use klaw_gateway::GatewayRuntimeInfo;
+use klaw_mcp::McpSyncResult;
 use klaw_util::EnvironmentCheckReport;
 use std::sync::{mpsc, Mutex, OnceLock};
 use tokio::sync::mpsc::UnboundedSender;
@@ -25,6 +26,9 @@ pub enum RuntimeCommand {
     },
     SyncChannels {
         response: mpsc::Sender<Result<ChannelSyncResult, String>>,
+    },
+    SyncMcp {
+        response: mpsc::Sender<Result<McpSyncResult, String>>,
     },
     RunCronNow {
         cron_id: String,
@@ -285,6 +289,24 @@ pub fn request_set_tailscale_mode(mode: TailscaleMode) -> Result<GatewayStatusSn
     sender
         .send(RuntimeCommand::SetTailscaleMode {
             mode,
+            response: response_tx,
+        })
+        .map_err(|_| "failed to send runtime command".to_string())?;
+
+    response_rx
+        .recv()
+        .map_err(|_| "runtime command response channel closed".to_string())?
+}
+
+pub fn request_sync_mcp() -> Result<McpSyncResult, String> {
+    let sender = sender_slot()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone()
+        .ok_or_else(|| "runtime command channel is not available".to_string())?;
+    let (response_tx, response_rx) = mpsc::channel();
+    sender
+        .send(RuntimeCommand::SyncMcp {
             response: response_tx,
         })
         .map_err(|_| "failed to send runtime command".to_string())?;

--- a/klaw-mcp/CHANGELOG.md
+++ b/klaw-mcp/CHANGELOG.md
@@ -1,5 +1,28 @@
 # CHANGELOG
 
+## 2026-03-22
+
+### Added
+
+- 新增 MCP 热重载支持：`McpManager` 支持动态启动/停止/重启 MCP 服务器
+- 新增 `McpServerKey`、`McpLifecycleState`、`McpServerStatus` 数据结构用于状态管理
+- 新增 `McpConfigSnapshot` 用于配置快照和差异比较
+- 新增 `McpSyncResult` 返回同步操作结果
+- 新增 `RuntimeCommand::SyncMcp` 命令支持 GUI 触发 MCP 配置同步
+- 新增 `ToolRegistry::unregister` 和 `unregister_many` 方法支持工具动态注销
+
+### Changed
+
+- `McpManager::spawn_init` 现在接收 `ToolRegistry` 和 `McpConfigSnapshot` 参数，返回 `McpInitHandle`
+- `McpInitHandle` 包含 `manager()` 方法获取 `Arc<Mutex<McpManager>>` 用于后续 sync 操作
+- `McpClientHub::remove` 返回类型改为 `()`
+- `McpServerConfig` 新增 `Default` 和 `PartialEq` 实现
+
+### Fixed
+
+- Stdio 类型的 MCP 服务器在停止时正确杀子进程
+- SSE 类型的 MCP 服务器在停止时仅更新内存数据
+
 ## 2026-03-13
 
 ### Added

--- a/klaw-mcp/README.md
+++ b/klaw-mcp/README.md
@@ -1,13 +1,45 @@
 # klaw-mcp
 
-`klaw-mcp` 负责 MCP server 的连接、bootstrap、远程工具发现，以及把远端工具挂接到本地 `ToolRegistry`。
+`klaw-mcp` 负责 MCP server 的连接、bootstrap、远程工具发现，以及把远端工具挂接到本地 `ToolRegistry`，并支持 MCP 服务器的热重载。
 
 ## Responsibilities
 
 - 按配置启动 `stdio` MCP 子进程或连接 `sse` MCP 服务
 - 执行 `initialize` / `tools/list` 并汇总可用工具
 - 处理工具名冲突与 bootstrap 失败汇总
+- 支持动态启动/停止/重启 MCP 服务器（热重载）
 - 在 runtime 退出时关闭已连接的 MCP client
+
+## Hot Reload
+
+`McpManager` 支持通过配置变更动态管理 MCP 服务器：
+
+```rust
+// 初始化
+let manager = McpManager::spawn_init(tools, config_snapshot);
+let mcp_manager = manager.manager();
+
+// 热重载配置
+let new_snapshot = McpConfigSnapshot::from_mcp_config(&new_config);
+let result = mcp_manager.lock().await.sync(new_snapshot).await;
+```
+
+### Lifecycle States
+
+| State | Description |
+|-------|-------------|
+| `Starting` | Server is being initialized |
+| `Running` | Server is operational |
+| `Stopped` | Server is stopped |
+| `Failed` | Server failed to start |
+
+### Stdio vs SSE Handling
+
+| Operation | Stdio Mode | SSE Mode |
+|-----------|------------|----------|
+| Start | Spawn subprocess + init handshake | Create HTTP client + init handshake |
+| Stop | Kill subprocess + cleanup | Remove client from hub (memory only) |
+| Restart | Kill → Respawn | Update client config |
 
 ## Shutdown
 

--- a/klaw-mcp/src/hub.rs
+++ b/klaw-mcp/src/hub.rs
@@ -56,6 +56,10 @@ impl McpClientHub {
         self.clients.keys().cloned().collect()
     }
 
+    pub fn contains(&self, server_id: &str) -> bool {
+        self.clients.contains_key(server_id)
+    }
+
     pub async fn call_tool(
         &self,
         server_id: &str,

--- a/klaw-mcp/src/lib.rs
+++ b/klaw-mcp/src/lib.rs
@@ -7,5 +7,8 @@ pub use hub::{
     format_tool_result_for_model, McpBootstrapFailure, McpBootstrapResult, McpClientHub,
     McpClientHubError, McpRuntimeHandles, McpToolDescriptor,
 };
-pub use manager::{McpBootstrapError, McpBootstrapHandle, McpBootstrapSummary, McpManager};
+pub use manager::{
+    McpBootstrapError, McpConfigSnapshot, McpInitHandle, McpLifecycleState, McpManager,
+    McpServerKey, McpServerStatus, McpSyncResult,
+};
 pub use runtime::McpProxyTool;

--- a/klaw-mcp/src/manager.rs
+++ b/klaw-mcp/src/manager.rs
@@ -1,15 +1,13 @@
 use crate::{
     client::{McpClient, McpRemoteTool, SseMcpClient, StdioMcpClient},
-    hub::{
-        McpBootstrapFailure, McpBootstrapResult, McpClientHub, McpRuntimeHandles, McpToolDescriptor,
-    },
+    hub::{McpClientHub, McpToolDescriptor},
 };
-use async_trait::async_trait;
 use klaw_config::{McpConfig, McpServerConfig, McpServerMode};
 use klaw_tool::ToolRegistry;
 use std::{
     collections::{BTreeMap, BTreeSet},
-    sync::Arc,
+    fmt,
+    sync::{Arc, Mutex as StdMutex},
     time::Duration,
 };
 use thiserror::Error;
@@ -20,304 +18,726 @@ use tokio::{
 };
 use tracing::{info, warn};
 
-pub struct McpManager;
+const SERVER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
 
-impl McpManager {
-    pub async fn bootstrap(config: &McpConfig) -> McpBootstrapResult {
-        let factory: Arc<dyn McpClientFactory> = Arc::new(RealMcpClientFactory);
-        bootstrap_with_factory(config, factory).await
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct McpServerKey(String);
+
+impl McpServerKey {
+    #[must_use]
+    pub fn new(id: impl AsRef<str>) -> Self {
+        Self(id.as_ref().trim().to_string())
     }
 
-    pub fn spawn_bootstrap(config: McpConfig, tools: ToolRegistry) -> McpBootstrapHandle {
-        let factory: Arc<dyn McpClientFactory> = Arc::new(RealMcpClientFactory);
-        spawn_bootstrap_with_factory(config, tools, factory)
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
     }
+}
+
+impl fmt::Display for McpServerKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl From<&str> for McpServerKey {
+    fn from(value: &str) -> Self {
+        Self::new(value)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum McpLifecycleState {
+    Starting,
+    Running,
+    Stopped,
+    Failed,
+}
+
+impl McpLifecycleState {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Starting => "starting",
+            Self::Running => "running",
+            Self::Stopped => "stopped",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct McpServerStatus {
+    pub key: McpServerKey,
+    pub mode: McpServerMode,
+    pub enabled: bool,
+    pub state: McpLifecycleState,
+    pub last_error: Option<String>,
+    pub tool_count: usize,
+}
+
+impl McpServerStatus {
+    fn from_config(
+        config: &McpServerConfig,
+        state: McpLifecycleState,
+        last_error: Option<String>,
+        tool_count: usize,
+    ) -> Self {
+        Self {
+            key: McpServerKey::new(&config.id),
+            mode: config.mode.clone(),
+            enabled: config.enabled,
+            state,
+            last_error,
+            tool_count,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct McpConfigSnapshot {
+    pub enabled: bool,
+    pub startup_timeout_seconds: u64,
+    pub servers: Vec<McpServerConfig>,
+}
+
+impl McpConfigSnapshot {
+    pub fn from_mcp_config(config: &McpConfig) -> Self {
+        Self {
+            enabled: config.enabled,
+            startup_timeout_seconds: config.startup_timeout_seconds,
+            servers: config.servers.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct McpSyncResult {
+    pub keep: Vec<McpServerKey>,
+    pub start: Vec<McpServerKey>,
+    pub restart: Vec<McpServerKey>,
+    pub stop: Vec<McpServerKey>,
+    pub statuses: Vec<McpServerStatus>,
+    pub active_servers: Vec<String>,
+    pub tool_count: usize,
 }
 
 #[derive(Debug, Error)]
 pub enum McpBootstrapError {
-    #[error("bootstrap timed out after {timeout_seconds}s")]
+    #[error("init timed out after {timeout_seconds}s")]
     Timeout { timeout_seconds: u64 },
     #[error("{0}")]
     Other(String),
 }
 
-struct ServerBootstrapOk {
-    index: usize,
+struct ServerStartOk {
     server_id: String,
     mode: McpServerMode,
     client: Arc<dyn McpClient>,
     tools: Vec<McpRemoteTool>,
 }
 
-struct ServerBootstrapErr {
+struct ServerStartErr {
     reason: String,
     stderr_tail: Option<String>,
 }
 
-#[derive(Debug, Clone)]
-pub struct McpBootstrapSummary {
-    pub active_servers: Vec<String>,
-    pub required_stdio_servers: Vec<String>,
-    pub active_stdio_servers: Vec<String>,
-    pub tool_count: usize,
-    pub failures: Vec<McpBootstrapFailure>,
+struct McpServerHandle {
+    config: McpServerConfig,
+    client: Arc<dyn McpClient>,
+    tool_names: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
-enum McpBootstrapState {
+enum McpInitState {
     Pending,
-    Ready(McpBootstrapSummary),
+    Ready(McpSyncResult),
 }
 
-pub struct McpBootstrapHandle {
-    receiver: watch::Receiver<McpBootstrapState>,
+pub struct McpInitHandle {
+    receiver: watch::Receiver<McpInitState>,
     task: JoinHandle<()>,
-    hub: Arc<Mutex<Option<Arc<McpClientHub>>>>,
+    manager: Arc<Mutex<McpManager>>,
 }
 
-impl McpBootstrapHandle {
-    pub async fn wait_until_ready(&mut self) -> Result<McpBootstrapSummary, McpBootstrapError> {
+impl McpInitHandle {
+    pub async fn wait_until_ready(&mut self) -> Result<McpSyncResult, McpBootstrapError> {
         loop {
             let state = self.receiver.borrow().clone();
             match state {
-                McpBootstrapState::Pending => {
+                McpInitState::Pending => {
                     if self.receiver.changed().await.is_err() {
                         return Err(McpBootstrapError::Other(
-                            "bootstrap background task terminated unexpectedly".to_string(),
+                            "init background task terminated unexpectedly".to_string(),
                         ));
                     }
                 }
-                McpBootstrapState::Ready(summary) => return Ok(summary),
+                McpInitState::Ready(result) => return Ok(result),
             }
         }
     }
 
     pub fn is_ready(&self) -> bool {
-        matches!(*self.receiver.borrow(), McpBootstrapState::Ready(_))
+        matches!(*self.receiver.borrow(), McpInitState::Ready(_))
     }
 
-    pub async fn shutdown(&mut self) -> Result<(), McpBootstrapError> {
-        if !self.is_ready() {
-            self.task.abort();
-            return Ok(());
-        }
-
-        let hub = self.hub.lock().await.clone();
-        if let Some(hub) = hub {
-            hub.shutdown_all()
-                .await
-                .map_err(|err| McpBootstrapError::Other(err.to_string()))?;
-        }
-        Ok(())
+    pub fn manager(&self) -> Arc<Mutex<McpManager>> {
+        Arc::clone(&self.manager)
     }
 }
 
-impl Drop for McpBootstrapHandle {
+impl Drop for McpInitHandle {
     fn drop(&mut self) {
         self.task.abort();
     }
 }
 
-#[async_trait]
-trait McpClientFactory: Send + Sync {
-    async fn create_client(
-        &self,
-        server: &McpServerConfig,
-    ) -> Result<Arc<dyn McpClient>, McpBootstrapError>;
+pub struct McpManager {
+    tools: ToolRegistry,
+    hub: McpClientHub,
+    servers: BTreeMap<McpServerKey, McpServerHandle>,
+    statuses: Arc<StdMutex<BTreeMap<McpServerKey, McpServerStatus>>>,
+    config: McpConfigSnapshot,
 }
 
-struct RealMcpClientFactory;
-
-#[async_trait]
-impl McpClientFactory for RealMcpClientFactory {
-    async fn create_client(
-        &self,
-        server: &McpServerConfig,
-    ) -> Result<Arc<dyn McpClient>, McpBootstrapError> {
-        match server.mode {
-            McpServerMode::Stdio => {
-                let client = StdioMcpClient::new(server)
-                    .await
-                    .map_err(|err| McpBootstrapError::Other(err.to_string()))?;
-                Ok(Arc::new(client))
-            }
-            McpServerMode::Sse => {
-                let client = SseMcpClient::new(server)
-                    .map_err(|err| McpBootstrapError::Other(err.to_string()))?;
-                Ok(Arc::new(client))
-            }
+impl McpManager {
+    pub fn new(tools: ToolRegistry) -> Self {
+        Self {
+            tools,
+            hub: McpClientHub::default(),
+            servers: BTreeMap::new(),
+            statuses: Arc::new(StdMutex::new(BTreeMap::new())),
+            config: McpConfigSnapshot::default(),
         }
     }
-}
 
-async fn bootstrap_with_factory(
-    config: &McpConfig,
-    factory: Arc<dyn McpClientFactory>,
-) -> McpBootstrapResult {
-    if !config.enabled {
-        return McpBootstrapResult {
-            descriptors: Vec::new(),
-            hub: McpClientHub::default(),
-            runtime_handles: McpRuntimeHandles::default(),
-            failures: Vec::new(),
-        };
+    pub fn spawn_init(tools: ToolRegistry, config: McpConfigSnapshot) -> McpInitHandle {
+        let manager = Arc::new(Mutex::new(Self::new(tools)));
+        let manager_for_task = Arc::clone(&manager);
+        let (sender, receiver) = watch::channel(McpInitState::Pending);
+
+        let task = tokio::spawn(async move {
+            let mut guard = manager_for_task.lock().await;
+            let result = guard.do_init(&config).await;
+            let _ = sender.send(McpInitState::Ready(result));
+        });
+
+        McpInitHandle {
+            receiver,
+            task,
+            manager,
+        }
     }
 
-    let enabled_servers: Vec<(usize, McpServerConfig)> = config
-        .servers
-        .iter()
-        .cloned()
-        .enumerate()
-        .filter(|(_, server)| server.enabled)
-        .collect();
+    pub async fn sync(&mut self, snapshot: McpConfigSnapshot) -> McpSyncResult {
+        let current = self
+            .servers
+            .iter()
+            .map(|(key, handle)| (key.clone(), handle.config.clone()))
+            .collect::<BTreeMap<_, _>>();
+        let plan = plan_server_updates(&current, &snapshot);
 
-    let mut join_set = JoinSet::new();
-    for (index, server) in enabled_servers {
-        let timeout_seconds = config.startup_timeout_seconds;
-        let server_id = server.id.clone();
-        let mode = server.mode.clone();
-        info!(
-            server = %server_id,
-            mode = ?mode,
-            timeout_seconds,
-            status = "pending",
-            "starting mcp server bootstrap"
-        );
-        let factory = Arc::clone(&factory);
-        join_set.spawn(async move {
-            let fut = async {
-                let client = match factory.create_client(&server).await {
-                    Ok(client) => client,
-                    Err(err) => {
-                        return Err(ServerBootstrapErr {
-                            reason: err.to_string(),
-                            stderr_tail: None,
-                        });
-                    }
-                };
-                if let Err(err) = client.initialize().await {
-                    return Err(ServerBootstrapErr {
-                        reason: err.to_string(),
-                        stderr_tail: client.stderr_tail().await,
-                    });
-                }
-                let tools = match client.list_tools().await {
-                    Ok(tools) => tools,
-                    Err(err) => {
-                        return Err(ServerBootstrapErr {
+        for key in &plan.stop {
+            self.stop_server(key).await;
+        }
+
+        for config in &plan.restart {
+            self.stop_server(&McpServerKey::new(&config.id)).await;
+        }
+
+        for config in plan.start.iter().chain(plan.restart.iter()) {
+            self.start_server(config.clone()).await;
+        }
+
+        self.config = snapshot.clone();
+        self.reconcile_statuses(&snapshot);
+
+        let active_servers: Vec<String> = self
+            .servers
+            .keys()
+            .map(|k| k.as_str().to_string())
+            .collect();
+        let tool_count: usize = self.servers.values().map(|h| h.tool_names.len()).sum();
+
+        McpSyncResult {
+            keep: plan.keep,
+            start: plan
+                .start
+                .into_iter()
+                .map(|c| McpServerKey::new(&c.id))
+                .collect(),
+            restart: plan
+                .restart
+                .into_iter()
+                .map(|c| McpServerKey::new(&c.id))
+                .collect(),
+            stop: plan.stop,
+            statuses: self.snapshot_statuses(&snapshot),
+            active_servers,
+            tool_count,
+        }
+    }
+
+    pub async fn shutdown_all(&mut self) {
+        let keys = self.servers.keys().cloned().collect::<Vec<_>>();
+        for key in keys {
+            self.stop_server(&key).await;
+        }
+    }
+
+    #[must_use]
+    pub fn snapshot(&self) -> Vec<McpServerStatus> {
+        self.statuses
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
+            .values()
+            .cloned()
+            .collect()
+    }
+
+    async fn do_init(&mut self, config: &McpConfigSnapshot) -> McpSyncResult {
+        if !config.enabled {
+            return McpSyncResult::default();
+        }
+
+        let enabled_servers: Vec<McpServerConfig> = config
+            .servers
+            .iter()
+            .filter(|server| server.enabled)
+            .cloned()
+            .collect();
+
+        let mut join_set = JoinSet::new();
+        for server in enabled_servers {
+            let timeout_seconds = config.startup_timeout_seconds;
+            let server_id = server.id.clone();
+            let mode = server.mode.clone();
+            info!(
+                server = %server_id,
+                mode = ?mode,
+                timeout_seconds,
+                status = "pending",
+                "starting mcp server"
+            );
+            join_set.spawn(async move {
+                let fut = async {
+                    let client = match create_client(&server).await {
+                        Ok(client) => client,
+                        Err(err) => {
+                            return Err(ServerStartErr {
+                                reason: err.to_string(),
+                                stderr_tail: None,
+                            });
+                        }
+                    };
+                    if let Err(err) = client.initialize().await {
+                        return Err(ServerStartErr {
                             reason: err.to_string(),
                             stderr_tail: client.stderr_tail().await,
                         });
                     }
+                    match client.list_tools().await {
+                        Ok(tools) => Ok(ServerStartOk {
+                            server_id: server.id.clone(),
+                            mode: server.mode,
+                            client,
+                            tools,
+                        }),
+                        Err(err) => Err(ServerStartErr {
+                            reason: err.to_string(),
+                            stderr_tail: client.stderr_tail().await,
+                        }),
+                    }
                 };
-                Ok::<ServerBootstrapOk, ServerBootstrapErr>(ServerBootstrapOk {
-                    index,
-                    server_id: server.id.clone(),
-                    mode: server.mode,
-                    client,
-                    tools,
-                })
-            };
-            match timeout(Duration::from_secs(timeout_seconds), fut).await {
-                Ok(outcome) => (server_id, outcome),
-                Err(_) => (
-                    server_id,
-                    Err(ServerBootstrapErr {
-                        reason: McpBootstrapError::Timeout { timeout_seconds }.to_string(),
-                        stderr_tail: None,
-                    }),
-                ),
-            }
-        });
-    }
+                match timeout(Duration::from_secs(timeout_seconds), fut).await {
+                    Ok(outcome) => (server_id, outcome),
+                    Err(_) => (
+                        server_id,
+                        Err(ServerStartErr {
+                            reason: McpBootstrapError::Timeout { timeout_seconds }.to_string(),
+                            stderr_tail: None,
+                        }),
+                    ),
+                }
+            });
+        }
 
-    let mut oks = Vec::new();
-    let mut failures = Vec::new();
-    while let Some(joined) = join_set.join_next().await {
-        match joined {
-            Ok((_server_id, Ok(ok))) => {
-                info!(
-                    server = %ok.server_id,
-                    mode = ?ok.mode,
-                    tool_count = ok.tools.len(),
-                    status = "ready",
-                    "mcp server bootstrap completed"
-                );
-                oks.push(ok);
-            }
-            Ok((server_id, Err(err))) => {
-                let reason = format_failure_reason(&err.reason, err.stderr_tail.as_deref());
-                warn!(
-                    server = %server_id,
-                    reason = %reason,
-                    stderr_tail = err.stderr_tail.as_deref().unwrap_or(""),
-                    status = "failed",
-                    "mcp server bootstrap failed"
-                );
-                failures.push(McpBootstrapFailure { server_id, reason });
-            }
-            Err(err) => {
-                warn!(
-                    server = "<join-task>",
-                    reason = %err,
-                    status = "failed",
-                    "mcp server bootstrap join failed"
-                );
-                failures.push(McpBootstrapFailure {
-                    server_id: "<join-task>".to_string(),
-                    reason: format!("join error: {err}"),
-                });
+        let mut oks = Vec::new();
+        let mut failures = Vec::new();
+        let mut seen_tool_names = BTreeSet::new();
+
+        while let Some(joined) = join_set.join_next().await {
+            match joined {
+                Ok((_server_id, Ok(ok))) => {
+                    let has_conflict = ok
+                        .tools
+                        .iter()
+                        .any(|tool| seen_tool_names.contains(&tool.name));
+                    if has_conflict {
+                        warn!(
+                            server = %ok.server_id,
+                            status = "failed",
+                            reason = "tool name conflicts with another MCP server",
+                            "mcp server rejected after discovery"
+                        );
+                        failures.push(McpServerStatus::from_config(
+                            &McpServerConfig {
+                                id: ok.server_id.clone(),
+                                mode: ok.mode,
+                                ..Default::default()
+                            },
+                            McpLifecycleState::Failed,
+                            Some("tool name conflicts with another MCP server".to_string()),
+                            0,
+                        ));
+                        continue;
+                    }
+
+                    info!(
+                        server = %ok.server_id,
+                        mode = ?ok.mode,
+                        tool_count = ok.tools.len(),
+                        status = "ready",
+                        "mcp server started"
+                    );
+
+                    for tool in &ok.tools {
+                        seen_tool_names.insert(tool.name.clone());
+                    }
+                    oks.push(ok);
+                }
+                Ok((server_id, Err(err))) => {
+                    let reason = format_failure_reason(&err.reason, err.stderr_tail.as_deref());
+                    warn!(
+                        server = %server_id,
+                        reason = %reason,
+                        stderr_tail = err.stderr_tail.as_deref().unwrap_or(""),
+                        status = "failed",
+                        "mcp server failed to start"
+                    );
+                    failures.push(McpServerStatus::from_config(
+                        &McpServerConfig {
+                            id: server_id.clone(),
+                            ..Default::default()
+                        },
+                        McpLifecycleState::Failed,
+                        Some(reason),
+                        0,
+                    ));
+                }
+                Err(err) => {
+                    warn!(
+                        server = "<join-task>",
+                        reason = %err,
+                        status = "failed",
+                        "mcp server join failed"
+                    );
+                }
             }
         }
-    }
 
-    oks.sort_by_key(|item| item.index);
-    let mut descriptors = Vec::new();
-    let mut hub = McpClientHub::default();
-    let mut runtime_handles = McpRuntimeHandles::default();
-    let mut seen_tool_names = BTreeSet::new();
-
-    for item in oks {
-        let has_conflict = item
-            .tools
-            .iter()
-            .any(|tool| seen_tool_names.contains(&tool.name));
-        if has_conflict {
-            warn!(
-                server = %item.server_id,
-                status = "failed",
-                reason = "tool name conflicts with another MCP server",
-                "mcp server bootstrap rejected after discovery"
+        for ok in &oks {
+            let tool_names: Vec<String> = ok.tools.iter().map(|t| t.name.clone()).collect();
+            for tool in &ok.tools {
+                let descriptor = McpToolDescriptor {
+                    name: tool.name.clone(),
+                    description: tool.description.clone(),
+                    parameters: tool.parameters.clone(),
+                    server_id: ok.server_id.clone(),
+                    tool_name: tool.name.clone(),
+                };
+                self.tools
+                    .register_shared(Arc::new(crate::McpProxyTool::new(
+                        descriptor,
+                        Arc::new(self.hub.clone()),
+                    )));
+            }
+            self.hub
+                .insert(ok.server_id.clone(), Arc::clone(&ok.client));
+            self.servers.insert(
+                McpServerKey::new(&ok.server_id),
+                McpServerHandle {
+                    config: McpServerConfig {
+                        id: ok.server_id.clone(),
+                        mode: ok.mode.clone(),
+                        enabled: true,
+                        ..Default::default()
+                    },
+                    client: Arc::clone(&ok.client),
+                    tool_names,
+                },
             );
-            failures.push(McpBootstrapFailure {
-                server_id: item.server_id,
-                reason: "tool name conflicts with another MCP server".to_string(),
-            });
-            continue;
         }
 
-        for tool in &item.tools {
-            seen_tool_names.insert(tool.name.clone());
-            descriptors.push(McpToolDescriptor {
-                name: tool.name.clone(),
-                description: tool.description.clone(),
-                parameters: tool.parameters.clone(),
-                server_id: item.server_id.clone(),
-                tool_name: tool.name.clone(),
-            });
+        {
+            let mut guard = self.statuses.lock().unwrap_or_else(|err| err.into_inner());
+            for ok in &oks {
+                guard.insert(
+                    McpServerKey::new(&ok.server_id),
+                    McpServerStatus::from_config(
+                        &McpServerConfig {
+                            id: ok.server_id.clone(),
+                            mode: ok.mode.clone(),
+                            enabled: true,
+                            ..Default::default()
+                        },
+                        McpLifecycleState::Running,
+                        None,
+                        ok.tools.len(),
+                    ),
+                );
+            }
+            for failure in &failures {
+                guard.insert(failure.key.clone(), failure.clone());
+            }
         }
-        if item.mode == McpServerMode::Stdio {
-            runtime_handles.stdio_servers.push(item.server_id.clone());
+
+        let mut result = McpSyncResult::default();
+        for ok in &oks {
+            result.start.push(McpServerKey::new(&ok.server_id));
+            result.active_servers.push(ok.server_id.clone());
+            result.tool_count += ok.tools.len();
+            result.statuses.push(McpServerStatus::from_config(
+                &McpServerConfig {
+                    id: ok.server_id.clone(),
+                    mode: ok.mode.clone(),
+                    enabled: true,
+                    ..Default::default()
+                },
+                McpLifecycleState::Running,
+                None,
+                ok.tools.len(),
+            ));
         }
-        hub.insert(item.server_id, item.client);
+        result.statuses.extend(failures);
+        result
     }
 
-    McpBootstrapResult {
-        descriptors,
-        hub,
-        runtime_handles,
-        failures,
+    async fn start_server(&mut self, config: McpServerConfig) {
+        let key = McpServerKey::new(&config.id);
+        {
+            let mut guard = self.statuses.lock().unwrap_or_else(|err| err.into_inner());
+            guard.insert(
+                key.clone(),
+                McpServerStatus::from_config(&config, McpLifecycleState::Starting, None, 0),
+            );
+        }
+
+        let timeout_seconds = self.config.startup_timeout_seconds;
+        let start_result = async {
+            let client = match create_client(&config).await {
+                Ok(client) => client,
+                Err(err) => return Err((err.to_string(), None)),
+            };
+            if let Err(err) = client.initialize().await {
+                return Err((err.to_string(), client.stderr_tail().await));
+            }
+            match client.list_tools().await {
+                Ok(tools) => Ok((client, tools)),
+                Err(err) => Err((err.to_string(), client.stderr_tail().await)),
+            }
+        };
+
+        let result = timeout(Duration::from_secs(timeout_seconds), start_result).await;
+
+        match result {
+            Ok(Ok((client, tools))) => {
+                let tool_names: Vec<String> = tools.iter().map(|t| t.name.clone()).collect();
+
+                for tool in &tools {
+                    let descriptor = McpToolDescriptor {
+                        name: tool.name.clone(),
+                        description: tool.description.clone(),
+                        parameters: tool.parameters.clone(),
+                        server_id: config.id.clone(),
+                        tool_name: tool.name.clone(),
+                    };
+                    self.tools
+                        .register_shared(Arc::new(crate::McpProxyTool::new(
+                            descriptor,
+                            Arc::new(self.hub.clone()),
+                        )));
+                }
+
+                self.hub.insert(config.id.clone(), Arc::clone(&client));
+
+                {
+                    let mut guard = self.statuses.lock().unwrap_or_else(|err| err.into_inner());
+                    guard.insert(
+                        key.clone(),
+                        McpServerStatus::from_config(
+                            &config,
+                            McpLifecycleState::Running,
+                            None,
+                            tool_names.len(),
+                        ),
+                    );
+                }
+
+                self.servers.insert(
+                    key,
+                    McpServerHandle {
+                        config: config.clone(),
+                        client,
+                        tool_names,
+                    },
+                );
+
+                info!(
+                    server = %config.id,
+                    mode = ?config.mode,
+                    status = "running",
+                    "mcp server started"
+                );
+            }
+            Ok(Err((reason, stderr))) => {
+                let message = format_failure_reason(&reason, stderr.as_deref());
+                warn!(
+                    server = %config.id,
+                    reason = %message,
+                    status = "failed",
+                    "mcp server failed to start"
+                );
+                let mut guard = self.statuses.lock().unwrap_or_else(|err| err.into_inner());
+                guard.insert(
+                    key,
+                    McpServerStatus::from_config(
+                        &config,
+                        McpLifecycleState::Failed,
+                        Some(message),
+                        0,
+                    ),
+                );
+            }
+            Err(_) => {
+                let message = format!("timeout after {timeout_seconds}s");
+                warn!(
+                    server = %config.id,
+                    reason = %message,
+                    status = "failed",
+                    "mcp server failed to start"
+                );
+                let mut guard = self.statuses.lock().unwrap_or_else(|err| err.into_inner());
+                guard.insert(
+                    key,
+                    McpServerStatus::from_config(
+                        &config,
+                        McpLifecycleState::Failed,
+                        Some(message),
+                        0,
+                    ),
+                );
+            }
+        }
+    }
+
+    async fn stop_server(&mut self, key: &McpServerKey) {
+        let Some(handle) = self.servers.remove(key) else {
+            return;
+        };
+
+        let tool_names: Vec<&str> = handle.tool_names.iter().map(String::as_str).collect();
+        self.tools.unregister_many(&tool_names);
+
+        if handle.config.mode == McpServerMode::Stdio {
+            let client = Arc::clone(&handle.client);
+            let key_for_log = key.clone();
+            if let Err(err) = timeout(SERVER_SHUTDOWN_TIMEOUT, client.shutdown()).await {
+                warn!(
+                    server = %key_for_log,
+                    error = %err,
+                    "mcp server shutdown timed out"
+                );
+            } else {
+                info!(
+                    server = %key,
+                    mode = "stdio",
+                    status = "stopped",
+                    "mcp server stopped"
+                );
+            }
+        } else {
+            info!(
+                server = %key,
+                mode = "sse",
+                status = "stopped",
+                "mcp server stopped"
+            );
+        }
+
+        self.hub.remove(key.as_str());
+
+        {
+            let mut guard = self.statuses.lock().unwrap_or_else(|err| err.into_inner());
+            guard.insert(
+                key.clone(),
+                McpServerStatus::from_config(&handle.config, McpLifecycleState::Stopped, None, 0),
+            );
+        }
+    }
+
+    fn reconcile_statuses(&mut self, snapshot: &McpConfigSnapshot) {
+        let desired_keys: BTreeSet<McpServerKey> = snapshot
+            .servers
+            .iter()
+            .map(|s| McpServerKey::new(&s.id))
+            .collect();
+
+        let mut guard = self.statuses.lock().unwrap_or_else(|err| err.into_inner());
+        guard.retain(|key, _| desired_keys.contains(key));
+
+        for config in &snapshot.servers {
+            let key = McpServerKey::new(&config.id);
+            match guard.get_mut(&key) {
+                Some(status) => {
+                    status.enabled = config.enabled;
+                    status.mode = config.mode.clone();
+                    if !config.enabled {
+                        status.state = McpLifecycleState::Stopped;
+                        status.last_error = None;
+                    }
+                }
+                None => {
+                    guard.insert(
+                        key,
+                        McpServerStatus::from_config(config, McpLifecycleState::Stopped, None, 0),
+                    );
+                }
+            }
+        }
+    }
+
+    fn snapshot_statuses(&self, snapshot: &McpConfigSnapshot) -> Vec<McpServerStatus> {
+        let guard = self.statuses.lock().unwrap_or_else(|err| err.into_inner());
+        snapshot
+            .servers
+            .iter()
+            .map(|config| {
+                guard
+                    .get(&McpServerKey::new(&config.id))
+                    .cloned()
+                    .unwrap_or_else(|| {
+                        McpServerStatus::from_config(config, McpLifecycleState::Stopped, None, 0)
+                    })
+            })
+            .collect()
+    }
+}
+
+async fn create_client(server: &McpServerConfig) -> Result<Arc<dyn McpClient>, McpBootstrapError> {
+    match server.mode {
+        McpServerMode::Stdio => {
+            let client = StdioMcpClient::new(server)
+                .await
+                .map_err(|err| McpBootstrapError::Other(err.to_string()))?;
+            Ok(Arc::new(client))
+        }
+        McpServerMode::Sse => {
+            let client = SseMcpClient::new(server)
+                .map_err(|err| McpBootstrapError::Other(err.to_string()))?;
+            Ok(Arc::new(client))
+        }
     }
 }
 
@@ -330,342 +750,192 @@ fn format_failure_reason(reason: &str, stderr_tail: Option<&str>) -> String {
     }
 }
 
-fn spawn_bootstrap_with_factory(
-    config: McpConfig,
-    mut tools: ToolRegistry,
-    factory: Arc<dyn McpClientFactory>,
-) -> McpBootstrapHandle {
-    let (sender, receiver) = watch::channel(McpBootstrapState::Pending);
-    let hub_state = Arc::new(Mutex::new(None));
-    let hub_state_for_task = Arc::clone(&hub_state);
-    let task = tokio::spawn(async move {
-        let bootstrap = bootstrap_with_factory(&config, factory).await;
-        let active_servers = bootstrap.hub.server_ids();
-        let active_stdio_servers = bootstrap.runtime_handles.stdio_servers.clone();
-        let required_stdio_servers: Vec<String> = config
-            .servers
-            .iter()
-            .filter(|server| server.enabled && server.mode == McpServerMode::Stdio)
-            .map(|server| server.id.clone())
-            .collect();
+#[derive(Debug, Default)]
+struct McpSyncPlan {
+    keep: Vec<McpServerKey>,
+    start: Vec<McpServerConfig>,
+    restart: Vec<McpServerConfig>,
+    stop: Vec<McpServerKey>,
+}
 
-        if bootstrap.descriptors.is_empty() {
-            if !bootstrap.failures.is_empty() {
-                for failure in &bootstrap.failures {
-                    warn!(
-                        server = %failure.server_id,
-                        reason = %failure.reason,
-                        "mcp server bootstrap failed"
-                    );
-                }
-            }
-            info!(
-                active_servers = ?active_servers,
-                required_stdio_servers = ?required_stdio_servers,
-                active_stdio_servers = ?active_stdio_servers,
-                failed_servers = bootstrap.failures.len(),
-                tool_count = 0,
-                "mcp bootstrap summary"
-            );
-            let _ = sender.send(McpBootstrapState::Ready(McpBootstrapSummary {
-                active_servers,
-                required_stdio_servers,
-                active_stdio_servers,
-                tool_count: 0,
-                failures: bootstrap.failures,
-            }));
-            return;
+fn plan_server_updates(
+    current: &BTreeMap<McpServerKey, McpServerConfig>,
+    desired: &McpConfigSnapshot,
+) -> McpSyncPlan {
+    let desired_enabled: BTreeMap<McpServerKey, McpServerConfig> = desired
+        .servers
+        .iter()
+        .filter(|config| config.enabled)
+        .map(|config| (McpServerKey::new(&config.id), config.clone()))
+        .collect();
+
+    let mut plan = McpSyncPlan::default();
+
+    for key in current.keys() {
+        if !desired_enabled.contains_key(key) {
+            plan.stop.push(key.clone());
         }
-
-        let mut blocked_servers = BTreeSet::new();
-        let mut existing_names: BTreeSet<String> = tools.list().into_iter().collect();
-        let mut by_server: BTreeMap<String, Vec<McpToolDescriptor>> = BTreeMap::new();
-        for descriptor in bootstrap.descriptors {
-            by_server
-                .entry(descriptor.server_id.clone())
-                .or_default()
-                .push(descriptor);
-        }
-
-        let mut failures = bootstrap.failures;
-        for (server_id, descriptors) in &by_server {
-            if descriptors
-                .iter()
-                .any(|descriptor| existing_names.contains(&descriptor.name))
-            {
-                blocked_servers.insert(server_id.clone());
-                failures.push(McpBootstrapFailure {
-                    server_id: server_id.clone(),
-                    reason: "tool name conflict with existing registry".to_string(),
-                });
-                warn!(
-                    server = %server_id,
-                    "mcp server skipped due to tool name conflict with existing registry"
-                );
-                continue;
-            }
-            for descriptor in descriptors {
-                existing_names.insert(descriptor.name.clone());
-            }
-        }
-
-        let hub = Arc::new(bootstrap.hub);
-        {
-            let mut guard = hub_state_for_task.lock().await;
-            *guard = Some(Arc::clone(&hub));
-        }
-        let mut tool_count = 0usize;
-        for (server_id, descriptors) in by_server {
-            if blocked_servers.contains(&server_id) {
-                continue;
-            }
-            for descriptor in descriptors {
-                tools.register_shared(Arc::new(crate::McpProxyTool::new(
-                    descriptor,
-                    Arc::clone(&hub),
-                )));
-                tool_count += 1;
-            }
-        }
-
-        info!(
-            active_servers = ?active_servers,
-            required_stdio_servers = ?required_stdio_servers,
-            active_stdio_servers = ?active_stdio_servers,
-            failed_servers = failures.len(),
-            server_count = active_servers.len(),
-            tool_count,
-            "mcp bootstrap summary"
-        );
-
-        let _ = sender.send(McpBootstrapState::Ready(McpBootstrapSummary {
-            active_servers,
-            required_stdio_servers,
-            active_stdio_servers,
-            tool_count,
-            failures,
-        }));
-    });
-
-    McpBootstrapHandle {
-        receiver,
-        task,
-        hub: hub_state,
     }
+
+    for (key, desired_config) in desired_enabled {
+        match current.get(&key) {
+            Some(current_config) if current_config == &desired_config => {
+                plan.keep.push(key);
+            }
+            Some(_) => {
+                plan.restart.push(desired_config);
+            }
+            None => {
+                plan.start.push(desired_config);
+            }
+        }
+    }
+
+    plan
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::client::McpClientError;
-    use klaw_tool::{Tool, ToolCategory, ToolContext, ToolError, ToolOutput, ToolRegistry};
-    use serde_json::{json, Value};
-    use std::{
-        collections::BTreeMap,
-        sync::atomic::{AtomicUsize, Ordering},
-    };
+    use klaw_config::{McpConfig, McpServerConfig, McpServerMode};
+    use std::collections::BTreeMap;
 
-    struct MockClient {
-        list_tools: Vec<McpRemoteTool>,
-    }
-
-    #[async_trait]
-    impl McpClient for MockClient {
-        async fn initialize(&self) -> Result<(), McpClientError> {
-            Ok(())
-        }
-
-        async fn list_tools(&self) -> Result<Vec<McpRemoteTool>, McpClientError> {
-            Ok(self.list_tools.clone())
-        }
-
-        async fn call_tool(
-            &self,
-            _tool_name: &str,
-            _arguments: Value,
-        ) -> Result<Value, McpClientError> {
-            Ok(json!({"content":[{"type":"text","text":"ok"}]}))
-        }
-    }
-
-    struct MockFactory {
-        delay_ms: u64,
-        calls: Arc<AtomicUsize>,
-    }
-
-    struct BuiltinTool;
-
-    #[async_trait]
-    impl Tool for BuiltinTool {
-        fn name(&self) -> &str {
-            "builtin"
-        }
-
-        fn description(&self) -> &str {
-            "builtin"
-        }
-
-        fn parameters(&self) -> Value {
-            json!({"type":"object"})
-        }
-
-        fn category(&self) -> ToolCategory {
-            ToolCategory::FilesystemRead
-        }
-
-        async fn execute(&self, _args: Value, _ctx: &ToolContext) -> Result<ToolOutput, ToolError> {
-            Ok(ToolOutput {
-                content_for_model: "ok".to_string(),
-                content_for_user: None,
-            })
-        }
-    }
-
-    #[async_trait]
-    impl McpClientFactory for MockFactory {
-        async fn create_client(
-            &self,
-            server: &McpServerConfig,
-        ) -> Result<Arc<dyn McpClient>, McpBootstrapError> {
-            self.calls.fetch_add(1, Ordering::Relaxed);
-            if self.delay_ms > 0 {
-                tokio::time::sleep(Duration::from_millis(self.delay_ms)).await;
-            }
-            if server.id == "bad" {
-                return Err(McpBootstrapError::Other("boom".to_string()));
-            }
-            let tool_name = if server.id == "s2" {
-                "same"
-            } else {
-                &server.id
-            };
-            let tools = vec![McpRemoteTool {
-                name: if server.id == "s1" { "same" } else { tool_name }.to_string(),
-                description: "d".to_string(),
-                parameters: json!({"type":"object"}),
-            }];
-            Ok(Arc::new(MockClient { list_tools: tools }))
-        }
-    }
-
-    fn server(id: &str) -> McpServerConfig {
+    fn server(id: &str, mode: McpServerMode, enabled: bool) -> McpServerConfig {
+        let is_stdio = mode == McpServerMode::Stdio;
         McpServerConfig {
             id: id.to_string(),
-            enabled: true,
-            mode: McpServerMode::Stdio,
-            command: Some("echo".to_string()),
+            enabled,
+            mode,
+            command: if is_stdio {
+                Some("echo".to_string())
+            } else {
+                None
+            },
             args: vec![],
             env: BTreeMap::new(),
             cwd: None,
-            url: None,
+            url: if !is_stdio {
+                Some("https://example.com/sse".to_string())
+            } else {
+                None
+            },
             headers: BTreeMap::new(),
         }
     }
 
-    #[tokio::test]
-    async fn bootstrap_degrades_on_partial_failures() {
-        let calls = Arc::new(AtomicUsize::new(0));
-        let factory = MockFactory {
-            delay_ms: 0,
-            calls: Arc::clone(&calls),
-        };
-        let cfg = McpConfig {
-            enabled: true,
-            startup_timeout_seconds: 30,
-            servers: vec![server("ok"), server("bad")],
-        };
-        let out = bootstrap_with_factory(&cfg, Arc::new(factory)).await;
-        assert_eq!(calls.load(Ordering::Relaxed), 2);
-        assert_eq!(out.descriptors.len(), 1);
-        assert_eq!(out.hub.server_ids(), vec!["ok".to_string()]);
-        assert_eq!(out.failures.len(), 1);
+    #[test]
+    fn mcp_server_key_new_trims_whitespace() {
+        let key = McpServerKey::new("  test  ");
+        assert_eq!(key.as_str(), "test");
     }
 
-    #[tokio::test]
-    async fn bootstrap_enforces_timeout() {
-        let factory = MockFactory {
-            delay_ms: 200,
-            calls: Arc::new(AtomicUsize::new(0)),
-        };
-        let cfg = McpConfig {
-            enabled: true,
-            startup_timeout_seconds: 0,
-            servers: vec![server("slow")],
-        };
-        let out = bootstrap_with_factory(&cfg, Arc::new(factory)).await;
-        assert!(out.descriptors.is_empty());
-        assert_eq!(out.failures.len(), 1);
-        assert!(out.failures[0].reason.contains("timed out"));
+    #[test]
+    fn mcp_lifecycle_state_as_str() {
+        assert_eq!(McpLifecycleState::Starting.as_str(), "starting");
+        assert_eq!(McpLifecycleState::Running.as_str(), "running");
+        assert_eq!(McpLifecycleState::Stopped.as_str(), "stopped");
+        assert_eq!(McpLifecycleState::Failed.as_str(), "failed");
     }
 
-    #[tokio::test]
-    async fn bootstrap_rejects_conflicting_tool_names_between_servers() {
-        let factory = MockFactory {
-            delay_ms: 0,
-            calls: Arc::new(AtomicUsize::new(0)),
-        };
-        let cfg = McpConfig {
+    #[test]
+    fn mcp_config_snapshot_from_config() {
+        let config = McpConfig {
             enabled: true,
             startup_timeout_seconds: 30,
-            servers: vec![server("s1"), server("s2")],
+            servers: vec![server("test", McpServerMode::Stdio, true)],
         };
-        let out = bootstrap_with_factory(&cfg, Arc::new(factory)).await;
-        assert_eq!(out.descriptors.len(), 1);
-        assert_eq!(out.hub.server_ids(), vec!["s1".to_string()]);
-        assert_eq!(out.failures.len(), 1);
-        assert!(out.failures[0].reason.contains("conflicts"));
+        let snapshot = McpConfigSnapshot::from_mcp_config(&config);
+        assert!(snapshot.enabled);
+        assert_eq!(snapshot.startup_timeout_seconds, 30);
+        assert_eq!(snapshot.servers.len(), 1);
     }
 
-    #[tokio::test]
-    async fn spawned_bootstrap_registers_tools_into_shared_registry() {
-        let calls = Arc::new(AtomicUsize::new(0));
-        let factory = MockFactory {
-            delay_ms: 20,
-            calls,
-        };
-        let cfg = McpConfig {
-            enabled: true,
-            startup_timeout_seconds: 30,
-            servers: vec![server("ok")],
-        };
-        let mut tools = ToolRegistry::default();
-        tools.register(BuiltinTool);
-        let runtime_view = tools.clone();
-
-        let mut handle = spawn_bootstrap_with_factory(cfg, tools, Arc::new(factory));
-        assert!(!handle.is_ready());
-        let summary = handle.wait_until_ready().await.unwrap_or_else(|err| {
-            panic!("bootstrap should succeed: {err}");
-        });
-
-        assert_eq!(summary.active_servers, vec!["ok".to_string()]);
-        assert_eq!(summary.required_stdio_servers, vec!["ok".to_string()]);
-        assert_eq!(summary.active_stdio_servers, vec!["ok".to_string()]);
-        assert_eq!(summary.tool_count, 1);
-        assert!(runtime_view.get("ok").is_some());
-        assert!(runtime_view.get("builtin").is_some());
+    #[test]
+    fn plan_updates_empty_to_empty() {
+        let current = BTreeMap::new();
+        let desired = McpConfigSnapshot::default();
+        let plan = plan_server_updates(&current, &desired);
+        assert!(plan.keep.is_empty());
+        assert!(plan.start.is_empty());
+        assert!(plan.restart.is_empty());
+        assert!(plan.stop.is_empty());
     }
 
-    #[tokio::test]
-    async fn spawned_bootstrap_reports_failures_after_completion() {
-        let calls = Arc::new(AtomicUsize::new(0));
-        let factory = MockFactory { delay_ms: 0, calls };
-        let cfg = McpConfig {
+    #[test]
+    fn plan_updates_starts_new_servers() {
+        let current = BTreeMap::new();
+        let desired = McpConfigSnapshot {
             enabled: true,
             startup_timeout_seconds: 30,
-            servers: vec![server("bad")],
+            servers: vec![server("new", McpServerMode::Stdio, true)],
         };
+        let plan = plan_server_updates(&current, &desired);
+        assert!(plan.keep.is_empty());
+        assert_eq!(plan.start.len(), 1);
+        assert!(plan.restart.is_empty());
+        assert!(plan.stop.is_empty());
+    }
 
-        let mut handle =
-            spawn_bootstrap_with_factory(cfg, ToolRegistry::default(), Arc::new(factory));
-        let summary = handle.wait_until_ready().await.unwrap_or_else(|err| {
-            panic!("bootstrap should complete: {err}");
-        });
+    #[test]
+    fn plan_updates_stops_removed_servers() {
+        let mut current = BTreeMap::new();
+        current.insert(
+            McpServerKey::new("old"),
+            server("old", McpServerMode::Stdio, true),
+        );
+        let desired = McpConfigSnapshot::default();
+        let plan = plan_server_updates(&current, &desired);
+        assert!(plan.keep.is_empty());
+        assert!(plan.start.is_empty());
+        assert!(plan.restart.is_empty());
+        assert_eq!(plan.stop.len(), 1);
+    }
 
-        assert!(summary.active_servers.is_empty());
-        assert_eq!(summary.required_stdio_servers, vec!["bad".to_string()]);
-        assert!(summary.active_stdio_servers.is_empty());
-        assert_eq!(summary.failures.len(), 1);
-        assert_eq!(summary.failures[0].server_id, "bad");
+    #[test]
+    fn plan_updates_restarts_changed_servers() {
+        let mut current = BTreeMap::new();
+        current.insert(
+            McpServerKey::new("test"),
+            server("test", McpServerMode::Stdio, true),
+        );
+        let desired = McpConfigSnapshot {
+            enabled: true,
+            startup_timeout_seconds: 30,
+            servers: vec![server("test", McpServerMode::Sse, true)],
+        };
+        let plan = plan_server_updates(&current, &desired);
+        assert!(plan.keep.is_empty());
+        assert!(plan.start.is_empty());
+        assert_eq!(plan.restart.len(), 1);
+        assert!(plan.stop.is_empty());
+    }
+
+    #[test]
+    fn plan_updates_keeps_unchanged_servers() {
+        let config = server("test", McpServerMode::Stdio, true);
+        let mut current = BTreeMap::new();
+        current.insert(McpServerKey::new("test"), config.clone());
+        let desired = McpConfigSnapshot {
+            enabled: true,
+            startup_timeout_seconds: 30,
+            servers: vec![config],
+        };
+        let plan = plan_server_updates(&current, &desired);
+        assert_eq!(plan.keep.len(), 1);
+        assert!(plan.start.is_empty());
+        assert!(plan.restart.is_empty());
+        assert!(plan.stop.is_empty());
+    }
+
+    #[test]
+    fn plan_updates_ignores_disabled_servers() {
+        let current = BTreeMap::new();
+        let desired = McpConfigSnapshot {
+            enabled: true,
+            startup_timeout_seconds: 30,
+            servers: vec![server("disabled", McpServerMode::Stdio, false)],
+        };
+        let plan = plan_server_updates(&current, &desired);
+        assert!(plan.start.is_empty());
     }
 }

--- a/klaw-tool/src/lib.rs
+++ b/klaw-tool/src/lib.rs
@@ -239,4 +239,25 @@ impl ToolRegistry {
             .cloned()
             .collect()
     }
+
+    /// 注销工具。
+    pub fn unregister(&self, name: &str) -> bool {
+        self.tools
+            .write()
+            .unwrap_or_else(|err| err.into_inner())
+            .remove(name)
+            .is_some()
+    }
+
+    /// 注销多个工具。
+    pub fn unregister_many(&self, names: &[&str]) -> usize {
+        let mut guard = self.tools.write().unwrap_or_else(|err| err.into_inner());
+        let mut count = 0;
+        for name in names {
+            if guard.remove(*name).is_some() {
+                count += 1;
+            }
+        }
+        count
+    }
 }


### PR DESCRIPTION
## Summary

Implement dynamic MCP server management similar to `ChannelManager`, allowing start/stop/restart of MCP servers based on configuration changes without restarting the application.

## Changes

### Core Implementation
- **McpManager**: New manager with `sync()`, `start_server()`, `stop_server()` methods for dynamic server lifecycle management
- **McpServerKey, McpLifecycleState, McpServerStatus**: Data structures for server state tracking
- **McpConfigSnapshot**: Config snapshot for diff calculation between current and desired state
- **McpSyncResult**: Sync operation result containing keep/start/restart/stop lists

### Runtime Integration
- **RuntimeCommand::SyncMcp**: New command for GUI-triggered MCP config sync
- **McpInitHandle**: Async initialization handle with `manager()` accessor for subsequent sync operations
- Updated `build_runtime_bundle()` and `shutdown_runtime_bundle()` to use new manager

### Tool Registry
- Added `unregister()` and `unregister_many()` methods for dynamic tool removal

### Stdio vs SSE Handling
| Operation | Stdio Mode | SSE Mode |
|-----------|------------|----------|
| Start | Spawn subprocess + init handshake | Create HTTP client + init handshake |
| Stop | Kill subprocess + cleanup | Remove client from hub (memory only) |
| Restart | Kill → Respawn | Update client config |

## Test Plan

- [x] Unit tests for config diff planning (`plan_server_updates`)
- [x] Unit tests for state transitions
- [x] `cargo test --workspace` passes
- [x] `cargo check --workspace` passes

## Documentation

- Updated `klaw-mcp/README.md` with hot-reload documentation
- Updated `klaw-mcp/CHANGELOG.md`

Closes #4