### PR TITLE
chore(config): raise default conversation history limit

### DIFF
--- a/docs/src/configration/fields.md
+++ b/docs/src/configration/fields.md
@@ -46,7 +46,7 @@ model = "gpt-4-turbo"
 ### `conversation_history_limit`
 
 **类型**: `usize`
-**默认值**: `20`
+**默认值**: `40`
 **必填**: 否
 
 控制每次发送给模型的历史消息窗口大小（按条数，保留最近 N 条）。
@@ -61,7 +61,7 @@ model = "gpt-4-turbo"
 - 压缩失败时自动回退到普通滑动窗口，不影响主流程。
 
 ```toml
-conversation_history_limit = 20  # 推荐默认值
+conversation_history_limit = 40  # 推荐默认值
 ```
 
 ### `model_providers.<name>`

--- a/klaw-config/CHANGELOG.md
+++ b/klaw-config/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 2026-03-24
+
+### Changed
+
+- `conversation_history_limit` 默认值由 `20` 调整为 `40`，在保持 `N/2` 压缩触发规则不变的前提下扩大默认历史窗口
+
 ## 2026-03-21
 
 ### Added

--- a/klaw-config/src/lib.rs
+++ b/klaw-config/src/lib.rs
@@ -57,7 +57,7 @@ impl Default for AppConfig {
 }
 
 fn default_conversation_history_limit() -> usize {
-    20
+    40
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/klaw-config/src/tests.rs
+++ b/klaw-config/src/tests.rs
@@ -10,7 +10,7 @@ fn parse_default_template_succeeds() {
     let parsed: AppConfig = toml::from_str(&template).expect("default template should parse");
     assert_eq!(parsed.model_provider, "openai");
     assert!(parsed.model.is_none());
-    assert_eq!(parsed.conversation_history_limit, 20);
+    assert_eq!(parsed.conversation_history_limit, 40);
     assert!(parsed.model_providers.contains_key("openai"));
     assert!(!parsed.model_providers["openai"].proxy);
     assert!(!parsed.memory.embedding.enabled);


### PR DESCRIPTION
## Summary
- raise the default `conversation_history_limit` from 20 to 40
- update the generated config expectation and user-facing docs to match the new default
- document the default-window change in `klaw-config/CHANGELOG.md`

## Test plan
- [x] `cargo test -p klaw-config`

Closes #26

Made with [Cursor](https://cursor.com)