### PR TITLE
fix(gui): embed runtime icons for macOS binaries

### DIFF
--- a/klaw-gui/CHANGELOG.md
+++ b/klaw-gui/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `MCP` global settings moved behind a `Config` dialog instead of rendering inline
 - `MCP` runtime status refresh now reads a manager snapshot instead of triggering a full sync, avoiding long-lived GUI spinners while keeping polling off the GUI thread
 - `Memory` panel provider selection now reads available providers from `config.toml` and fills the embedding model from the selected provider's default model
+- GUI app and tray icons now load from embedded image assets at runtime, so both packaged `.app` bundles and standalone macOS binaries keep the custom icon without relying on source-tree file paths
 
 ## 2026-03-22
 

--- a/klaw-gui/README.md
+++ b/klaw-gui/README.md
@@ -11,12 +11,12 @@
   - File menu includes `Force Persist Layout` to immediately flush layout state to disk
 - Bottom status bar with version and theme-mode switcher
   - Runtime provider override dropdown on the right (select from `model_providers` without editing config; applies immediately to the running runtime's default provider for new routes and `/new`)
-- System tray / macOS menu bar icon loaded from `assets/icons/logo.iconset`
+- System tray / macOS menu bar icon loaded from embedded PNG assets at runtime
   - tray menu includes `Open Klaw`, `Setting`, `About`, and `Quit Klaw`
   - `Setting` opens the in-app settings workbench
 - UI state persistence across restart (`~/.klaw/gui_state.json`)
   - includes tabs/theme/fullscreen and window size
-- macOS app icon is loaded from `assets/icons/logo.icns` at startup
+- macOS app icon is loaded from embedded image bytes at startup, so both `.app` bundles and standalone binaries keep the custom icon
 - System CJK font fallback via `fontdb` to avoid Chinese text missing-glyph rendering
 - Strongly typed menu model for workspace modules
 - Single-tab-per-menu behavior (click to open or activate)
@@ -153,4 +153,4 @@ make build-macos-app
 make package-macos-dmg
 ```
 
-The app bundle uses `assets/icons/logo.icns` as the bundle icon and emits packaged artifacts to `dist/macos/`.
+The app bundle still ships `assets/icons/logo.icns` for Finder/Dock bundle metadata, while runtime window/tray icon loading uses embedded assets so distributed binaries do not depend on the source tree layout. Packaged artifacts are emitted to `dist/macos/`.

--- a/klaw-gui/src/icon.rs
+++ b/klaw-gui/src/icon.rs
@@ -1,0 +1,78 @@
+use anyhow::Context;
+
+const APP_ICON_PNG: &[u8] = include_bytes!("../assets/icons/logo.iconset/icon_512x512@2x.png");
+
+#[cfg(target_os = "macos")]
+const TRAY_ICON_PNG: &[u8] = include_bytes!("../assets/icons/logo.iconset/icon_16x16@2x.png");
+
+#[cfg(not(target_os = "macos"))]
+const TRAY_ICON_PNG: &[u8] = include_bytes!("../assets/icons/logo.iconset/icon_32x32.png");
+
+struct DecodedIcon {
+    rgba: Vec<u8>,
+    width: u32,
+    height: u32,
+}
+
+pub fn viewport_icon() -> Option<egui::IconData> {
+    let decoded = decode_png_icon(APP_ICON_PNG).ok()?;
+    Some(egui::IconData {
+        rgba: decoded.rgba,
+        width: decoded.width,
+        height: decoded.height,
+    })
+}
+
+pub fn tray_icon() -> anyhow::Result<tray_icon::Icon> {
+    let decoded = decode_png_icon(TRAY_ICON_PNG)?;
+    tray_icon::Icon::from_rgba(decoded.rgba, decoded.width, decoded.height)
+        .map_err(|err| anyhow::anyhow!("failed to convert embedded tray icon: {err}"))
+}
+
+#[cfg(target_os = "macos")]
+pub fn application_icon_image() -> Option<objc2::rc::Retained<objc2_app_kit::NSImage>> {
+    use objc2::ClassType as _;
+    use objc2_app_kit::NSImage;
+    use objc2_foundation::NSData;
+
+    let data = NSData::with_bytes(APP_ICON_PNG);
+    NSImage::initWithData(NSImage::alloc(), &data)
+}
+
+fn decode_png_icon(bytes: &[u8]) -> anyhow::Result<DecodedIcon> {
+    let image = image::load_from_memory(bytes)
+        .context("failed to decode embedded icon image")?
+        .into_rgba8();
+    Ok(DecodedIcon {
+        width: image.width(),
+        height: image.height(),
+        rgba: image.into_raw(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{decode_png_icon, APP_ICON_PNG, TRAY_ICON_PNG};
+
+    #[test]
+    fn embedded_viewport_icon_decodes() {
+        let decoded = decode_png_icon(APP_ICON_PNG).expect("app icon should decode");
+        assert!(decoded.width > 0);
+        assert!(decoded.height > 0);
+        assert_eq!(
+            decoded.rgba.len(),
+            decoded.width as usize * decoded.height as usize * 4
+        );
+    }
+
+    #[test]
+    fn embedded_tray_icon_decodes() {
+        let decoded = decode_png_icon(TRAY_ICON_PNG).expect("tray icon should decode");
+        assert!(decoded.width > 0);
+        assert!(decoded.height > 0);
+        assert_eq!(
+            decoded.rgba.len(),
+            decoded.width as usize * decoded.height as usize * 4
+        );
+    }
+}

--- a/klaw-gui/src/lib.rs
+++ b/klaw-gui/src/lib.rs
@@ -1,5 +1,6 @@
 mod app;
 mod domain;
+mod icon;
 mod notifications;
 mod panels;
 mod runtime_bridge;
@@ -48,7 +49,8 @@ pub fn run() -> anyhow::Result<()> {
 
 #[cfg(target_os = "macos")]
 fn configure_platform_viewport(viewport: egui::ViewportBuilder) -> egui::ViewportBuilder {
-    if let Some(icon) = load_macos_app_icon() {
+    install_macos_app_icon();
+    if let Some(icon) = icon::viewport_icon() {
         viewport.with_icon(icon)
     } else {
         viewport
@@ -61,63 +63,19 @@ fn configure_platform_viewport(viewport: egui::ViewportBuilder) -> egui::Viewpor
 }
 
 #[cfg(target_os = "macos")]
-fn load_macos_app_icon() -> Option<egui::IconData> {
-    use objc2::ClassType as _;
-    use objc2_app_kit::NSImage;
-    use objc2_foundation::{MainThreadMarker, NSString};
+fn install_macos_app_icon() {
+    use objc2_app_kit::NSApplication;
+    use objc2_foundation::MainThreadMarker;
 
-    let mtm = MainThreadMarker::new()?;
+    let Some(mtm) = MainThreadMarker::new() else {
+        return;
+    };
+    let Some(icon) = icon::application_icon_image() else {
+        return;
+    };
 
-    let icon_path = macos_icon_path();
-    let icon_path_ns = NSString::from_str(&icon_path);
-    let icon = unsafe { NSImage::initWithContentsOfFile(NSImage::alloc(), &icon_path_ns) }?;
-
-    let app = objc2_app_kit::NSApplication::sharedApplication(mtm);
+    let app = NSApplication::sharedApplication(mtm);
     unsafe {
         app.setApplicationIconImage(Some(&icon));
     }
-
-    let tiff = unsafe { icon.TIFFRepresentation() }?;
-    macos_nsdata_to_vec(&tiff).and_then(|bytes| {
-        let image = image::load_from_memory(&bytes).ok()?.into_rgba8();
-        Some(egui::IconData {
-            width: image.width(),
-            height: image.height(),
-            rgba: image.into_raw(),
-        })
-    })
-}
-
-#[cfg(target_os = "macos")]
-fn macos_icon_path() -> String {
-    use objc2_foundation::NSBundle;
-
-    let bundle = NSBundle::mainBundle();
-    let Some(resource_url) = (unsafe { bundle.resourceURL() }) else {
-        return format!("{}/assets/icons/logo.icns", env!("CARGO_MANIFEST_DIR"));
-    };
-    let Some(path) = (unsafe { resource_url.path() }) else {
-        return format!("{}/assets/icons/logo.icns", env!("CARGO_MANIFEST_DIR"));
-    };
-    if path.is_empty() {
-        return format!("{}/assets/icons/logo.icns", env!("CARGO_MANIFEST_DIR"));
-    }
-    format!("{}/logo.icns", path)
-}
-
-#[cfg(target_os = "macos")]
-fn macos_nsdata_to_vec(data: &objc2_foundation::NSData) -> Option<Vec<u8>> {
-    use std::ptr::NonNull;
-
-    let len = data.length();
-    if len == 0 {
-        return None;
-    }
-
-    let mut bytes = vec![0_u8; len];
-    let ptr = NonNull::new(bytes.as_mut_ptr().cast())?;
-    unsafe {
-        data.getBytes_length(ptr, len);
-    }
-    Some(bytes)
 }

--- a/klaw-gui/src/tray.rs
+++ b/klaw-gui/src/tray.rs
@@ -1,3 +1,4 @@
+use crate::icon;
 use anyhow::Context;
 use std::sync::mpsc::{self, Receiver};
 use tray_icon::{
@@ -25,9 +26,7 @@ pub struct TrayIntegration {
 }
 
 pub fn install(egui_ctx: &egui::Context) -> anyhow::Result<Option<TrayIntegration>> {
-    let Some(icon) = load_tray_icon()? else {
-        return Ok(None);
-    };
+    let icon = load_tray_icon()?;
     let menu = build_tray_menu()?;
     let (command_tx, command_rx) = mpsc::channel();
     let repaint_ctx = egui_ctx.clone();
@@ -53,33 +52,8 @@ pub fn install(egui_ctx: &egui::Context) -> anyhow::Result<Option<TrayIntegratio
     }))
 }
 
-fn load_tray_icon() -> anyhow::Result<Option<tray_icon::Icon>> {
-    let icon_path = tray_icon_path();
-    if !icon_path.exists() {
-        return Ok(None);
-    }
-
-    let image = image::open(&icon_path)
-        .with_context(|| format!("failed to load tray icon from {}", icon_path.display()))?
-        .into_rgba8();
-    let width = image.width();
-    let height = image.height();
-
-    tray_icon::Icon::from_rgba(image.into_raw(), width, height)
-        .map(Some)
-        .map_err(|err| anyhow::anyhow!("failed to convert tray icon image: {err}"))
-}
-
-#[cfg(target_os = "macos")]
-fn tray_icon_path() -> std::path::PathBuf {
-    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("assets/icons/logo.iconset/icon_16x16@2x.png")
-}
-
-#[cfg(not(target_os = "macos"))]
-fn tray_icon_path() -> std::path::PathBuf {
-    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("assets/icons/logo.iconset/icon_32x32.png")
+fn load_tray_icon() -> anyhow::Result<tray_icon::Icon> {
+    icon::tray_icon().context("failed to load embedded tray icon")
 }
 
 fn build_tray_menu() -> anyhow::Result<Menu> {


### PR DESCRIPTION
## Summary
- embed the macOS runtime app icon and tray icon so GUI startup no longer depends on source-tree or bundle resource paths
- keep `logo.icns` as bundle metadata for Finder while using embedded PNG assets for runtime window and tray icon loading
- add icon decode tests and refresh `klaw-gui` docs/changelog to describe the new runtime icon behavior

Fixes #16

## Test plan
- [x] `cargo test -p klaw-gui`
- [x] verify the packaged `.app` shows the custom icon at runtime
- [x] verify the standalone macOS binary shows the custom icon at runtime

Made with [Cursor](https://cursor.com)