### PR TITLE
fix(gui): validate r2 sync and show backup progress

### DIFF
--- a/klaw-gui/CHANGELOG.md
+++ b/klaw-gui/CHANGELOG.md
@@ -15,6 +15,8 @@
 - `MCP` runtime status refresh now reads a manager snapshot instead of triggering a full sync, avoiding long-lived GUI spinners while keeping polling off the GUI thread
 - `Memory` panel provider selection now reads available providers from `config.toml` and fills the embedding model from the selected provider's default model
 - GUI app and tray icons now load from embedded image assets at runtime, so both packaged `.app` bundles and standalone macOS binaries keep the custom icon without relying on source-tree file paths
+- `Setting > Sync` now validates custom S3 endpoint credentials before startup checks or manual actions run, so R2 users no longer fall through to missing AWS shared-profile files
+- `Setting > Sync` manual backup now renders a live progress bar with stage and item detail while snapshot preparation, upload, and retention cleanup run in the background
 
 ## 2026-03-22
 

--- a/klaw-gui/README.md
+++ b/klaw-gui/README.md
@@ -98,9 +98,11 @@
 - Setting panel features:
   - persist sync settings in `settings.json`, including S3 endpoint/region/bucket/prefix, backup scope, retention, schedule, hostname-based device ID, and both direct or env-backed credentials
   - trigger manual snapshot backup uploads
+  - show a live progress bar plus stage/detail text while manual snapshot backup is preparing, uploading, and pruning remote history
   - trigger manual retention cleanup against remote snapshots
   - list remote snapshots and manually restore a selected snapshot
   - surface startup remote-update detection and shared sync task status in the Sync UI
+  - validate custom S3 endpoint credentials up front so R2-style endpoints do not rely on AWS shared-profile discovery
 - Session panel features:
   - read indexed sessions via `klaw-session` manager abstraction
   - render session metadata in a read-only table with limit/offset controls

--- a/klaw-gui/src/panels/setting.rs
+++ b/klaw-gui/src/panels/setting.rs
@@ -6,13 +6,15 @@ use crate::settings::{
 };
 use crate::sync_runtime::{
     sync_runtime_finish_task, sync_runtime_set_last_snapshot, sync_runtime_set_remote_snapshots,
-    sync_runtime_set_remote_update, sync_runtime_snapshot, sync_runtime_sync_from_settings,
-    sync_runtime_try_start_task, SyncRuntimeSnapshot, SyncRuntimeTaskKind,
+    sync_runtime_set_remote_update, sync_runtime_set_task_progress, sync_runtime_snapshot,
+    sync_runtime_sync_from_settings, sync_runtime_try_start_task, SyncRuntimeProgress,
+    SyncRuntimeSnapshot, SyncRuntimeTaskKind,
 };
 use crate::time_format::format_optional_timestamp_millis;
 use egui_extras::{Size, StripBuilder};
 use klaw_storage::{
-    BackupItem, BackupPlan, BackupService, S3SnapshotStoreConfig, SnapshotListItem, SnapshotMode,
+    BackupItem, BackupPlan, BackupProgress, BackupService, S3SnapshotStoreConfig, SnapshotListItem,
+    SnapshotMode,
 };
 use std::sync::mpsc::{self, Receiver};
 use std::thread;
@@ -286,6 +288,13 @@ impl SettingPanel {
         }
     }
 
+    fn sync_validation_error(&self) -> Option<String> {
+        self.sync_config()
+            .validate()
+            .err()
+            .map(|err| err.to_string())
+    }
+
     fn backup_plan(&self) -> BackupPlan {
         BackupPlan {
             mode: match self.settings.sync.mode {
@@ -332,11 +341,29 @@ impl SettingPanel {
                     .build()
                     .map_err(|err| err.to_string())?;
                 runtime.block_on(async move {
+                    sync_runtime_set_task_progress(
+                        SyncRuntimeTaskKind::ManualBackup,
+                        Some(SyncRuntimeProgress {
+                            fraction: 0.02,
+                            stage: "Connecting to remote storage".to_string(),
+                            detail: Some("Validating sync configuration".to_string()),
+                        }),
+                    );
                     let service = BackupService::open_s3_default(config, device_id)
                         .await
                         .map_err(|err| err.to_string())?;
+                    let mut report = |progress: BackupProgress| {
+                        sync_runtime_set_task_progress(
+                            SyncRuntimeTaskKind::ManualBackup,
+                            Some(runtime_progress_from_backup(progress)),
+                        );
+                    };
                     let result = service
-                        .create_upload_and_cleanup_snapshot(&plan, keep_last)
+                        .create_upload_and_cleanup_snapshot_with_progress(
+                            &plan,
+                            keep_last,
+                            &mut report,
+                        )
                         .await
                         .map_err(|err| err.to_string())?;
                     let snapshots = service
@@ -563,6 +590,7 @@ impl SettingPanel {
     ) {
         ui.strong("Sync Settings");
         ui.add_space(8.0);
+        let sync_validation_error = self.sync_validation_error();
 
         let mut changed = false;
         changed |= ui
@@ -780,12 +808,26 @@ impl SettingPanel {
                 ));
                 if let Some(task) = &runtime.active_task {
                     ui.label(format!("In progress: {}", task.label));
+                    if let Some(progress) = &task.progress {
+                        ui.add(
+                            egui::ProgressBar::new(progress.fraction.clamp(0.0, 1.0))
+                                .desired_width(ui.available_width().max(200.0))
+                                .show_percentage()
+                                .text(progress.stage.clone()),
+                        );
+                        if let Some(detail) = &progress.detail {
+                            ui.small(detail);
+                        }
+                    }
+                }
+                if let Some(err) = &sync_validation_error {
+                    ui.colored_label(ui.visuals().warn_fg_color, err);
                 }
                 ui.add_space(6.0);
                 ui.horizontal_wrapped(|ui| {
                     let can_run = self.settings.sync.enabled
                         && !self.sync_busy()
-                        && !self.settings.sync.s3.bucket.trim().is_empty();
+                        && sync_validation_error.is_none();
                     if ui
                         .add_enabled(can_run, egui::Button::new("Run Backup Now"))
                         .clicked()
@@ -794,7 +836,7 @@ impl SettingPanel {
                     }
                     if ui
                         .add_enabled(
-                            !self.sync_busy(),
+                            !self.sync_busy() && sync_validation_error.is_none(),
                             egui::Button::new("Refresh Remote Snapshots"),
                         )
                         .clicked()
@@ -803,7 +845,9 @@ impl SettingPanel {
                     }
                     if ui
                         .add_enabled(
-                            self.settings.sync.enabled && !self.sync_busy(),
+                            self.settings.sync.enabled
+                                && !self.sync_busy()
+                                && sync_validation_error.is_none(),
                             egui::Button::new("Run Retention Cleanup"),
                         )
                         .clicked()
@@ -811,10 +855,9 @@ impl SettingPanel {
                         self.run_retention_cleanup();
                     }
                 });
-                if self.settings.sync.enabled && self.settings.sync.s3.bucket.trim().is_empty() {
-                    ui.colored_label(
-                        ui.visuals().warn_fg_color,
-                        "Bucket is required before backup or restore can run.",
+                if self.settings.sync.enabled && sync_validation_error.is_none() {
+                    ui.small(
+                        "Manual backup progress is shown below while snapshot preparation and upload are running.",
                     );
                 }
             });
@@ -841,7 +884,10 @@ impl SettingPanel {
                                 ui.label(format!("Device: {}", snapshot.device_id));
                             });
                             if ui
-                                .add_enabled(!self.sync_busy(), egui::Button::new("Restore"))
+                                .add_enabled(
+                                    !self.sync_busy() && sync_validation_error.is_none(),
+                                    egui::Button::new("Restore"),
+                                )
                                 .clicked()
                             {
                                 restore_target = Some(snapshot.snapshot_id.clone());
@@ -900,6 +946,24 @@ fn sync_item_to_backup_item(item: SyncItem) -> Option<BackupItem> {
         SyncItem::UserWorkspace => Some(BackupItem::UserWorkspace),
         SyncItem::Memory => Some(BackupItem::Memory),
         SyncItem::Config => Some(BackupItem::Config),
+    }
+}
+
+fn runtime_progress_from_backup(progress: BackupProgress) -> SyncRuntimeProgress {
+    SyncRuntimeProgress {
+        fraction: progress.fraction.clamp(0.0, 1.0),
+        stage: match progress.stage {
+            klaw_storage::BackupProgressStage::PreparingSnapshot => "Preparing snapshot",
+            klaw_storage::BackupProgressStage::UploadingManifest => "Uploading manifest",
+            klaw_storage::BackupProgressStage::UploadingBundle => "Uploading bundle",
+            klaw_storage::BackupProgressStage::UpdatingLatestPointer => {
+                "Updating latest snapshot pointer"
+            }
+            klaw_storage::BackupProgressStage::CleaningUpRemote => "Cleaning up old snapshots",
+            klaw_storage::BackupProgressStage::Completed => "Backup completed",
+        }
+        .to_string(),
+        detail: Some(progress.detail),
     }
 }
 

--- a/klaw-gui/src/sync_runtime.rs
+++ b/klaw-gui/src/sync_runtime.rs
@@ -20,10 +20,18 @@ pub struct SyncRuntimeSnapshot {
     pub last_snapshot_at: Option<i64>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
+pub struct SyncRuntimeProgress {
+    pub fraction: f32,
+    pub stage: String,
+    pub detail: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct SyncRuntimeTask {
     pub kind: SyncRuntimeTaskKind,
     pub label: String,
+    pub progress: Option<SyncRuntimeProgress>,
 }
 
 #[derive(Debug, Default)]
@@ -64,6 +72,7 @@ pub fn sync_runtime_try_start_task(kind: SyncRuntimeTaskKind, label: impl Into<S
         state.active_task = Some(SyncRuntimeTask {
             kind,
             label: label.into(),
+            progress: None,
         });
         true
     })
@@ -80,6 +89,19 @@ pub fn sync_runtime_finish_task(kind: SyncRuntimeTaskKind) {
 pub fn sync_runtime_set_remote_snapshots(snapshots: Vec<SnapshotListItem>) {
     with_runtime_state(|state| {
         state.remote_snapshots = snapshots;
+    });
+}
+
+pub fn sync_runtime_set_task_progress(
+    kind: SyncRuntimeTaskKind,
+    progress: Option<SyncRuntimeProgress>,
+) {
+    with_runtime_state(|state| {
+        if let Some(task) = state.active_task.as_mut() {
+            if task.kind == kind {
+                task.progress = progress;
+            }
+        }
     });
 }
 
@@ -131,5 +153,30 @@ mod tests {
             "Auto backup"
         ));
         sync_runtime_finish_task(SyncRuntimeTaskKind::AutoBackup);
+    }
+
+    #[test]
+    fn task_progress_updates_active_task() {
+        sync_runtime_finish_task(SyncRuntimeTaskKind::ManualBackup);
+        assert!(sync_runtime_try_start_task(
+            SyncRuntimeTaskKind::ManualBackup,
+            "Manual backup"
+        ));
+        sync_runtime_set_task_progress(
+            SyncRuntimeTaskKind::ManualBackup,
+            Some(SyncRuntimeProgress {
+                fraction: 0.5,
+                stage: "Preparing snapshot".to_string(),
+                detail: Some("Prepared 1/2".to_string()),
+            }),
+        );
+
+        let snapshot = sync_runtime_snapshot();
+        let task = snapshot.active_task.expect("active task should exist");
+        let progress = task.progress.expect("progress should exist");
+        assert_eq!(progress.fraction, 0.5);
+        assert_eq!(progress.stage, "Preparing snapshot");
+
+        sync_runtime_finish_task(SyncRuntimeTaskKind::ManualBackup);
     }
 }

--- a/klaw-gui/src/ui/shell.rs
+++ b/klaw-gui/src/ui/shell.rs
@@ -495,7 +495,7 @@ impl SyncSupervisor {
 }
 
 fn sync_ready(settings: &AppSettings) -> bool {
-    settings.sync.enabled && !settings.sync.s3.bucket.trim().is_empty()
+    settings.sync.enabled && build_sync_store_config(settings).validate().is_ok()
 }
 
 fn build_sync_store_config(settings: &AppSettings) -> S3SnapshotStoreConfig {

--- a/klaw-storage/CHANGELOG.md
+++ b/klaw-storage/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-03-23
+
+### Changed
+- custom S3 endpoints such as R2 now require explicit credentials or credential env names up front, avoiding fallback to missing AWS shared-profile files during sync startup and backup
+- `BackupService` now exposes progress callbacks for snapshot preparation, upload, and retention cleanup so GUI clients can render live backup progress
+
 ## 2026-03-22
 
 ### Added

--- a/klaw-storage/README.md
+++ b/klaw-storage/README.md
@@ -38,5 +38,7 @@
 - `DefaultMemoryDb` provides a generic SQL interface for `klaw-memory`
 - `DefaultArchiveDb` provides a generic SQL interface for `klaw-archive`
 - `BackupService` snapshots managed SQLite/filesystem state into `manifest.json` plus `bundle.tar.zst`, uploads them, and restores full snapshots after checksum verification
+- `BackupService` can emit progress updates for snapshot preparation, object upload, and retention cleanup so callers can surface live backup state
 - retention cleanup keeps only the configured latest snapshot count and refreshes `latest.json` after pruning
 - S3 snapshot config accepts either direct credentials (`access_key`, `secret_key`, `session_token`) or environment-variable indirection, and empty device IDs normalize to the local hostname
+- custom S3 endpoints such as R2 must provide explicit credentials or credential env names instead of relying on AWS shared-profile discovery

--- a/klaw-storage/src/backup.rs
+++ b/klaw-storage/src/backup.rs
@@ -143,6 +143,24 @@ impl S3SnapshotStoreConfig {
                 "sync.s3 access_key_env and secret_key_env must both be set or both be empty",
             ));
         }
+        if !self.endpoint.trim().is_empty() && access_key.is_empty() && secret_key.is_empty() {
+            if access.is_empty() && secret.is_empty() {
+                return Err(StorageError::backend(
+                    "sync.s3 custom endpoint requires explicit credentials via access_key/secret_key or access_key_env/secret_key_env; R2 does not use AWS shared profile files",
+                ));
+            }
+
+            let missing_envs = [access, secret]
+                .into_iter()
+                .filter(|name| std::env::var_os(name).is_none())
+                .collect::<Vec<_>>();
+            if !missing_envs.is_empty() {
+                return Err(StorageError::backend(format!(
+                    "sync.s3 custom endpoint requires credential env vars to exist: {}; otherwise set access_key and secret_key directly",
+                    missing_envs.join(", ")
+                )));
+            }
+        }
         Ok(())
     }
 }
@@ -178,6 +196,23 @@ pub struct SnapshotPrepareResult {
 pub struct BackupResult {
     pub snapshot_id: String,
     pub manifest: SnapshotManifest,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackupProgressStage {
+    PreparingSnapshot,
+    UploadingManifest,
+    UploadingBundle,
+    UpdatingLatestPointer,
+    CleaningUpRemote,
+    Completed,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct BackupProgress {
+    pub stage: BackupProgressStage,
+    pub fraction: f32,
+    pub detail: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -268,8 +303,11 @@ impl BackupService {
         &self,
         plan: &BackupPlan,
     ) -> Result<BackupResult, StorageError> {
-        let prepared = self.create_snapshot(plan).await?;
-        let result = self.upload_snapshot(&prepared).await?;
+        let mut noop = |_| {};
+        let prepared = self.create_snapshot_with_progress(plan, &mut noop).await?;
+        let result = self
+            .upload_snapshot_with_progress(&prepared, &mut noop)
+            .await?;
         let _ = fs::remove_dir_all(&prepared.snapshot_dir).await;
         Ok(result)
     }
@@ -279,8 +317,37 @@ impl BackupService {
         plan: &BackupPlan,
         keep_last: u32,
     ) -> Result<BackupResult, StorageError> {
-        let result = self.create_and_upload_snapshot(plan).await?;
+        let mut noop = |_| {};
+        self.create_upload_and_cleanup_snapshot_with_progress(plan, keep_last, &mut noop)
+            .await
+    }
+
+    pub async fn create_upload_and_cleanup_snapshot_with_progress<F>(
+        &self,
+        plan: &BackupPlan,
+        keep_last: u32,
+        progress: &mut F,
+    ) -> Result<BackupResult, StorageError>
+    where
+        F: FnMut(BackupProgress),
+    {
+        let prepared = self.create_snapshot_with_progress(plan, progress).await?;
+        let result = self
+            .upload_snapshot_with_progress(&prepared, progress)
+            .await?;
+        report_progress(
+            progress,
+            BackupProgressStage::CleaningUpRemote,
+            0.98,
+            format!("Keeping the latest {} remote snapshot(s)", keep_last.max(1)),
+        );
         self.cleanup_remote_snapshots(keep_last).await?;
+        report_progress(
+            progress,
+            BackupProgressStage::Completed,
+            1.0,
+            format!("Snapshot {} uploaded successfully", result.snapshot_id),
+        );
         Ok(result)
     }
 
@@ -288,6 +355,18 @@ impl BackupService {
         &self,
         plan: &BackupPlan,
     ) -> Result<SnapshotPrepareResult, StorageError> {
+        let mut noop = |_| {};
+        self.create_snapshot_with_progress(plan, &mut noop).await
+    }
+
+    pub async fn create_snapshot_with_progress<F>(
+        &self,
+        plan: &BackupPlan,
+        progress: &mut F,
+    ) -> Result<SnapshotPrepareResult, StorageError>
+    where
+        F: FnMut(BackupProgress),
+    {
         self.paths.ensure_dirs().await?;
 
         let snapshot_id = build_snapshot_id();
@@ -305,16 +384,26 @@ impl BackupService {
             .await
             .map_err(StorageError::CreateTmpDir)?;
 
+        let sources = self.resolve_sources(plan)?;
+        let total_sources = sources.len();
+        report_progress(
+            progress,
+            BackupProgressStage::PreparingSnapshot,
+            0.05,
+            if total_sources == 0 {
+                "No local files matched the selected backup scope".to_string()
+            } else {
+                format!("Preparing {total_sources} snapshot item(s)")
+            },
+        );
+
         let mut entries = Vec::new();
-        for source in self.collect_sources(plan) {
+        for (index, source) in sources.into_iter().enumerate() {
             match source {
-                LocalSource::Database {
+                ResolvedLocalSource::Database {
                     source_path,
                     relative_path,
                 } => {
-                    if !path_exists(&source_path).await {
-                        continue;
-                    }
                     let dest = snapshot_dir.join(&relative_path);
                     if let Some(parent) = dest.parent() {
                         fs::create_dir_all(parent)
@@ -326,14 +415,12 @@ impl BackupService {
                         continue;
                     }
                     entries.push(build_entry(&snapshot_dir, &dest).await?);
+                    report_preparing_progress(progress, index + 1, total_sources, &relative_path);
                 }
-                LocalSource::File {
+                ResolvedLocalSource::File {
                     source_path,
                     relative_path,
                 } => {
-                    if !path_exists(&source_path).await {
-                        continue;
-                    }
                     let dest = snapshot_dir.join(&relative_path);
                     if let Some(parent) = dest.parent() {
                         fs::create_dir_all(parent)
@@ -344,30 +431,7 @@ impl BackupService {
                         .await
                         .map_err(StorageError::backend)?;
                     entries.push(build_entry(&snapshot_dir, &dest).await?);
-                }
-                LocalSource::Directory {
-                    source_dir,
-                    relative_root,
-                } => {
-                    if !path_exists(&source_dir).await {
-                        continue;
-                    }
-                    for file_path in walk_files(&source_dir)? {
-                        let rel = file_path
-                            .strip_prefix(&source_dir)
-                            .map_err(StorageError::backend)?;
-                        let relative_path = relative_root.join(rel);
-                        let dest = snapshot_dir.join(&relative_path);
-                        if let Some(parent) = dest.parent() {
-                            fs::create_dir_all(parent)
-                                .await
-                                .map_err(StorageError::CreateTmpDir)?;
-                        }
-                        fs::copy(&file_path, &dest)
-                            .await
-                            .map_err(StorageError::backend)?;
-                        entries.push(build_entry(&snapshot_dir, &dest).await?);
-                    }
+                    report_preparing_progress(progress, index + 1, total_sources, &relative_path);
                 }
             }
         }
@@ -386,8 +450,20 @@ impl BackupService {
 
         let manifest_path = snapshot_dir.join("manifest.json");
         write_json(&manifest_path, &manifest).await?;
+        report_progress(
+            progress,
+            BackupProgressStage::PreparingSnapshot,
+            0.72,
+            "Writing snapshot manifest".to_string(),
+        );
         let bundle_path = snapshot_dir.join("bundle.tar.zst");
         create_bundle(&snapshot_dir, &bundle_path).await?;
+        report_progress(
+            progress,
+            BackupProgressStage::PreparingSnapshot,
+            0.8,
+            "Compressing snapshot bundle".to_string(),
+        );
 
         Ok(SnapshotPrepareResult {
             manifest,
@@ -401,6 +477,19 @@ impl BackupService {
         &self,
         prepared: &SnapshotPrepareResult,
     ) -> Result<BackupResult, StorageError> {
+        let mut noop = |_| {};
+        self.upload_snapshot_with_progress(prepared, &mut noop)
+            .await
+    }
+
+    pub async fn upload_snapshot_with_progress<F>(
+        &self,
+        prepared: &SnapshotPrepareResult,
+        progress: &mut F,
+    ) -> Result<BackupResult, StorageError>
+    where
+        F: FnMut(BackupProgress),
+    {
         let manifest_bytes = fs::read(&prepared.manifest_path)
             .await
             .map_err(StorageError::backend)?;
@@ -409,13 +498,31 @@ impl BackupService {
             .map_err(StorageError::backend)?;
         let manifest_key = manifest_object_key(&prepared.manifest.snapshot_id);
         let bundle_key = bundle_object_key(&prepared.manifest.snapshot_id);
+        report_progress(
+            progress,
+            BackupProgressStage::UploadingManifest,
+            0.86,
+            format!("Uploading {}", manifest_key),
+        );
         self.store
             .put_bytes(&manifest_key, manifest_bytes, "application/json")
             .await?;
+        report_progress(
+            progress,
+            BackupProgressStage::UploadingBundle,
+            0.94,
+            format!("Uploading {}", bundle_key),
+        );
         self.store
             .put_bytes(&bundle_key, bundle_bytes, "application/zstd")
             .await?;
         let latest = SnapshotListItem::from_manifest(&prepared.manifest);
+        report_progress(
+            progress,
+            BackupProgressStage::UpdatingLatestPointer,
+            0.97,
+            "Updating latest.json".to_string(),
+        );
         self.store
             .put_bytes(
                 &latest_object_key(),
@@ -600,6 +707,55 @@ impl BackupService {
             }
         }
         sources
+    }
+
+    fn resolve_sources(&self, plan: &BackupPlan) -> Result<Vec<ResolvedLocalSource>, StorageError> {
+        let mut resolved = Vec::new();
+        for source in self.collect_sources(plan) {
+            match source {
+                LocalSource::Database {
+                    source_path,
+                    relative_path,
+                } => {
+                    if source_path.exists() {
+                        resolved.push(ResolvedLocalSource::Database {
+                            source_path,
+                            relative_path,
+                        });
+                    }
+                }
+                LocalSource::File {
+                    source_path,
+                    relative_path,
+                } => {
+                    if source_path.exists() {
+                        resolved.push(ResolvedLocalSource::File {
+                            source_path,
+                            relative_path,
+                        });
+                    }
+                }
+                LocalSource::Directory {
+                    source_dir,
+                    relative_root,
+                } => {
+                    if !source_dir.exists() {
+                        continue;
+                    }
+                    for file_path in walk_files(&source_dir)? {
+                        let rel = file_path
+                            .strip_prefix(&source_dir)
+                            .map_err(StorageError::backend)?
+                            .to_path_buf();
+                        resolved.push(ResolvedLocalSource::File {
+                            source_path: file_path,
+                            relative_path: relative_root.join(&rel),
+                        });
+                    }
+                }
+            }
+        }
+        Ok(resolved)
     }
 
     async fn apply_restore(
@@ -888,6 +1044,18 @@ enum LocalSource {
     },
 }
 
+#[derive(Debug, Clone)]
+enum ResolvedLocalSource {
+    Database {
+        source_path: PathBuf,
+        relative_path: PathBuf,
+    },
+    File {
+        source_path: PathBuf,
+        relative_path: PathBuf,
+    },
+}
+
 fn default_snapshot_interval_minutes() -> u32 {
     60
 }
@@ -988,6 +1156,41 @@ fn dedup_items(items: &[BackupItem]) -> Vec<BackupItem> {
         }
     }
     out
+}
+
+fn report_progress<F>(progress: &mut F, stage: BackupProgressStage, fraction: f32, detail: String)
+where
+    F: FnMut(BackupProgress),
+{
+    progress(BackupProgress {
+        stage,
+        fraction: fraction.clamp(0.0, 1.0),
+        detail,
+    });
+}
+
+fn report_preparing_progress<F>(
+    progress: &mut F,
+    completed: usize,
+    total: usize,
+    relative_path: &Path,
+) where
+    F: FnMut(BackupProgress),
+{
+    let fraction = if total == 0 {
+        0.7
+    } else {
+        0.1 + (completed as f32 / total as f32) * 0.6
+    };
+    report_progress(
+        progress,
+        BackupProgressStage::PreparingSnapshot,
+        fraction,
+        format!(
+            "Prepared {completed}/{total}: {}",
+            relative_path.to_string_lossy().replace('\\', "/")
+        ),
+    );
 }
 
 async fn path_exists(path: &Path) -> bool {
@@ -1469,5 +1672,16 @@ mod tests {
         };
         let err = config.validate().expect_err("config should fail");
         assert!(err.to_string().contains("access_key and secret_key"));
+    }
+
+    #[test]
+    fn s3_custom_endpoint_requires_explicit_credentials() {
+        let config = S3SnapshotStoreConfig {
+            endpoint: "https://example.r2.cloudflarestorage.com".to_string(),
+            bucket: "demo".to_string(),
+            ..Default::default()
+        };
+        let err = config.validate().expect_err("config should fail");
+        assert!(err.to_string().contains("custom endpoint requires"));
     }
 }

--- a/klaw-storage/src/lib.rs
+++ b/klaw-storage/src/lib.rs
@@ -10,9 +10,10 @@ mod util;
 pub mod backend;
 
 pub use backup::{
-    BackupItem, BackupPlan, BackupResult, BackupService, DatabaseSnapshotExporter,
-    S3SnapshotStoreConfig, SnapshotEntry, SnapshotListItem, SnapshotManifest, SnapshotMode,
-    SnapshotPrepareResult, SnapshotRestoreResult, SnapshotSchedule, SnapshotStore,
+    BackupItem, BackupPlan, BackupProgress, BackupProgressStage, BackupResult, BackupService,
+    DatabaseSnapshotExporter, S3SnapshotStoreConfig, SnapshotEntry, SnapshotListItem,
+    SnapshotManifest, SnapshotMode, SnapshotPrepareResult, SnapshotRestoreResult, SnapshotSchedule,
+    SnapshotStore,
 };
 pub use error::StorageError;
 pub use memory_db::{DbRow, DbValue, MemoryDb};


### PR DESCRIPTION
## Summary
- validate custom S3 endpoint sync configs up front so R2-style storage requires explicit credentials instead of falling back to AWS shared-profile discovery
- add backup progress callbacks in `klaw-storage` and surface them in `Setting > Sync` as a live progress bar with stage/detail text
- gate startup checks and manual sync actions behind the same validation path so invalid R2 configs fail early with a clear message

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo test -p klaw-storage`
- [x] `cargo test -p klaw-gui`
- [ ] Manually verify `Setting > Sync` with an R2 endpoint and explicit credentials
- [ ] Manually verify the manual backup progress bar updates through prepare/upload/cleanup stages

Fixes #18

Made with [Cursor](https://cursor.com)