### PR TITLE
fix(timezone): use system timezone defaults

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3957,6 +3957,7 @@ dependencies = [
 name = "klaw-util"
 version = "0.1.1"
 dependencies = [
+ "iana-time-zone",
  "serde",
  "time",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ toml = "0.8"
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "sqlite", "macros"] }
 turso = { version = "0.4.3"}
 time = { version = "0.3", features = ["formatting"] }
+iana-time-zone = "0.1.65"
 sha2 = "0.10"
 hex = "0.4"
 base64 = "0.22"

--- a/klaw-config/CHANGELOG.md
+++ b/klaw-config/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 2026-03-25
+
+### Changed
+
+- `heartbeat.defaults.timezone` 的默认值改为启动时探测到的系统 timezone，不再硬编码为 `UTC`
+
 ## 2026-03-24
 
 ### Added

--- a/klaw-config/README.md
+++ b/klaw-config/README.md
@@ -16,6 +16,7 @@
 - 支持 `observability.local_store` 配置项,用于控制本地分析存储是否启用、保留时长与刷新间隔。
 - 支持 `gateway.enabled` 开关配置、`gateway.listen_port = 0` 随机端口模式，以及 `gateway.webhook` 的 Bearer 鉴权 webhook 入口配置。
 - 支持完整 `voice` 配置块，用于声明 STT/TTS 默认 provider、默认语言/音色，以及 Deepgram、AssemblyAI、ElevenLabs 的 provider 参数。
+- `heartbeat.defaults.timezone` 在未显式配置时会默认采用系统探测到的 timezone，而不是硬编码 `UTC`。
 
 ## 模型配置
 

--- a/klaw-config/src/lib.rs
+++ b/klaw-config/src/lib.rs
@@ -1,3 +1,4 @@
+use klaw_util::system_timezone_name;
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, path::PathBuf};
 use thiserror::Error;
@@ -474,7 +475,7 @@ fn default_heartbeat_silent_ack_token() -> String {
 }
 
 fn default_heartbeat_timezone() -> String {
-    "UTC".to_string()
+    system_timezone_name()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/klaw-config/src/tests.rs
+++ b/klaw-config/src/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use klaw_util::system_timezone_name;
 use std::{
     env, fs,
     time::{SystemTime, UNIX_EPOCH},
@@ -37,6 +38,7 @@ fn parse_default_template_succeeds() {
     assert!(parsed.tools.heartbeat_manager.enabled);
     assert!(parsed.tools.skills_registry.enabled);
     assert!(parsed.tools.skills_manager.enabled);
+    assert_eq!(parsed.heartbeat.defaults.timezone, system_timezone_name());
     assert!(parsed.tools.shell.workspace.is_none());
     assert!(parsed.tools.apply_patch.enabled);
     assert!(parsed.tools.apply_patch.workspace.is_none());

--- a/klaw-gui/CHANGELOG.md
+++ b/klaw-gui/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- GUI 统一时间格式现在按系统本地时区展示 `*_at_ms` / Unix 时间戳，而不再直接按 UTC 语义渲染
+- `Cron` 与 `Heartbeat` 新建表单的默认 timezone 改为系统探测值，不再硬编码 `UTC`
 - `Profile Prompt` 面板恢复旧的持久化 tab 状态时，现在会把历史标题 `Profile` 自动规范为 `Profile Prompt`
 - `Profile Prompt` 面板的 `System Prompt Preview` 改为后台加载，避免首次打开或手动刷新时阻塞 GUI 渲染线程
 - `Profile Prompt` 面板的 `Workspace Markdown Files` 与 `System Prompt Preview` 区块现在会按分配高度填充，窗口变高时不再留下异常空隙

--- a/klaw-gui/README.md
+++ b/klaw-gui/README.md
@@ -45,6 +45,7 @@
 - system-monitor (real-time CPU/memory/data-dir/uptime cards in a 2x2 equal-width layout, plus detailed system information)
 - logs panel (live tracing stream in-process with level filters, keyword search, pause stream, auto-scroll, clear, export, and bounded in-memory buffer)
 - analyze dashboard panel (local observability-backed tool and model analytics with time-range switching, provider/model filters, token composition, error breakdown, tool success breakdown, and trend sampling)
+- GUI timestamp rendering uses the host system timezone for human-readable datetime display
 - Configuration panel features:
   - load and edit `config.toml` raw text
   - TOML syntax highlighting (section/key/value/comment)

--- a/klaw-gui/src/panels/cron.rs
+++ b/klaw-gui/src/panels/cron.rs
@@ -10,6 +10,7 @@ use klaw_cron::{
     SqliteCronManager, UpdateCronJobPatch,
 };
 use klaw_storage::CronTaskStatus;
+use klaw_util::system_timezone_name;
 use std::future::Future;
 use std::thread;
 use tokio::runtime::Builder;
@@ -36,7 +37,7 @@ impl CronForm {
             schedule_kind: CronScheduleKind::Every,
             schedule_expr: "5m".to_string(),
             payload_json: "{}".to_string(),
-            timezone: "UTC".to_string(),
+            timezone: system_timezone_name(),
             enabled: true,
         }
     }
@@ -724,5 +725,15 @@ fn require_string_field(
         Some(serde_json::Value::String(_)) => Err(format!("`{key}` cannot be empty")),
         Some(_) => Err(format!("`{key}` must be a string")),
         None => Err(format!("missing required field `{key}`")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_cron_form_defaults_to_system_timezone() {
+        assert_eq!(CronForm::new().timezone, system_timezone_name());
     }
 }

--- a/klaw-gui/src/panels/heartbeat.rs
+++ b/klaw-gui/src/panels/heartbeat.rs
@@ -6,13 +6,12 @@ use chrono::NaiveDate;
 use egui::{Color32, RichText};
 use egui_extras::{Column, DatePickerButton, TableBuilder};
 use egui_phosphor::regular;
-use klaw_heartbeat::{
-    DEFAULT_SILENT_ACK_TOKEN, DEFAULT_TIMEZONE, HeartbeatInput, HeartbeatManager,
-};
+use klaw_heartbeat::{DEFAULT_SILENT_ACK_TOKEN, HeartbeatInput, HeartbeatManager};
 use klaw_storage::{
     DefaultSessionStore, HeartbeatJob, HeartbeatTaskRun, HeartbeatTaskStatus, SessionIndex,
     SessionStorage, open_default_store,
 };
+use klaw_util::system_timezone_name;
 use std::future::Future;
 use std::sync::Arc;
 use std::thread;
@@ -45,7 +44,7 @@ impl HeartbeatForm {
             every: "30m".to_string(),
             prompt: "Review the session state. If no user-visible action is needed, reply exactly HEARTBEAT_OK.".to_string(),
             silent_ack_token: DEFAULT_SILENT_ACK_TOKEN.to_string(),
-            timezone: DEFAULT_TIMEZONE.to_string(),
+            timezone: defaults.timezone.clone(),
         }
     }
 
@@ -90,11 +89,15 @@ impl HeartbeatForm {
 #[derive(Debug, Clone)]
 struct HeartbeatDefaults {
     enabled: bool,
+    timezone: String,
 }
 
 impl Default for HeartbeatDefaults {
     fn default() -> Self {
-        Self { enabled: true }
+        Self {
+            enabled: true,
+            timezone: system_timezone_name(),
+        }
     }
 }
 
@@ -828,4 +831,16 @@ fn render_date_picker(ui: &mut egui::Ui, value: &mut Option<NaiveDate>, id: &str
             }
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn heartbeat_defaults_to_system_timezone() {
+        let defaults = HeartbeatDefaults::default();
+        assert_eq!(defaults.timezone, system_timezone_name());
+        assert_eq!(HeartbeatForm::new(&defaults).timezone, defaults.timezone);
+    }
 }

--- a/klaw-gui/src/panels/profile.rs
+++ b/klaw-gui/src/panels/profile.rs
@@ -1193,6 +1193,7 @@ fn fmt_md_quote() -> TextFormat {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::TimeZone;
     use std::sync::atomic::{AtomicU64, Ordering};
 
     static TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -1269,8 +1270,16 @@ mod tests {
 
     #[test]
     fn format_modified_time_uses_gui_readable_datetime_format() {
-        let value = std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_710_000_000);
-        assert_eq!(format_modified_time(Some(value)), "2024/03/09 16:00:00");
+        let timestamp_secs = 1_710_000_000_i64;
+        let value = std::time::UNIX_EPOCH
+            + std::time::Duration::from_secs(timestamp_secs.try_into().expect("valid timestamp"));
+        let expected = chrono::Local
+            .timestamp_opt(timestamp_secs, 0)
+            .single()
+            .expect("test timestamp should be valid")
+            .format("%Y/%m/%d %H:%M:%S")
+            .to_string();
+        assert_eq!(format_modified_time(Some(value)), expected);
     }
 
     #[test]

--- a/klaw-gui/src/time_format.rs
+++ b/klaw-gui/src/time_format.rs
@@ -1,11 +1,11 @@
-use time::OffsetDateTime;
+use chrono::{Local, TimeZone};
 
 pub fn format_timestamp_millis(timestamp_ms: i64) -> String {
-    let timestamp_nanos = i128::from(timestamp_ms) * 1_000_000;
-    match OffsetDateTime::from_unix_timestamp_nanos(timestamp_nanos) {
-        Ok(dt) => format_offset_datetime(dt),
-        Err(_) => timestamp_ms.to_string(),
-    }
+    Local
+        .timestamp_millis_opt(timestamp_ms)
+        .single()
+        .map(format_local_datetime)
+        .unwrap_or_else(|| timestamp_ms.to_string())
 }
 
 pub fn format_optional_timestamp_millis(timestamp_ms: Option<i64>) -> String {
@@ -15,22 +15,44 @@ pub fn format_optional_timestamp_millis(timestamp_ms: Option<i64>) -> String {
 }
 
 pub fn format_timestamp_seconds(timestamp_secs: u64) -> String {
-    let timestamp_nanos = i128::from(timestamp_secs) * 1_000_000_000;
-    match OffsetDateTime::from_unix_timestamp_nanos(timestamp_nanos) {
-        Ok(dt) => format_offset_datetime(dt),
-        Err(_) => timestamp_secs.to_string(),
-    }
+    i64::try_from(timestamp_secs)
+        .ok()
+        .and_then(|secs| Local.timestamp_opt(secs, 0).single())
+        .map(format_local_datetime)
+        .unwrap_or_else(|| timestamp_secs.to_string())
 }
 
-fn format_offset_datetime(dt: OffsetDateTime) -> String {
-    let month = u8::from(dt.month());
-    format!(
-        "{:04}/{:02}/{:02} {:02}:{:02}:{:02}",
-        dt.year(),
-        month,
-        dt.day(),
-        dt.hour(),
-        dt.minute(),
-        dt.second()
-    )
+fn format_local_datetime(dt: chrono::DateTime<Local>) -> String {
+    dt.format("%Y/%m/%d %H:%M:%S").to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn formats_millis_in_local_timezone() {
+        let timestamp_ms = 1_735_689_600_000_i64;
+        let expected = Local
+            .timestamp_millis_opt(timestamp_ms)
+            .single()
+            .expect("test timestamp should be valid")
+            .format("%Y/%m/%d %H:%M:%S")
+            .to_string();
+        assert_eq!(format_timestamp_millis(timestamp_ms), expected);
+    }
+
+    #[test]
+    fn formats_seconds_in_local_timezone() {
+        let timestamp_secs = 1_735_689_600_u64;
+        let timestamp_secs_i64 =
+            i64::try_from(timestamp_secs).expect("test timestamp should fit in i64");
+        let expected = Local
+            .timestamp_opt(timestamp_secs_i64, 0)
+            .single()
+            .expect("test timestamp should be valid")
+            .format("%Y/%m/%d %H:%M:%S")
+            .to_string();
+        assert_eq!(format_timestamp_seconds(timestamp_secs), expected);
+    }
 }

--- a/klaw-tool/CHANGELOG.md
+++ b/klaw-tool/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-03-25
+
+### Changed
+- changed `cron_manager` and `heartbeat_manager` timezone defaults to use the detected system timezone when callers omit `timezone`
+
 ## 2026-03-24
 
 ### Added

--- a/klaw-tool/README.md
+++ b/klaw-tool/README.md
@@ -22,6 +22,7 @@
 - the `shell` tool now supports two rule lists: `blocked_patterns` reject immediately, while `unsafe_patterns` require approval; commands that match neither execute directly
 - the `cron_manager` tool accepts planner-friendly schedule inputs such as 5-field cron (`0 8 * * *`), `every 24h`, and daily time shorthand (`8:00`), then normalizes them before persistence
 - the `cron_manager` tool also accepts either a JSON object or a JSON string for payloads, and tolerates common boolean strings like `"true"` / `"false"` for `enabled`
+- the `cron_manager` and `heartbeat_manager` tools now default `timezone` to the detected system timezone when callers omit it
 - the `cron_manager` tool supports a high-level `message` shortcut for scheduled prompts in the current conversation, auto-filling channel/chat/session defaults from tool context unless explicitly overridden
 - the `message` shortcut now defaults to an isolated cron session key like `cron:<job_id>` so scheduled runs do not silently accumulate the current chat's conversation history
 - the `heartbeat_manager` tool manages session-bound heartbeat jobs directly from storage, with session/channel/chat defaults inferred from current tool context when possible

--- a/klaw-tool/src/cron_manager.rs
+++ b/klaw-tool/src/cron_manager.rs
@@ -4,6 +4,7 @@ use klaw_storage::{
     CronJob, CronScheduleKind, CronStorage, CronTaskRun, DefaultSessionStore, NewCronJob,
     StorageError, UpdateCronJobPatch, open_default_store,
 };
+use klaw_util::system_timezone_name;
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
 use std::str::FromStr;
@@ -208,7 +209,7 @@ impl CronManagerTool {
         let default_session_key = format!("cron:{id}");
         let payload_json = Self::parse_payload_json(args, ctx, Some(&default_session_key))?;
         let enabled = Self::optional_bool(args, "enabled")?.unwrap_or(true);
-        let timezone = Self::optional_str(args, "timezone")?.unwrap_or_else(|| "UTC".to_string());
+        let timezone = Self::optional_str(args, "timezone")?.unwrap_or_else(system_timezone_name);
         let next_run_at_ms = match Self::optional_i64(args, "next_run_at_ms")? {
             Some(v) => v,
             None => Self::compute_next_run_ms(schedule_kind, &schedule_expr, now_ms())?,
@@ -429,7 +430,7 @@ impl Tool for CronManagerTool {
                         "session_key": { "type": "string", "description": "Optional override used only with `message` shortcut. Defaults to an isolated cron session such as `cron:<job_id>`." },
                         "metadata": { "type": "object", "description": "Optional metadata object used only with `message` shortcut. Defaults to `{}`." },
                         "enabled": { "description": "Whether the cron starts enabled. Defaults to true. Prefer a boolean; string values like `\"true\"` and `\"false\"` are also accepted.", "oneOf": [{ "type": "boolean" }, { "type": "string" }] },
-                        "timezone": { "type": "string", "description": "Timezone label. Defaults to UTC." },
+                        "timezone": { "type": "string", "description": "Timezone label. Defaults to the detected system timezone." },
                         "next_run_at_ms": { "type": "integer", "description": "Optional explicit next run timestamp in ms." }
                     },
                     "required": ["action", "name", "schedule_expr"],
@@ -1120,7 +1121,7 @@ mod tests {
     #[tokio::test]
     async fn create_and_get_cron_job() {
         let storage = Arc::new(MockCronStorage::default());
-        let tool = CronManagerTool::from_storage(storage);
+        let tool = CronManagerTool::from_storage(storage.clone());
 
         let create = tool
             .execute(
@@ -1150,6 +1151,9 @@ mod tests {
             .await
             .expect("get should succeed");
         assert!(get.content_for_model.contains("\"id\": \"job-1\""));
+
+        let job = storage.get_cron("job-1").await.expect("job should exist");
+        assert_eq!(job.timezone, system_timezone_name());
     }
 
     #[tokio::test]

--- a/klaw-tool/src/heartbeat_manager.rs
+++ b/klaw-tool/src/heartbeat_manager.rs
@@ -3,6 +3,7 @@ use klaw_storage::{
     DefaultSessionStore, HeartbeatJob, HeartbeatStorage, HeartbeatTaskRun, NewHeartbeatJob,
     UpdateHeartbeatJobPatch, open_default_store,
 };
+use klaw_util::system_timezone_name;
 use serde_json::{Value, json};
 use std::sync::Arc;
 use uuid::Uuid;
@@ -137,7 +138,7 @@ impl HeartbeatManagerTool {
             Self::require_str(args, "prompt")?,
             Self::optional_str(args, "silent_ack_token")?
                 .unwrap_or_else(|| "HEARTBEAT_OK".to_string()),
-            Self::optional_str(args, "timezone")?.unwrap_or_else(|| "UTC".to_string()),
+            Self::optional_str(args, "timezone")?.unwrap_or_else(system_timezone_name),
         ))
     }
 
@@ -310,7 +311,7 @@ impl Tool for HeartbeatManagerTool {
                         "every": { "type": "string", "description": "Repeat interval such as `10m`, `1h`, or `24h`." },
                         "prompt": { "type": "string", "description": "Prompt injected into the bound session on each heartbeat." },
                         "silent_ack_token": { "type": "string", "description": "Exact token used to suppress no-op heartbeat output. Defaults to HEARTBEAT_OK." },
-                        "timezone": { "type": "string", "description": "Timezone label. Defaults to UTC." }
+                        "timezone": { "type": "string", "description": "Timezone label. Defaults to the detected system timezone." }
                     },
                     "required": ["action", "every", "prompt"],
                     "additionalProperties": false
@@ -476,4 +477,57 @@ fn heartbeat_task_run_to_json(run: HeartbeatTaskRun) -> Value {
         "published_message_id": run.published_message_id,
         "created_at_ms": run.created_at_ms
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use klaw_storage::StoragePaths;
+    use std::collections::BTreeMap;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    async fn test_tool() -> HeartbeatManagerTool {
+        let suffix = TEST_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let root =
+            std::env::temp_dir().join(format!("klaw-heartbeat-tool-test-{}-{suffix}", now_ms()));
+        let store = DefaultSessionStore::open(StoragePaths::from_root(root))
+            .await
+            .expect("store should open");
+        HeartbeatManagerTool::with_store(store)
+    }
+
+    fn ctx() -> ToolContext {
+        ToolContext {
+            session_key: "stdio:test".to_string(),
+            metadata: BTreeMap::from([
+                ("channel".to_string(), json!("stdio")),
+                ("chat_id".to_string(), json!("chat-1")),
+            ]),
+        }
+    }
+
+    #[tokio::test]
+    async fn create_defaults_to_system_timezone() {
+        let tool = test_tool().await;
+        let output = tool
+            .execute(
+                json!({
+                    "action": "create",
+                    "id": "hb-1",
+                    "every": "30m",
+                    "prompt": "review session"
+                }),
+                &ctx(),
+            )
+            .await
+            .expect("create should succeed");
+
+        assert!(
+            output
+                .content_for_model
+                .contains(&format!("\"timezone\": \"{}\"", system_timezone_name()))
+        );
+    }
 }

--- a/klaw-util/CHANGELOG.md
+++ b/klaw-util/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-03-25
+
+### Added
+- added `system_timezone_name()` with an `iana-time-zone` fallback-to-UTC resolver so runtime defaults can reuse the host system timezone label
+
 ## 2026-03-20
 
 ### Added

--- a/klaw-util/Cargo.toml
+++ b/klaw-util/Cargo.toml
@@ -6,4 +6,5 @@ license.workspace = true
 
 [dependencies]
 serde = { workspace = true }
+iana-time-zone = { workspace = true }
 time = { workspace = true, features = ["serde"] }

--- a/klaw-util/README.md
+++ b/klaw-util/README.md
@@ -1,6 +1,6 @@
 # klaw-util
 
-`klaw-util` contains shared Klaw constants and filesystem path helpers for the default data directory layout.
+`klaw-util` contains shared Klaw constants, filesystem path helpers for the default data directory layout, and lightweight runtime environment helpers such as system timezone detection.
 
 It centralizes fixed names such as:
 
@@ -11,4 +11,4 @@ It centralizes fixed names such as:
 - `skills-registry/`
 - `tokenizers/`
 
-Use this crate when a module needs to derive default local paths without pulling in higher-level storage or config abstractions.
+Use this crate when a module needs to derive default local paths or reuse host-level defaults like the detected system timezone without pulling in higher-level storage or config abstractions.

--- a/klaw-util/src/lib.rs
+++ b/klaw-util/src/lib.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
 pub const KLAW_DIR_NAME: &str = ".klaw";
+pub const UTC_TIMEZONE_NAME: &str = "UTC";
 pub const CONFIG_FILE_NAME: &str = "config.toml";
 pub const SETTINGS_FILE_NAME: &str = "settings.json";
 pub const GUI_STATE_FILE_NAME: &str = "gui_state.json";
@@ -31,6 +32,14 @@ pub fn data_dir_in_home(home: impl AsRef<Path>) -> PathBuf {
 
 pub fn default_data_dir() -> Option<PathBuf> {
     home_dir().map(data_dir_in_home)
+}
+
+pub fn system_timezone_name() -> String {
+    iana_time_zone::get_timezone()
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| UTC_TIMEZONE_NAME.to_string())
 }
 
 pub fn config_path(root_dir: impl AsRef<Path>) -> PathBuf {
@@ -167,5 +176,10 @@ mod tests {
             observability_db_path(root),
             PathBuf::from("/tmp/demo/observability.db")
         );
+    }
+
+    #[test]
+    fn system_timezone_name_is_non_empty() {
+        assert!(!system_timezone_name().trim().is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- add a shared system timezone resolver and use it for `heartbeat.defaults.timezone` plus cron/heartbeat creation defaults
- keep `*_at_ms` persisted as UTC/epoch while rendering GUI timestamps in the host local timezone
- add regression tests for GUI/local rendering, config defaults, and cron/heartbeat default timezone behavior

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo test -p klaw-util -p klaw-config -p klaw-gui -p klaw-tool`

Fixes #36

Made with [Cursor](https://cursor.com)