### PR TITLE
feat(gui): add gateway config modal dialog

### DIFF
--- a/klaw-gui/src/panels/gateway.rs
+++ b/klaw-gui/src/panels/gateway.rs
@@ -2,28 +2,157 @@ use crate::notifications::NotificationCenter;
 use crate::panels::{PanelRenderer, RenderCtx};
 use crate::time_format::format_timestamp_seconds;
 use crate::{
-    request_gateway_status, request_restart_gateway, request_set_gateway_enabled,
-    request_set_tailscale_mode, GatewayStatusSnapshot,
+    request_gateway_status, request_restart_gateway, request_set_tailscale_mode,
+    GatewayStatusSnapshot,
 };
-use klaw_config::TailscaleMode;
+use klaw_config::{AppConfig, ConfigSnapshot, ConfigStore, GatewayConfig, TailscaleMode};
 use klaw_gateway::TailscaleStatus;
+use std::path::PathBuf;
 use std::time::Duration;
 
 const GATEWAY_POLL_INTERVAL: Duration = Duration::from_millis(250);
 
-#[derive(Default)]
+#[derive(Debug, Clone)]
+struct GatewayConfigForm {
+    enabled: bool,
+    listen_ip: String,
+    listen_port: String,
+    auth_enabled: bool,
+    auth_token: String,
+    auth_env_key: String,
+    webhook_enabled: bool,
+    webhook_path: String,
+    webhook_max_body_bytes: String,
+}
+
+impl Default for GatewayConfigForm {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            listen_ip: "127.0.0.1".to_string(),
+            listen_port: "0".to_string(),
+            auth_enabled: false,
+            auth_token: String::new(),
+            auth_env_key: String::new(),
+            webhook_enabled: false,
+            webhook_path: "/webhook/events".to_string(),
+            webhook_max_body_bytes: "262144".to_string(),
+        }
+    }
+}
+
+impl GatewayConfigForm {
+    fn from_config(config: &GatewayConfig) -> Self {
+        Self {
+            enabled: config.enabled,
+            listen_ip: config.listen_ip.clone(),
+            listen_port: config.listen_port.to_string(),
+            auth_enabled: config.auth.enabled,
+            auth_token: config.auth.token.clone().unwrap_or_default(),
+            auth_env_key: config.auth.env_key.clone().unwrap_or_default(),
+            webhook_enabled: config.webhook.enabled,
+            webhook_path: config.webhook.path.clone(),
+            webhook_max_body_bytes: config.webhook.max_body_bytes.to_string(),
+        }
+    }
+
+    fn apply_to_config(&self, config: &mut AppConfig) -> Result<(), String> {
+        let listen_ip = self.listen_ip.trim();
+        if listen_ip.is_empty() {
+            return Err("listen IP cannot be empty".to_string());
+        }
+
+        let listen_port = self
+            .listen_port
+            .trim()
+            .parse::<u16>()
+            .map_err(|_| "listen port must be a valid number (0-65535)".to_string())?;
+
+        let webhook_path = self.webhook_path.trim();
+        if webhook_path.is_empty() {
+            return Err("webhook path cannot be empty".to_string());
+        }
+
+        let webhook_max_body_bytes = self
+            .webhook_max_body_bytes
+            .trim()
+            .parse::<usize>()
+            .map_err(|_| "webhook max body bytes must be a valid integer".to_string())?;
+
+        config.gateway.enabled = self.enabled;
+        config.gateway.listen_ip = listen_ip.to_string();
+        config.gateway.listen_port = listen_port;
+        config.gateway.auth.enabled = self.auth_enabled;
+        config.gateway.auth.token = if self.auth_token.trim().is_empty() {
+            None
+        } else {
+            Some(self.auth_token.trim().to_string())
+        };
+        config.gateway.auth.env_key = if self.auth_env_key.trim().is_empty() {
+            None
+        } else {
+            Some(self.auth_env_key.trim().to_string())
+        };
+        config.gateway.webhook.enabled = self.webhook_enabled;
+        config.gateway.webhook.path = webhook_path.to_string();
+        config.gateway.webhook.max_body_bytes = webhook_max_body_bytes;
+
+        Ok(())
+    }
+}
+
 pub struct GatewayPanel {
     status: Option<GatewayStatusSnapshot>,
     loaded: bool,
+    store: Option<ConfigStore>,
+    config_path: Option<PathBuf>,
+    config: AppConfig,
+    config_form: GatewayConfigForm,
+    config_window_open: bool,
+}
+
+impl Default for GatewayPanel {
+    fn default() -> Self {
+        Self {
+            status: None,
+            loaded: false,
+            store: None,
+            config_path: None,
+            config: AppConfig::default(),
+            config_form: GatewayConfigForm::default(),
+            config_window_open: false,
+        }
+    }
 }
 
 impl GatewayPanel {
     fn ensure_loaded(&mut self, notifications: &mut NotificationCenter) {
+        self.ensure_store_loaded(notifications);
         if self.loaded {
             return;
         }
         self.loaded = true;
         self.refresh(notifications, false);
+    }
+
+    fn ensure_store_loaded(&mut self, notifications: &mut NotificationCenter) {
+        if self.store.is_some() {
+            return;
+        }
+        match ConfigStore::open(None) {
+            Ok(store) => {
+                let snapshot = store.snapshot();
+                self.store = Some(store);
+                self.apply_snapshot(snapshot);
+            }
+            Err(err) => notifications.error(format!("Failed to load config: {err}")),
+        }
+    }
+
+    fn apply_snapshot(&mut self, snapshot: ConfigSnapshot) {
+        self.config_path = Some(snapshot.path);
+        self.config = snapshot.config;
+        self.config_form = GatewayConfigForm::from_config(&self.config.gateway);
     }
 
     fn refresh(&mut self, notifications: &mut NotificationCenter, announce: bool) {
@@ -38,25 +167,53 @@ impl GatewayPanel {
         }
     }
 
-    fn set_enabled(&mut self, enabled: bool, notifications: &mut NotificationCenter) {
-        match request_set_gateway_enabled(enabled) {
-            Ok(status) => {
-                let message = if enabled {
-                    status
-                        .info
-                        .as_ref()
-                        .map(|info| format!("Gateway started at {}", info.ws_url))
-                        .unwrap_or_else(|| "Gateway started".to_string())
-                } else {
-                    "Gateway stopped".to_string()
-                };
-                self.status = Some(status);
-                notifications.success(message);
+    fn open_config_window(&mut self) {
+        self.config_form = GatewayConfigForm::from_config(&self.config.gateway);
+        self.config_window_open = true;
+    }
+
+    fn save_config(&mut self, notifications: &mut NotificationCenter) {
+        let Some(store) = self.store.as_ref() else {
+            notifications.error("Configuration store is not available");
+            return;
+        };
+
+        let mut next = self.config.clone();
+        if let Err(err) = self.config_form.apply_to_config(&mut next) {
+            notifications.error(err);
+            return;
+        }
+
+        match toml::to_string_pretty(&next) {
+            Ok(raw) => match store.save_raw_toml(&raw) {
+                Ok(snapshot) => {
+                    self.apply_snapshot(snapshot);
+                    self.config_window_open = false;
+                    let running = self.status.as_ref().map(|s| s.running).unwrap_or(false);
+                    if running {
+                        notifications
+                            .success("Gateway config saved. Restart gateway to apply changes.");
+                    } else {
+                        notifications.success("Gateway config saved");
+                    }
+                }
+                Err(err) => notifications.error(format!("Save failed: {err}")),
+            },
+            Err(err) => notifications.error(format!("Failed to render config TOML: {err}")),
+        }
+    }
+
+    fn reload_config(&mut self, notifications: &mut NotificationCenter) {
+        let Some(store) = self.store.as_ref() else {
+            notifications.error("Configuration store is not available");
+            return;
+        };
+        match store.reload() {
+            Ok(snapshot) => {
+                self.apply_snapshot(snapshot);
+                notifications.success("Config reloaded from disk");
             }
-            Err(err) => {
-                notifications.error(format!("Failed to update gateway: {err}"));
-                self.refresh(notifications, false);
-            }
+            Err(err) => notifications.error(format!("Reload failed: {err}")),
         }
     }
 
@@ -95,6 +252,98 @@ impl GatewayPanel {
             }
         }
     }
+
+    fn render_config_window(
+        &mut self,
+        ctx: &egui::Context,
+        notifications: &mut NotificationCenter,
+    ) {
+        let mut open = self.config_window_open;
+        egui::Window::new("Gateway Config")
+            .id(egui::Id::new("gateway-config-window"))
+            .open(&mut open)
+            .resizable(true)
+            .default_width(520.0)
+            .show(ctx, |ui| {
+                ui.heading("Basic");
+                ui.horizontal(|ui| {
+                    ui.label("Enabled");
+                    ui.checkbox(&mut self.config_form.enabled, "");
+                });
+
+                ui.horizontal(|ui| {
+                    ui.label("Listen IP");
+                    ui.add_sized(
+                        [200.0, ui.spacing().interact_size.y],
+                        egui::TextEdit::singleline(&mut self.config_form.listen_ip),
+                    );
+                });
+
+                ui.horizontal(|ui| {
+                    ui.label("Listen Port");
+                    ui.add_sized(
+                        [100.0, ui.spacing().interact_size.y],
+                        egui::TextEdit::singleline(&mut self.config_form.listen_port),
+                    );
+                    ui.label("(0 = auto)");
+                });
+
+                ui.add_space(8.0);
+                ui.separator();
+                ui.heading("Auth");
+                ui.horizontal(|ui| {
+                    ui.label("Enabled");
+                    ui.checkbox(&mut self.config_form.auth_enabled, "");
+                });
+                ui.horizontal(|ui| {
+                    ui.label("Token");
+                    ui.add_sized(
+                        [280.0, ui.spacing().interact_size.y],
+                        egui::TextEdit::singleline(&mut self.config_form.auth_token).password(true),
+                    );
+                });
+                ui.horizontal(|ui| {
+                    ui.label("Env Key");
+                    ui.add_sized(
+                        [200.0, ui.spacing().interact_size.y],
+                        egui::TextEdit::singleline(&mut self.config_form.auth_env_key),
+                    );
+                });
+
+                ui.add_space(8.0);
+                ui.separator();
+                ui.heading("Webhook");
+                ui.horizontal(|ui| {
+                    ui.label("Enabled");
+                    ui.checkbox(&mut self.config_form.webhook_enabled, "");
+                });
+                ui.horizontal(|ui| {
+                    ui.label("Path");
+                    ui.add_sized(
+                        [280.0, ui.spacing().interact_size.y],
+                        egui::TextEdit::singleline(&mut self.config_form.webhook_path),
+                    );
+                });
+                ui.horizontal(|ui| {
+                    ui.label("Max Body Bytes");
+                    ui.add_sized(
+                        [120.0, ui.spacing().interact_size.y],
+                        egui::TextEdit::singleline(&mut self.config_form.webhook_max_body_bytes),
+                    );
+                });
+
+                ui.add_space(8.0);
+                ui.horizontal(|ui| {
+                    if ui.button("Reload").clicked() {
+                        self.reload_config(notifications);
+                    }
+                    if ui.button("Save").clicked() {
+                        self.save_config(notifications);
+                    }
+                });
+            });
+        self.config_window_open = open;
+    }
 }
 
 impl PanelRenderer for GatewayPanel {
@@ -119,20 +368,13 @@ impl PanelRenderer for GatewayPanel {
             ui.ctx().request_repaint_after(GATEWAY_POLL_INTERVAL);
         }
 
-        let mut enabled = status.configured_enabled;
         ui.horizontal(|ui| {
             if ui.button("Refresh").clicked() {
                 self.refresh(notifications, true);
             }
 
-            if ui
-                .add_enabled(
-                    !status.transitioning,
-                    egui::Checkbox::new(&mut enabled, "Enabled"),
-                )
-                .changed()
-            {
-                self.set_enabled(enabled, notifications);
+            if ui.button("Config").clicked() {
+                self.open_config_window();
             }
 
             if ui
@@ -287,6 +529,10 @@ impl PanelRenderer for GatewayPanel {
                 ui.visuals().warn_fg_color,
                 "⚠️ Funnel exposes your gateway publicly. Configure gateway.auth to protect it.",
             );
+        }
+
+        if self.config_window_open {
+            self.render_config_window(ui.ctx(), notifications);
         }
     }
 }


### PR DESCRIPTION
Replace the enabled checkbox with a Config button that opens a modal dialog containing gateway configuration options:

- Basic: enabled, listen IP, listen port
- Auth: enabled, token (masked), env key
- Webhook: enabled, path, max body bytes

Config is loaded/saved via ConfigStore with validation. Changes to running gateway show restart notification.

Closes #3