### PR TITLE
fix(mcp): keep proxy tools bound to live hub

### DIFF
--- a/klaw-mcp/CHANGELOG.md
+++ b/klaw-mcp/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+## 2026-03-25
+
+### Added
+
+- 为 `McpProxyTool` 增加回归测试，覆盖代理工具在创建后读取最新 hub 状态的调用路径
+
+### Fixed
+
+- 修复 MCP 代理工具持有 hub 快照导致的 `mcp server '<id>' not found` 问题
+- 调整 MCP client 插入与代理工具注册顺序，避免启动和热重载期间暴露过期路由状态
+
 ## 2026-03-23
 
 ### Added

--- a/klaw-mcp/README.md
+++ b/klaw-mcp/README.md
@@ -9,6 +9,7 @@
 - 缓存每个 MCP server 最近一次成功 `tools/list` 的响应，供 GUI/调试面板查看
 - 处理工具名冲突与 bootstrap 失败汇总
 - 支持动态启动/停止/重启 MCP 服务器（热重载）
+- 通过共享 hub 状态保证代理工具在启动后和热重载后都能路由到最新 client
 - 支持只读运行时快照查询，不触发额外 MCP 同步
 - 在 runtime 退出时关闭已连接的 MCP client
 

--- a/klaw-mcp/src/hub.rs
+++ b/klaw-mcp/src/hub.rs
@@ -1,6 +1,9 @@
 use crate::client::McpClient;
 use serde_json::Value;
-use std::{collections::BTreeMap, sync::Arc};
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, RwLock},
+};
 use thiserror::Error;
 
 #[derive(Debug, Clone)]
@@ -40,24 +43,38 @@ pub enum McpClientHubError {
 
 #[derive(Default, Clone)]
 pub struct McpClientHub {
-    clients: BTreeMap<String, Arc<dyn McpClient>>,
+    clients: Arc<RwLock<BTreeMap<String, Arc<dyn McpClient>>>>,
 }
 
 impl McpClientHub {
-    pub(crate) fn insert(&mut self, server_id: String, client: Arc<dyn McpClient>) {
-        self.clients.insert(server_id, client);
+    pub(crate) fn insert(&self, server_id: String, client: Arc<dyn McpClient>) {
+        self.clients
+            .write()
+            .unwrap_or_else(|err| err.into_inner())
+            .insert(server_id, client);
     }
 
-    pub fn remove(&mut self, server_id: &str) {
-        self.clients.remove(server_id);
+    pub fn remove(&self, server_id: &str) {
+        self.clients
+            .write()
+            .unwrap_or_else(|err| err.into_inner())
+            .remove(server_id);
     }
 
     pub fn server_ids(&self) -> Vec<String> {
-        self.clients.keys().cloned().collect()
+        self.clients
+            .read()
+            .unwrap_or_else(|err| err.into_inner())
+            .keys()
+            .cloned()
+            .collect()
     }
 
     pub fn contains(&self, server_id: &str) -> bool {
-        self.clients.contains_key(server_id)
+        self.clients
+            .read()
+            .unwrap_or_else(|err| err.into_inner())
+            .contains_key(server_id)
     }
 
     pub async fn call_tool(
@@ -66,7 +83,11 @@ impl McpClientHub {
         tool_name: &str,
         arguments: Value,
     ) -> Result<Value, McpClientHubError> {
-        let Some(client) = self.clients.get(server_id) else {
+        let client = {
+            let guard = self.clients.read().unwrap_or_else(|err| err.into_inner());
+            guard.get(server_id).cloned()
+        };
+        let Some(client) = client else {
             return Err(McpClientHubError::ServerNotFound(server_id.to_string()));
         };
         client
@@ -76,7 +97,14 @@ impl McpClientHub {
     }
 
     pub async fn shutdown_all(&self) -> Result<(), McpClientHubError> {
-        for (server_id, client) in &self.clients {
+        let clients: Vec<(String, Arc<dyn McpClient>)> = self
+            .clients
+            .read()
+            .unwrap_or_else(|err| err.into_inner())
+            .iter()
+            .map(|(server_id, client)| (server_id.clone(), Arc::clone(client)))
+            .collect();
+        for (server_id, client) in clients {
             client
                 .shutdown()
                 .await

--- a/klaw-mcp/src/manager.rs
+++ b/klaw-mcp/src/manager.rs
@@ -477,6 +477,8 @@ impl McpManager {
         for ok in &oks {
             self.set_tools_list_detail(&ok.server_id, &ok.tools);
             let tool_names: Vec<String> = ok.tools.iter().map(|t| t.name.clone()).collect();
+            self.hub
+                .insert(ok.server_id.clone(), Arc::clone(&ok.client));
             for tool in &ok.tools {
                 let descriptor = McpToolDescriptor {
                     name: tool.name.clone(),
@@ -488,11 +490,9 @@ impl McpManager {
                 self.tools
                     .register_shared(Arc::new(crate::McpProxyTool::new(
                         descriptor,
-                        Arc::new(self.hub.clone()),
+                        self.hub.clone(),
                     )));
             }
-            self.hub
-                .insert(ok.server_id.clone(), Arc::clone(&ok.client));
             self.servers.insert(
                 McpServerKey::new(&ok.server_id),
                 McpServerHandle {
@@ -584,6 +584,7 @@ impl McpManager {
             Ok(Ok((client, tools))) => {
                 self.set_tools_list_detail(&config.id, &tools);
                 let tool_names: Vec<String> = tools.iter().map(|t| t.name.clone()).collect();
+                self.hub.insert(config.id.clone(), Arc::clone(&client));
 
                 for tool in &tools {
                     let descriptor = McpToolDescriptor {
@@ -596,11 +597,9 @@ impl McpManager {
                     self.tools
                         .register_shared(Arc::new(crate::McpProxyTool::new(
                             descriptor,
-                            Arc::new(self.hub.clone()),
+                            self.hub.clone(),
                         )));
                 }
-
-                self.hub.insert(config.id.clone(), Arc::clone(&client));
 
                 {
                     let mut guard = self.statuses.lock().unwrap_or_else(|err| err.into_inner());

--- a/klaw-mcp/src/runtime.rs
+++ b/klaw-mcp/src/runtime.rs
@@ -1,16 +1,15 @@
 use async_trait::async_trait;
 use klaw_tool::{Tool, ToolCategory, ToolContext, ToolError, ToolOutput};
-use std::sync::Arc;
 
 use crate::{McpClientHub, McpToolDescriptor, format_tool_result_for_model};
 
 pub struct McpProxyTool {
     descriptor: McpToolDescriptor,
-    hub: Arc<McpClientHub>,
+    hub: McpClientHub,
 }
 
 impl McpProxyTool {
-    pub fn new(descriptor: McpToolDescriptor, hub: Arc<McpClientHub>) -> Self {
+    pub fn new(descriptor: McpToolDescriptor, hub: McpClientHub) -> Self {
         Self { descriptor, hub }
     }
 }
@@ -48,5 +47,82 @@ impl Tool for McpProxyTool {
             content_for_model: content.clone(),
             content_for_user: Some(content),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::{McpClient, McpClientError, McpRemoteTool};
+    use async_trait::async_trait;
+    use klaw_tool::ToolContext;
+    use serde_json::json;
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
+
+    struct TestClient;
+
+    #[async_trait]
+    impl McpClient for TestClient {
+        async fn initialize(&self) -> Result<(), McpClientError> {
+            Ok(())
+        }
+
+        async fn list_tools(&self) -> Result<Vec<McpRemoteTool>, McpClientError> {
+            Ok(Vec::new())
+        }
+
+        async fn call_tool(
+            &self,
+            tool_name: &str,
+            arguments: serde_json::Value,
+        ) -> Result<serde_json::Value, McpClientError> {
+            Ok(json!({
+                "content": [{
+                    "type": "text",
+                    "text": format!("{tool_name}:{}", arguments["scope"].as_str().unwrap_or_default()),
+                }]
+            }))
+        }
+    }
+
+    fn test_ctx() -> ToolContext {
+        ToolContext {
+            session_key: "test-session".to_string(),
+            metadata: BTreeMap::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn proxy_tool_uses_live_hub_state_after_client_insert() {
+        let hub = McpClientHub::default();
+        let tool = McpProxyTool::new(
+            McpToolDescriptor {
+                name: "configuration_contexts_list".to_string(),
+                description: "list contexts".to_string(),
+                parameters: json!({
+                    "type": "object",
+                    "properties": {
+                        "scope": { "type": "string" }
+                    }
+                }),
+                server_id: "kubernetes-mcp".to_string(),
+                tool_name: "configuration_contexts_list".to_string(),
+            },
+            hub.clone(),
+        );
+
+        hub.insert("kubernetes-mcp".to_string(), Arc::new(TestClient));
+
+        let output = tool
+            .execute(json!({"scope": "all"}), &test_ctx())
+            .await
+            .expect("proxy tool should resolve client from shared hub");
+
+        assert_eq!(output.content_for_model, "configuration_contexts_list:all");
+        assert_eq!(
+            output.content_for_user.as_deref(),
+            Some("configuration_contexts_list:all")
+        );
     }
 }


### PR DESCRIPTION
## Summary
- share `McpClientHub` state across MCP proxy tools instead of freezing a cloned snapshot at registration time
- insert MCP clients into the hub before registering proxy tools so startup and hot reload expose a live route immediately
- add a regression test for the stale-hub failure mode and document the fix in `klaw-mcp`

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo test -p klaw-mcp`
- [x] `cargo test --workspace`

Fixes #42

Made with [Cursor](https://cursor.com)