### PR TITLE
fix(sync): reduce redundant startup s3 requests

### DIFF
--- a/klaw-gui/CHANGELOG.md
+++ b/klaw-gui/CHANGELOG.md
@@ -8,6 +8,8 @@
 - `Profile Prompt` 面板的 `System Prompt Preview` 改为后台加载，避免首次打开或手动刷新时阻塞 GUI 渲染线程
 - `Profile Prompt` 面板的 `Workspace Markdown Files` 与 `System Prompt Preview` 区块现在会按分配高度填充，窗口变高时不再留下异常空隙
 - `Profile Prompt` 面板 `Workspace Markdown Files` 列表中的 `Modified` 时间现在复用 GUI 统一时间格式，显示为可读日期而不是 Unix 秒时间戳
+- GUI startup sync checks now read only the latest remote manifest needed for update detection instead of loading the full remote manifest history
+- GUI startup no longer runs remote retention cleanup when sync is enabled but automatic backup is disabled
 
 ### Added
 

--- a/klaw-gui/README.md
+++ b/klaw-gui/README.md
@@ -112,7 +112,7 @@
   - show a live progress bar plus stage/detail text while manual sync is reconciling, uploading blobs, publishing manifests, and pruning remote history
   - trigger manual retention cleanup against remote manifests
   - list remote manifests and manually restore a selected manifest version
-  - surface startup remote-update detection and shared sync task status in the Sync UI
+  - surface startup remote-update detection via a lightweight latest-manifest check, while full remote manifest history loads only on manual refresh or backup flows
   - validate custom S3 endpoint credentials up front so R2-style endpoints do not rely on AWS shared-profile discovery
 - Session panel features:
   - read indexed sessions via `klaw-session` manager abstraction

--- a/klaw-gui/src/ui/shell.rs
+++ b/klaw-gui/src/ui/shell.rs
@@ -305,22 +305,18 @@ struct SyncSupervisor {
     last_poll_at: Option<Instant>,
     startup_check_completed: bool,
     startup_check_running: bool,
-    retention_check_completed: bool,
     task_rx: Option<Receiver<SyncSupervisorMessage>>,
 }
 
 enum SyncSupervisorMessage {
     StartupCheckFinished {
-        snapshots: Vec<SnapshotListItem>,
+        latest_snapshot: Option<SnapshotListItem>,
         local_last_id: Option<String>,
         local_last_at: Option<i64>,
     },
     AutoBackupFinished {
         manifest_id: String,
         created_at: i64,
-    },
-    RetentionCleanupFinished {
-        snapshots: Vec<SnapshotListItem>,
     },
     Failed {
         kind: SyncRuntimeTaskKind,
@@ -345,37 +341,32 @@ impl SyncSupervisor {
             settings.sync.last_manifest_id.clone(),
             settings.sync.last_sync_at,
         );
-        if !self.startup_check_completed
-            && !self.startup_check_running
-            && !self.task_in_progress()
-            && sync_ready(&settings)
-        {
-            self.startup_check_running = true;
-            self.spawn_task(SyncRuntimeTaskKind::StartupCheck, settings);
-            return;
-        }
-
-        if !self.retention_check_completed && !self.task_in_progress() && sync_ready(&settings) {
-            self.retention_check_completed = true;
-            self.spawn_task(SyncRuntimeTaskKind::RetentionCleanup, settings);
-            return;
-        }
-
-        if self.task_in_progress() || !sync_ready(&settings) || !settings.sync.schedule.auto_backup
-        {
-            return;
-        }
-
-        let interval_ms = i64::from(settings.sync.schedule.interval_minutes.max(1)) * 60 * 1000;
         let now_ms = OffsetDateTime::now_utc().unix_timestamp() * 1000;
+        if let Some(kind) = self.next_task(&settings, now_ms) {
+            if kind == SyncRuntimeTaskKind::StartupCheck {
+                self.startup_check_running = true;
+            }
+            self.spawn_task(kind, settings);
+        }
+    }
+
+    fn next_task(&self, settings: &AppSettings, now_ms: i64) -> Option<SyncRuntimeTaskKind> {
+        if self.task_in_progress() || !sync_ready(settings) {
+            return None;
+        }
+        if !self.startup_check_completed && !self.startup_check_running {
+            return Some(SyncRuntimeTaskKind::StartupCheck);
+        }
+        if !settings.sync.schedule.auto_backup {
+            return None;
+        }
+        let interval_ms = i64::from(settings.sync.schedule.interval_minutes.max(1)) * 60 * 1000;
         let should_backup = settings
             .sync
             .last_sync_at
             .map(|last| now_ms.saturating_sub(last) >= interval_ms)
             .unwrap_or(true);
-        if should_backup {
-            self.spawn_task(SyncRuntimeTaskKind::AutoBackup, settings);
-        }
+        should_backup.then_some(SyncRuntimeTaskKind::AutoBackup)
     }
 
     fn task_in_progress(&self) -> bool {
@@ -386,8 +377,8 @@ impl SyncSupervisor {
         let label = match kind {
             SyncRuntimeTaskKind::StartupCheck => "Checking remote manifests",
             SyncRuntimeTaskKind::AutoBackup => "Automatic manifest sync",
-            SyncRuntimeTaskKind::RetentionCleanup => "Cleaning up remote manifests",
             SyncRuntimeTaskKind::ManualBackup
+            | SyncRuntimeTaskKind::RetentionCleanup
             | SyncRuntimeTaskKind::RefreshRemoteSnapshots
             | SyncRuntimeTaskKind::RestoreSnapshot => return,
         };
@@ -400,8 +391,8 @@ impl SyncSupervisor {
             let result = match kind {
                 SyncRuntimeTaskKind::StartupCheck => run_startup_check_task(&settings),
                 SyncRuntimeTaskKind::AutoBackup => run_auto_backup_task(&settings),
-                SyncRuntimeTaskKind::RetentionCleanup => run_retention_cleanup_task(&settings),
                 SyncRuntimeTaskKind::ManualBackup
+                | SyncRuntimeTaskKind::RetentionCleanup
                 | SyncRuntimeTaskKind::RefreshRemoteSnapshots
                 | SyncRuntimeTaskKind::RestoreSnapshot => {
                     Err("unsupported sync supervisor task".to_string())
@@ -425,7 +416,6 @@ impl SyncSupervisor {
                 self.startup_check_running = false;
                 sync_runtime_finish_task(SyncRuntimeTaskKind::StartupCheck);
                 sync_runtime_finish_task(SyncRuntimeTaskKind::AutoBackup);
-                sync_runtime_finish_task(SyncRuntimeTaskKind::RetentionCleanup);
                 return;
             }
         };
@@ -433,16 +423,14 @@ impl SyncSupervisor {
 
         match message {
             SyncSupervisorMessage::StartupCheckFinished {
-                snapshots,
+                latest_snapshot,
                 local_last_id,
                 local_last_at,
             } => {
                 self.startup_check_running = false;
                 self.startup_check_completed = true;
                 sync_runtime_finish_task(SyncRuntimeTaskKind::StartupCheck);
-                sync_runtime_set_remote_snapshots(snapshots.clone());
-                let newest = snapshots.first().cloned();
-                if let Some(remote) = newest {
+                if let Some(remote) = latest_snapshot {
                     let remote_id = remote.manifest_id.clone();
                     let remote_at = remote.created_at;
                     let remote_is_newer = match local_last_at {
@@ -474,11 +462,6 @@ impl SyncSupervisor {
                 sync_runtime_set_last_snapshot(Some(manifest_id.clone()), Some(created_at));
                 sync_runtime_set_remote_update(None);
                 notifications.success(format!("Automatic manifest sync completed: {manifest_id}."));
-            }
-            SyncSupervisorMessage::RetentionCleanupFinished { snapshots } => {
-                sync_runtime_finish_task(SyncRuntimeTaskKind::RetentionCleanup);
-                sync_runtime_set_remote_snapshots(snapshots);
-                sync_runtime_set_remote_update(None);
             }
             SyncSupervisorMessage::Failed { kind, message } => {
                 sync_runtime_finish_task(kind);
@@ -550,12 +533,12 @@ fn run_startup_check_task(settings: &AppSettings) -> Result<SyncSupervisorMessag
         let service = BackupService::open_s3_default(config, device_id)
             .await
             .map_err(|err| err.to_string())?;
-        let snapshots = service
-            .list_remote_snapshots()
+        let latest_snapshot = service
+            .latest_remote_snapshot()
             .await
             .map_err(|err| err.to_string())?;
         Ok(SyncSupervisorMessage::StartupCheckFinished {
-            snapshots,
+            latest_snapshot,
             local_last_id,
             local_last_at,
         })
@@ -591,26 +574,49 @@ fn run_auto_backup_task(settings: &AppSettings) -> Result<SyncSupervisorMessage,
     })
 }
 
-fn run_retention_cleanup_task(settings: &AppSettings) -> Result<SyncSupervisorMessage, String> {
-    let runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .map_err(|err| err.to_string())?;
-    let config = build_sync_store_config(settings);
-    let device_id = settings.sync.device_id.clone();
-    let keep_last = settings.sync.retention.keep_last;
-    runtime.block_on(async move {
-        let service = BackupService::open_s3_default(config, device_id)
-            .await
-            .map_err(|err| err.to_string())?;
-        service
-            .cleanup_remote_snapshots(keep_last)
-            .await
-            .map_err(|err| err.to_string())?;
-        let snapshots = service
-            .list_remote_snapshots()
-            .await
-            .map_err(|err| err.to_string())?;
-        Ok(SyncSupervisorMessage::RetentionCleanupFinished { snapshots })
-    })
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ready_settings(auto_backup: bool, last_sync_at: Option<i64>) -> AppSettings {
+        let mut settings = AppSettings::default();
+        settings.sync.enabled = true;
+        settings.sync.schedule.auto_backup = auto_backup;
+        settings.sync.last_sync_at = last_sync_at;
+        settings.sync.s3.bucket = "demo".to_string();
+        settings.sync.s3.access_key = "ak".to_string();
+        settings.sync.s3.secret_key = "sk".to_string();
+        settings
+    }
+
+    #[test]
+    fn next_task_runs_startup_check_before_other_work() {
+        let supervisor = SyncSupervisor::default();
+
+        assert_eq!(
+            supervisor.next_task(&ready_settings(false, None), 0),
+            Some(SyncRuntimeTaskKind::StartupCheck)
+        );
+    }
+
+    #[test]
+    fn next_task_skips_startup_maintenance_when_auto_backup_is_disabled() {
+        let mut supervisor = SyncSupervisor::default();
+        supervisor.startup_check_completed = true;
+
+        assert_eq!(supervisor.next_task(&ready_settings(false, None), 0), None);
+    }
+
+    #[test]
+    fn next_task_runs_auto_backup_after_interval_elapses() {
+        let mut supervisor = SyncSupervisor::default();
+        supervisor.startup_check_completed = true;
+        let mut settings = ready_settings(true, Some(1_000));
+        settings.sync.schedule.interval_minutes = 1;
+
+        assert_eq!(
+            supervisor.next_task(&settings, 62_000),
+            Some(SyncRuntimeTaskKind::AutoBackup)
+        );
+    }
 }

--- a/klaw-storage/CHANGELOG.md
+++ b/klaw-storage/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-03-25
+
+### Fixed
+- startup-oriented remote manifest lookups can now read `latest.json` plus the current manifest directly, avoiding full history listing when callers only need remote-update detection
+- remote retention cleanup no longer reloads the same manifest set twice while building its prune plan
+
 ## 2026-03-23
 
 ### Changed

--- a/klaw-storage/README.md
+++ b/klaw-storage/README.md
@@ -40,7 +40,8 @@
 - `DefaultArchiveDb` provides a generic SQL interface for `klaw-archive`
 - `BackupService` stages managed SQLite/filesystem state into versioned manifests plus content-addressed blobs, uploads only missing blobs, and restores historical manifests after checksum verification
 - `BackupService` keeps `latest.json` as the current-manifest ref while preserving `manifests/<id>.json` history for restore and GC
+- `BackupService` now exposes a lightweight latest-manifest lookup for GUI startup checks so clients can detect remote updates without listing full manifest history
 - `BackupService` can emit progress updates for remote reconciliation, manifest preparation, blob upload, manifest publish, and retention cleanup so callers can surface live sync state
-- retention cleanup keeps only the configured latest manifest count, refreshes `latest.json`, and removes unreferenced blobs after pruning
+- retention cleanup keeps only the configured latest manifest count, refreshes `latest.json`, removes unreferenced blobs after pruning, and no longer reloads the same manifest set twice while building its cleanup view
 - S3 snapshot config accepts either direct credentials (`access_key`, `secret_key`, `session_token`) or environment-variable indirection, and empty device IDs normalize to the local hostname
 - custom S3 endpoints such as R2 must provide explicit credentials or credential env names instead of relying on AWS shared-profile discovery

--- a/klaw-storage/src/backup.rs
+++ b/klaw-storage/src/backup.rs
@@ -407,6 +407,14 @@ impl BackupService {
         Ok(items)
     }
 
+    pub async fn latest_remote_snapshot(&self) -> Result<Option<SnapshotListItem>, StorageError> {
+        self.reject_legacy_snapshot_layout().await?;
+        let Some(manifest) = self.load_latest_manifest().await? else {
+            return Ok(None);
+        };
+        Ok(Some(SnapshotListItem::from_manifest(&manifest)))
+    }
+
     pub async fn cleanup_remote_snapshots(&self, keep_last: u32) -> Result<(), StorageError> {
         self.reject_legacy_snapshot_layout().await?;
 
@@ -837,14 +845,19 @@ impl BackupService {
     }
 
     async fn load_all_remote_manifests(&self) -> Result<Vec<SyncManifest>, StorageError> {
-        let mut manifests = self
-            .list_remote_snapshots()
+        let manifest_ids = self
+            .store
+            .list_keys(&manifests_prefix())
             .await?
             .into_iter()
-            .map(|item| item.manifest_id)
+            .filter_map(|key| {
+                key.strip_prefix("manifests/")
+                    .and_then(|value| value.strip_suffix(".json"))
+                    .map(str::to_string)
+            })
             .collect::<Vec<_>>();
-        let mut out = Vec::with_capacity(manifests.len());
-        for manifest_id in manifests.drain(..) {
+        let mut out = Vec::with_capacity(manifest_ids.len());
+        for manifest_id in manifest_ids {
             out.push(self.load_manifest(&manifest_id).await?);
         }
         out.sort_by(|left, right| {
@@ -1554,6 +1567,18 @@ mod tests {
     #[derive(Debug, Default)]
     struct MockStore {
         objects: Mutex<BTreeMap<String, Vec<u8>>>,
+        get_counts: Mutex<BTreeMap<String, usize>>,
+    }
+
+    impl MockStore {
+        fn get_count(&self, key: &str) -> usize {
+            self.get_counts
+                .lock()
+                .expect("get_counts lock")
+                .get(key)
+                .copied()
+                .unwrap_or(0)
+        }
     }
 
     #[async_trait]
@@ -1572,6 +1597,12 @@ mod tests {
         }
 
         async fn get_bytes(&self, key: &str) -> Result<Vec<u8>, StorageError> {
+            self.get_counts
+                .lock()
+                .expect("get_counts lock")
+                .entry(key.to_string())
+                .and_modify(|count| *count += 1)
+                .or_insert(1);
             self.objects
                 .lock()
                 .expect("objects lock")
@@ -1621,6 +1652,21 @@ mod tests {
         BackupService::with_store(
             paths,
             Arc::new(MockStore::default()),
+            Arc::new(DefaultDatabaseSnapshotExporter),
+            device_id.to_string(),
+        )
+    }
+
+    async fn create_service_with_mock_store(
+        name: &str,
+        device_id: &str,
+        store: Arc<MockStore>,
+    ) -> BackupService {
+        let paths = StoragePaths::from_root(test_root(name));
+        paths.ensure_dirs().await.expect("ensure dirs");
+        BackupService::with_store(
+            paths,
+            store,
             Arc::new(DefaultDatabaseSnapshotExporter),
             device_id.to_string(),
         )
@@ -2085,5 +2131,113 @@ mod tests {
             .await
             .expect("sync after tombstone");
         assert!(!path_exists(&service.paths.skills_dir.join("note.txt")).await);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn latest_remote_snapshot_reads_only_latest_manifest() {
+        let store = Arc::new(MockStore::default());
+        let service =
+            create_service_with_mock_store("latest-remote", "device-a", store.clone()).await;
+        let older_manifest = SyncManifest {
+            schema_version: MANIFEST_SCHEMA_VERSION,
+            manifest_id: "manifest-older".to_string(),
+            parent_manifest_id: None,
+            created_at: 1_000,
+            device_id: "device-a".to_string(),
+            app_version: "test".to_string(),
+            mode: SnapshotMode::ManifestVersioned,
+            included_items: vec![BackupItem::Skills],
+            entries: Vec::new(),
+        };
+        let latest_manifest = SyncManifest {
+            schema_version: MANIFEST_SCHEMA_VERSION,
+            manifest_id: "manifest-latest".to_string(),
+            parent_manifest_id: Some("manifest-older".to_string()),
+            created_at: 2_000,
+            device_id: "device-b".to_string(),
+            app_version: "test".to_string(),
+            mode: SnapshotMode::ManifestVersioned,
+            included_items: vec![BackupItem::Skills],
+            entries: Vec::new(),
+        };
+        store
+            .put_bytes(
+                &manifest_object_key(&older_manifest.manifest_id),
+                serde_json::to_vec_pretty(&older_manifest).expect("older manifest json"),
+                "application/json",
+            )
+            .await
+            .expect("put older manifest");
+        store
+            .put_bytes(
+                &manifest_object_key(&latest_manifest.manifest_id),
+                serde_json::to_vec_pretty(&latest_manifest).expect("latest manifest json"),
+                "application/json",
+            )
+            .await
+            .expect("put latest manifest");
+        store
+            .put_bytes(
+                &latest_object_key(),
+                serde_json::to_vec_pretty(&LatestRef::from_manifest(&latest_manifest))
+                    .expect("latest ref json"),
+                "application/json",
+            )
+            .await
+            .expect("put latest ref");
+
+        let snapshot = service
+            .latest_remote_snapshot()
+            .await
+            .expect("latest snapshot should load")
+            .expect("latest snapshot should exist");
+
+        assert_eq!(snapshot.manifest_id, latest_manifest.manifest_id);
+        assert_eq!(store.get_count(&latest_object_key()), 1);
+        assert_eq!(
+            store.get_count(&manifest_object_key(&older_manifest.manifest_id)),
+            0
+        );
+        assert_eq!(
+            store.get_count(&manifest_object_key(&latest_manifest.manifest_id)),
+            1
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn load_all_remote_manifests_reads_each_manifest_once() {
+        let store = Arc::new(MockStore::default());
+        let service =
+            create_service_with_mock_store("load-all-manifests", "device-a", store.clone()).await;
+        for (manifest_id, created_at) in [("manifest-a", 1_000_i64), ("manifest-b", 2_000_i64)] {
+            let manifest = SyncManifest {
+                schema_version: MANIFEST_SCHEMA_VERSION,
+                manifest_id: manifest_id.to_string(),
+                parent_manifest_id: None,
+                created_at,
+                device_id: "device-a".to_string(),
+                app_version: "test".to_string(),
+                mode: SnapshotMode::ManifestVersioned,
+                included_items: vec![BackupItem::Skills],
+                entries: Vec::new(),
+            };
+            store
+                .put_bytes(
+                    &manifest_object_key(manifest_id),
+                    serde_json::to_vec_pretty(&manifest).expect("manifest json"),
+                    "application/json",
+                )
+                .await
+                .expect("put manifest");
+        }
+
+        let manifests = service
+            .load_all_remote_manifests()
+            .await
+            .expect("manifests should load");
+
+        assert_eq!(manifests.len(), 2);
+        assert_eq!(store.get_count(&manifest_object_key("manifest-a")), 1);
+        assert_eq!(store.get_count(&manifest_object_key("manifest-b")), 1);
     }
 }


### PR DESCRIPTION
## Summary
- switch GUI startup sync checks to a lightweight latest-manifest lookup instead of loading full remote manifest history
- stop running remote retention cleanup during startup when sync is enabled but automatic backup is disabled
- remove duplicate manifest reads from the storage cleanup path and add regression tests for both behaviors

## Test plan
- [x] `cargo test -p klaw-storage`
- [x] `cargo test -p klaw-gui`

Fixes #34

Made with [Cursor](https://cursor.com)