### PR TITLE
feat(skill): add github release workflow (#44)

### DIFF
--- a/.agents/skills/github-release-main/SKILL.md
+++ b/.agents/skills/github-release-main/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: github-release-main
+description: Enforce a GitHub release workflow for this Rust workspace. Use when Codex needs to publish a release by updating the root `Cargo.toml` version, defaulting to a patch bump when no version is provided, committing the change, creating a `vx.y.z` tag, pushing the branch and tag, and creating a GitHub release titled `release-vx.y.z`. Only operate on the `main` branch; if the current branch is not `main`, switch back before doing any release actions.
+---
+
+# Github Release Main
+
+## Overview
+
+Follow one deterministic release path:
+- ensure the repo is on `main`
+- ensure local `main` matches `origin/main`
+- update the root `Cargo.toml` version
+- commit the version bump
+- create tag `vx.y.z`
+- push `main` and the tag
+- create a GitHub release named `release-vx.y.z`
+
+Use `scripts/release_main.py` for the full one-command workflow. Use `scripts/bump_root_cargo_version.py` only when you need the version update step by itself.
+
+## Release Workflow
+
+1. Inspect git status before making changes. If the working tree contains unrelated or unexpected changes, stop and ask the user how to proceed.
+2. Check the current branch. If it is not `main`, switch to `main` before continuing.
+3. Fetch the configured remote `main` and confirm local `main` is exactly in sync with `origin/main`. If local `main` is ahead, behind, or diverged, stop and ask the user to reconcile it first.
+4. Re-read the root `Cargo.toml` and determine the release version:
+   - use the user-provided version when present
+   - otherwise bump the patch part of `[workspace.package].version`
+5. Prefer running `scripts/release_main.py` to execute the workflow end-to-end.
+6. If running the steps manually, stage only the root `Cargo.toml` version change unless the user asked for more.
+7. Commit with a release-oriented conventional commit, for example `chore(release): cut vX.Y.Z`.
+8. Create the git tag exactly as `vX.Y.Z`.
+9. Push `main` and push the new tag.
+10. Create the GitHub release with title `release-vX.Y.Z`, using the same tag.
+11. Report the final version, commit hash, tag, and release URL back to the user.
+
+## Branch Rules
+
+- Never perform the release on feature branches.
+- If not on `main`, switch first and confirm the active branch is now `main`.
+- If switching branches would discard local work or create conflicts, stop and ask the user.
+- Prefer `git switch main` when available.
+- Require local `main` to match `origin/main` before version bumps, tags, or pushes.
+
+## Version Rules
+
+- The version source of truth is the root `Cargo.toml` file.
+- Update `[workspace.package].version` only.
+- If the user gives no version, compute `patch + 1`.
+- Use plain `x.y.z` inside `Cargo.toml`.
+- Use `vX.Y.Z` for the git tag.
+- Use `release-vX.Y.Z` for the GitHub release title.
+
+## Recommended Commands
+
+Prefer the one-command workflow:
+
+```bash
+python3 .agents/skills/github-release-main/scripts/release_main.py
+python3 .agents/skills/github-release-main/scripts/release_main.py --version 1.2.3
+```
+
+Use this command sequence only when you need to perform the workflow manually:
+
+```bash
+git status --short
+git branch --show-current
+git switch main
+git fetch origin main --prune
+git rev-list --left-right --count main...origin/main
+python3 .agents/skills/github-release-main/scripts/bump_root_cargo_version.py --file Cargo.toml --version 1.2.3
+git add Cargo.toml
+git commit -m "$(cat <<'EOF'
+chore(release): cut v1.2.3
+EOF
+)"
+git tag -a v1.2.3 -m v1.2.3
+git push origin main
+git push origin v1.2.3
+gh release create v1.2.3 --title release-v1.2.3 --generate-notes
+```
+
+When no explicit version is given, omit `--version` and let the script compute the patch bump.
+
+## Validation Checklist
+
+- Confirm `git branch --show-current` returns `main` before changing files.
+- Confirm local `main` exactly matches `origin/main` before changing files.
+- Confirm `Cargo.toml` now contains the intended version.
+- Confirm the commit succeeds before creating the tag.
+- Confirm the tag name matches the version exactly, including the leading `v`.
+- Confirm the GitHub release uses the same tag and title format `release-vX.Y.Z`.
+
+## Resources
+
+- `scripts/release_main.py`: run the end-to-end release workflow from branch switch through release creation.
+- `scripts/bump_root_cargo_version.py`: update the root workspace version, either from an explicit version or by applying a patch bump.

--- a/.agents/skills/github-release-main/agents/openai.yaml
+++ b/.agents/skills/github-release-main/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "GitHub Release Main"
+  short_description: "仅在 main 上执行 GitHub Release 发布流程"
+  default_prompt: "Use $github-release-main to run the main-branch release workflow, optionally choosing a version or defaulting to the next patch release."

--- a/.agents/skills/github-release-main/scripts/bump_root_cargo_version.py
+++ b/.agents/skills/github-release-main/scripts/bump_root_cargo_version.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+
+import argparse
+import re
+from pathlib import Path
+
+
+SECTION_HEADER_RE = re.compile(r"^\s*\[(?P<section>[^\]]+)\]\s*$")
+VERSION_LINE_RE = re.compile(r'^(?P<indent>\s*)version\s*=\s*"(?P<version>\d+\.\d+\.\d+)"\s*$')
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Update [workspace.package].version in the root Cargo.toml."
+    )
+    parser.add_argument(
+        "--file",
+        default="Cargo.toml",
+        help="Path to the root Cargo.toml file. Defaults to Cargo.toml.",
+    )
+    parser.add_argument(
+        "--version",
+        help="Explicit target version in x.y.z format. Defaults to patch + 1.",
+    )
+    return parser.parse_args()
+
+
+def bump_patch(version: str) -> str:
+    major_str, minor_str, patch_str = version.split(".")
+    return f"{int(major_str)}.{int(minor_str)}.{int(patch_str) + 1}"
+
+
+def validate_version(version: str) -> str:
+    if not re.fullmatch(r"\d+\.\d+\.\d+", version):
+        raise ValueError(f"Invalid version '{version}'. Expected x.y.z.")
+    return version
+
+
+def prepare_workspace_version_update(
+    contents: str,
+    requested_version: str | None,
+) -> tuple[str, str, str]:
+    lines = contents.splitlines()
+    updated_lines: list[str] = []
+    in_workspace_package = False
+    found_section = False
+    old_version: str | None = None
+    new_version: str | None = None
+
+    for line in lines:
+        header_match = SECTION_HEADER_RE.match(line)
+        if header_match:
+            in_workspace_package = header_match.group("section") == "workspace.package"
+            found_section = found_section or in_workspace_package
+
+        if in_workspace_package:
+            version_match = VERSION_LINE_RE.match(line)
+            if version_match and old_version is None:
+                old_version = version_match.group("version")
+                new_version = (
+                    validate_version(requested_version)
+                    if requested_version is not None
+                    else bump_patch(old_version)
+                )
+                indent = version_match.group("indent")
+                line = f'{indent}version = "{new_version}"'
+
+        updated_lines.append(line)
+
+    if not found_section:
+        raise ValueError("Could not find [workspace.package] section.")
+    if old_version is None or new_version is None:
+        raise ValueError("Could not find version in [workspace.package].")
+
+    updated_contents = "\n".join(updated_lines) + "\n"
+    return old_version, new_version, updated_contents
+
+
+def update_workspace_version(path: Path, requested_version: str | None) -> tuple[str, str]:
+    original_contents = path.read_text(encoding="utf-8")
+    old_version, new_version, updated_contents = prepare_workspace_version_update(
+        original_contents,
+        requested_version,
+    )
+    path.write_text(updated_contents, encoding="utf-8")
+    return old_version, new_version
+
+
+def main() -> int:
+    args = parse_args()
+    cargo_toml = Path(args.file)
+    old_version, new_version = update_workspace_version(cargo_toml, args.version)
+    print(f"{old_version} -> {new_version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/github-release-main/scripts/release_main.py
+++ b/.agents/skills/github-release-main/scripts/release_main.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+
+import argparse
+import shutil
+import subprocess
+from pathlib import Path
+
+from bump_root_cargo_version import prepare_workspace_version_update, validate_version
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run the main-branch GitHub release workflow for the root Cargo.toml."
+    )
+    parser.add_argument(
+        "--version",
+        help="Explicit target version in x.y.z format. Defaults to patch + 1.",
+    )
+    parser.add_argument(
+        "--cargo-file",
+        default="Cargo.toml",
+        help="Path to the root Cargo.toml file. Defaults to Cargo.toml.",
+    )
+    parser.add_argument(
+        "--remote",
+        default="origin",
+        help="Git remote used for pushes. Defaults to origin.",
+    )
+    parser.add_argument(
+        "--skip-remote-check",
+        action="store_true",
+        help="Skip fetching and comparing remote main. Intended for testing only.",
+    )
+    parser.add_argument(
+        "--skip-push",
+        action="store_true",
+        help="Skip pushing the branch and tag. Intended for testing only.",
+    )
+    parser.add_argument(
+        "--skip-release",
+        action="store_true",
+        help="Skip creating the GitHub release. Intended for testing only.",
+    )
+    return parser.parse_args()
+
+
+def run(
+    *args: str,
+    cwd: Path,
+    capture_output: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        cwd=cwd,
+        check=True,
+        text=True,
+        capture_output=capture_output,
+    )
+
+
+def require_command(name: str) -> None:
+    if shutil.which(name) is None:
+        raise RuntimeError(f"Required command not found: {name}")
+
+
+def ensure_clean_worktree(repo_root: Path) -> None:
+    status = run("git", "status", "--porcelain", cwd=repo_root, capture_output=True).stdout
+    if status.strip():
+        raise RuntimeError(
+            "Working tree is not clean. Commit or stash existing changes before releasing."
+        )
+
+
+def ensure_main_branch(repo_root: Path) -> None:
+    current_branch = run(
+        "git",
+        "branch",
+        "--show-current",
+        cwd=repo_root,
+        capture_output=True,
+    ).stdout.strip()
+    if current_branch == "main":
+        return
+
+    run("git", "switch", "main", cwd=repo_root)
+    current_branch = run(
+        "git",
+        "branch",
+        "--show-current",
+        cwd=repo_root,
+        capture_output=True,
+    ).stdout.strip()
+    if current_branch != "main":
+        raise RuntimeError("Failed to switch to main.")
+
+
+def ensure_tag_absent(repo_root: Path, tag_name: str) -> None:
+    existing = run("git", "tag", "--list", tag_name, cwd=repo_root, capture_output=True).stdout
+    if existing.strip():
+        raise RuntimeError(f"Tag already exists: {tag_name}")
+
+
+def ensure_remote_exists(repo_root: Path, remote: str) -> None:
+    remotes = run("git", "remote", cwd=repo_root, capture_output=True).stdout.splitlines()
+    if remote not in remotes:
+        raise RuntimeError(f"Git remote not found: {remote}")
+
+
+def ensure_main_matches_remote(repo_root: Path, remote: str) -> None:
+    ensure_remote_exists(repo_root, remote)
+    run("git", "fetch", remote, "main", "--prune", cwd=repo_root)
+
+    remote_ref = f"refs/remotes/{remote}/main"
+    remote_main = run(
+        "git",
+        "rev-parse",
+        "--verify",
+        remote_ref,
+        cwd=repo_root,
+        capture_output=True,
+    ).stdout.strip()
+    local_main = run(
+        "git",
+        "rev-parse",
+        "--verify",
+        "refs/heads/main",
+        cwd=repo_root,
+        capture_output=True,
+    ).stdout.strip()
+    if local_main == remote_main:
+        return
+
+    ahead_behind = run(
+        "git",
+        "rev-list",
+        "--left-right",
+        "--count",
+        f"main...{remote}/main",
+        cwd=repo_root,
+        capture_output=True,
+    ).stdout.strip()
+    ahead_str, behind_str = ahead_behind.split()
+    raise RuntimeError(
+        "Local main does not match "
+        f"{remote}/main (ahead={ahead_str}, behind={behind_str}). "
+        "Pull or reconcile main before releasing."
+    )
+
+
+def commit_version_bump(repo_root: Path, cargo_file: Path, version: str) -> None:
+    relative_cargo_file = cargo_file.relative_to(repo_root)
+    run("git", "add", str(relative_cargo_file), cwd=repo_root)
+    run(
+        "git",
+        "commit",
+        "-m",
+        f"chore(release): cut v{version}",
+        cwd=repo_root,
+    )
+
+
+def push_release(repo_root: Path, remote: str, tag_name: str) -> None:
+    run("git", "push", remote, "main", cwd=repo_root)
+    run("git", "push", remote, tag_name, cwd=repo_root)
+
+
+def create_release(repo_root: Path, version: str, tag_name: str) -> str:
+    title = f"release-v{version}"
+    result = run(
+        "gh",
+        "release",
+        "create",
+        tag_name,
+        "--title",
+        title,
+        "--generate-notes",
+        cwd=repo_root,
+        capture_output=True,
+    )
+    return result.stdout.strip()
+
+
+def resolve_repo_root(start: Path) -> Path:
+    result = run("git", "rev-parse", "--show-toplevel", cwd=start, capture_output=True)
+    return Path(result.stdout.strip())
+
+
+def write_version_update(cargo_file: Path, requested_version: str | None) -> tuple[str, str]:
+    original_contents = cargo_file.read_text(encoding="utf-8")
+    old_version, new_version, updated_contents = prepare_workspace_version_update(
+        original_contents,
+        requested_version,
+    )
+    cargo_file.write_text(updated_contents, encoding="utf-8")
+    return old_version, new_version
+
+
+def main() -> int:
+    args = parse_args()
+    if args.version is not None:
+        validate_version(args.version)
+
+    require_command("git")
+    if not args.skip_release:
+        require_command("gh")
+
+    repo_root = resolve_repo_root(Path.cwd())
+    cargo_file = (repo_root / args.cargo_file).resolve()
+
+    ensure_clean_worktree(repo_root)
+    ensure_main_branch(repo_root)
+    ensure_clean_worktree(repo_root)
+    if not args.skip_remote_check:
+        ensure_main_matches_remote(repo_root, args.remote)
+
+    original_contents = cargo_file.read_text(encoding="utf-8")
+    old_version, new_version, _ = prepare_workspace_version_update(
+        original_contents,
+        args.version,
+    )
+    tag_name = f"v{new_version}"
+    ensure_tag_absent(repo_root, tag_name)
+
+    committed = False
+    try:
+        write_version_update(cargo_file, args.version)
+        commit_version_bump(repo_root, cargo_file, new_version)
+        committed = True
+        run("git", "tag", "-a", tag_name, "-m", tag_name, cwd=repo_root)
+
+        if not args.skip_push:
+            push_release(repo_root, args.remote, tag_name)
+
+        release_url = ""
+        if not args.skip_release:
+            release_url = create_release(repo_root, new_version, tag_name)
+    except Exception:
+        if not committed and cargo_file.exists():
+            cargo_file.write_text(original_contents, encoding="utf-8")
+        raise
+
+    commit_sha = run("git", "rev-parse", "HEAD", cwd=repo_root, capture_output=True).stdout.strip()
+
+    print(f"old_version={old_version}")
+    print(f"new_version={new_version}")
+    print(f"tag={tag_name}")
+    print(f"commit={commit_sha}")
+    if release_url:
+        print(f"release_url={release_url}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a reusable `github-release-main` skill under `.agents/skills` for main-only GitHub releases
- include scripts to bump the root workspace version and run the end-to-end commit/tag/push/release workflow
- enforce remote sync checks so releases stop when local `main` does not match `origin/main`

## Test plan
- [x] `python3 /Users/zhubby/.codex/skills/.system/skill-creator/scripts/quick_validate.py /Users/zhubby/Repository/klaw/.agents/skills/github-release-main` with temporary `PYTHONPATH` for `pyyaml`
- [x] integration test in a temporary git repo verifying branch switch, patch bump, commit, tag, and push flow
- [x] integration test in a temporary git repo verifying the script refuses to release when local `main` is ahead of `origin/main`

Fixes #44

Made with [Cursor](https://cursor.com)