### PR TITLE
fix(runtime): require tool-calling for bootstrap

### DIFF
--- a/klaw-agent/CHANGELOG.md
+++ b/klaw-agent/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-03-24
+
+### Changed
+- `run_agent_execution` now forwards per-request `agent.tool_choice` metadata into provider `ChatOptions`, allowing callers to require tool use for specific turns such as bootstrap/session initialization
+
 ## 2026-03-22
 
 ### Changed

--- a/klaw-agent/src/lib.rs
+++ b/klaw-agent/src/lib.rs
@@ -22,6 +22,7 @@ pub use context_compression::{
 };
 
 const META_SYSTEM_PROMPT_KEY: &str = "agent.system_prompt";
+const META_TOOL_CHOICE_KEY: &str = "agent.tool_choice";
 const APPROVAL_REQUIRED_SIGNAL: &str = "approval_required";
 
 #[derive(Debug, Clone, Copy)]
@@ -297,7 +298,7 @@ pub async fn run_agent_execution(
             include: None,
             store: None,
             parallel_tool_calls: None,
-            tool_choice: None,
+            tool_choice: extract_tool_choice(&input.tool_metadata),
             text: None,
             reasoning: None,
             truncation: None,
@@ -445,6 +446,13 @@ fn extract_system_prompt(metadata: &BTreeMap<String, Value>) -> Option<String> {
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(ToString::to_string)
+}
+
+fn extract_tool_choice(metadata: &BTreeMap<String, Value>) -> Option<Value> {
+    metadata
+        .get(META_TOOL_CHOICE_KEY)
+        .cloned()
+        .filter(|value| !value.is_null())
 }
 
 fn is_supported_history_role(role: &str) -> bool {
@@ -673,6 +681,7 @@ mod tests {
     #[derive(Default)]
     struct CaptureFirstMessageProvider {
         first_message_role: Arc<Mutex<Option<String>>>,
+        tool_choice: Arc<Mutex<Option<Value>>>,
     }
 
     #[async_trait]
@@ -690,13 +699,17 @@ mod tests {
             messages: Vec<LlmMessage>,
             _tools: Vec<ToolDefinition>,
             _model: Option<&str>,
-            _options: ChatOptions,
+            options: ChatOptions,
         ) -> Result<LlmResponse, LlmError> {
             let first_role = messages.first().map(|m| m.role.clone());
             *self
                 .first_message_role
                 .lock()
                 .expect("mutex poisoned for first role") = first_role;
+            *self
+                .tool_choice
+                .lock()
+                .expect("mutex poisoned for tool choice") = options.tool_choice;
             Ok(LlmResponse {
                 content: "ok".to_string(),
                 reasoning: None,
@@ -744,6 +757,44 @@ mod tests {
             .expect("mutex poisoned for assert")
             .clone();
         assert_eq!(first_role.as_deref(), Some("system"));
+    }
+
+    #[tokio::test]
+    async fn run_agent_execution_includes_tool_choice_from_metadata() {
+        let provider = CaptureFirstMessageProvider::default();
+        let tools = MockToolExecutor;
+        let mut metadata = BTreeMap::new();
+        metadata.insert(
+            META_TOOL_CHOICE_KEY.to_string(),
+            Value::String("required".to_string()),
+        );
+        let _ = run_agent_execution(
+            &provider,
+            &tools,
+            AgentExecutionInput {
+                user_content: "hello".to_string(),
+                user_media: Vec::new(),
+                conversation_history: Vec::new(),
+                session_key: "s1".to_string(),
+                tool_metadata: metadata,
+                model: None,
+            },
+            AgentExecutionLimits {
+                max_tool_iterations: 2,
+                max_tool_calls: 2,
+                token_budget: 0,
+            },
+            None,
+        )
+        .await
+        .expect("agent execution should succeed");
+
+        let tool_choice = provider
+            .tool_choice
+            .lock()
+            .expect("mutex poisoned for tool choice assert")
+            .clone();
+        assert_eq!(tool_choice, Some(Value::String("required".to_string())));
     }
 
     #[derive(Default)]

--- a/klaw-cli/CHANGELOG.md
+++ b/klaw-cli/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- shared channel runtime `/new` bootstrap turn now requests `tool_choice=required` and explicitly tells the model to use tools for reading `BOOTSTRAP.md` and persisting bootstrap doc changes instead of only describing them
 - runtime startup and skills-prompt reload now delegate system prompt assembly to `klaw-core::build_runtime_system_prompt`, keeping `klaw-cli` focused on runtime data loading instead of prompt section composition
 - shared channel runtime `/new` 现在会在新 session 中自动写入首条 bootstrap `user` 消息并立即触发首轮 assistant 回复，统一覆盖 Telegram、钉钉等所有 channel
 

--- a/klaw-cli/src/runtime/mod.rs
+++ b/klaw-cli/src/runtime/mod.rs
@@ -44,7 +44,7 @@ use klaw_tool::{
     TerminalMultiplexerTool, ToolContext, ToolRegistry, WebFetchTool, WebSearchTool,
 };
 use klaw_util::EnvironmentCheckReport;
-use serde_json::json;
+use serde_json::{Value, json};
 use std::{
     collections::{BTreeMap, BTreeSet},
     error::Error,
@@ -60,7 +60,7 @@ use tracing::{info, warn};
 use uuid::Uuid;
 
 const LLM_AUDIT_QUEUE_CAPACITY: usize = 1024;
-const NEW_SESSION_BOOTSTRAP_USER_MESSAGE: &str = "You just woke up. Time to figure out who you are.\nThis is a brand new conversation. If `BOOTSTRAP.md` exists, read it and follow it before anything else. If it does not exist, start with a short, natural greeting.\nGuide the user through initializing the agent's identity, vibe, and context. Do not mention that this message was auto-generated.";
+const NEW_SESSION_BOOTSTRAP_USER_MESSAGE: &str = "You just woke up. Time to figure out who you are.\nThis is a brand new conversation. If `BOOTSTRAP.md` exists, use the available workspace tools to read it and follow it before anything else. If it does not exist, start with a short, natural greeting.\nGuide the user through initializing the agent's identity, vibe, and context. When you learn durable bootstrap details, use tools to update `IDENTITY.md` and `USER.md`, and delete `BOOTSTRAP.md` once bootstrap is truly complete. Do not claim files were updated unless you actually changed them with tools. Do not mention that this message was auto-generated.";
 
 #[derive(Debug, Clone, Default)]
 pub struct StartupReport {
@@ -268,6 +268,7 @@ pub struct AssistantOutput {
 const META_CONVERSATION_HISTORY_KEY: &str = "agent.conversation_history";
 const META_PROVIDER_KEY: &str = "agent.provider_id";
 const META_MODEL_KEY: &str = "agent.model";
+const META_TOOL_CHOICE_KEY: &str = "agent.tool_choice";
 
 #[derive(Debug, Clone)]
 struct SessionRoute {
@@ -587,6 +588,13 @@ fn build_new_session_bootstrap_user_message() -> String {
     NEW_SESSION_BOOTSTRAP_USER_MESSAGE.to_string()
 }
 
+fn build_new_session_bootstrap_request_metadata() -> BTreeMap<String, Value> {
+    BTreeMap::from([(
+        META_TOOL_CHOICE_KEY.to_string(),
+        Value::String("required".to_string()),
+    )])
+}
+
 fn format_new_session_started_message(
     session_key: &str,
     provider: &str,
@@ -844,7 +852,7 @@ async fn handle_im_command(
                 new_session_provider.clone(),
                 new_session_model.clone(),
                 Vec::new(),
-                BTreeMap::new(),
+                build_new_session_bootstrap_request_metadata(),
             )
             .await
             {
@@ -2406,7 +2414,7 @@ mod tests {
     use klaw_storage::{DefaultSessionStore, StoragePaths};
     use klaw_tool::ToolRegistry;
     use klaw_util::EnvironmentCheckReport;
-    use serde_json::json;
+    use serde_json::{Value, json};
     use std::{
         collections::{BTreeMap, BTreeSet},
         sync::{Arc, Mutex, RwLock},
@@ -2418,6 +2426,7 @@ mod tests {
     #[derive(Default, Clone)]
     struct BootstrapCaptureProvider {
         last_user_message: Arc<Mutex<Option<String>>>,
+        last_tool_choice: Arc<Mutex<Option<Value>>>,
     }
 
     #[async_trait::async_trait]
@@ -2435,7 +2444,7 @@ mod tests {
             messages: Vec<klaw_llm::LlmMessage>,
             _tools: Vec<klaw_llm::ToolDefinition>,
             _model: Option<&str>,
-            _options: ChatOptions,
+            options: ChatOptions,
         ) -> Result<klaw_llm::LlmResponse, LlmError> {
             let last_user_message = messages
                 .iter()
@@ -2446,6 +2455,10 @@ mod tests {
                 .last_user_message
                 .lock()
                 .unwrap_or_else(|err| err.into_inner()) = last_user_message;
+            *self
+                .last_tool_choice
+                .lock()
+                .unwrap_or_else(|err| err.into_inner()) = options.tool_choice;
             Ok(klaw_llm::LlmResponse {
                 content: "bootstrap reply".to_string(),
                 reasoning: None,
@@ -2602,8 +2615,11 @@ mod tests {
     fn new_session_bootstrap_user_message_mentions_bootstrap_or_greeting() {
         let message = build_new_session_bootstrap_user_message();
         assert!(message.contains("You just woke up"));
-        assert!(message.contains("If `BOOTSTRAP.md` exists"));
+        assert!(message.contains("If `BOOTSTRAP.md` exists, use the available workspace tools"));
         assert!(message.contains("start with a short, natural greeting"));
+        assert!(message.contains(
+            "Do not claim files were updated unless you actually changed them with tools"
+        ));
     }
 
     #[test]
@@ -2960,5 +2976,11 @@ A .docx file is a ZIP archive containing XML files.
             .unwrap_or_else(|err| err.into_inner())
             .clone();
         assert_eq!(captured.as_deref(), Some(new_history[0].content.as_str()));
+        let tool_choice = provider
+            .last_tool_choice
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
+            .clone();
+        assert_eq!(tool_choice, Some(Value::String("required".to_string())));
     }
 }


### PR DESCRIPTION
## Summary
- require `tool_choice=required` for `/new` bootstrap turns so the provider is explicitly asked to use tools
- tighten the bootstrap user message so `BOOTSTRAP.md`, `IDENTITY.md`, and `USER.md` changes must be performed through tools rather than only described
- add regression tests for metadata propagation and `/new` bootstrap request behavior

Closes #28

## Test plan
- [x] `cargo test -p klaw-agent -p klaw-cli`

Made with [Cursor](https://cursor.com)