### PR TITLE
fix(ci): upload macos binary artifact

### DIFF
--- a/.github/workflows/macos-package.yml
+++ b/.github/workflows/macos-package.yml
@@ -31,6 +31,12 @@ jobs:
       - name: Build macOS app bundle
         run: make build-macos-app
 
+      - name: Upload macOS binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Klaw-bin-${{ env.APP_VERSION }}-${{ env.MACOS_TARGET }}
+          path: target/${{ env.MACOS_TARGET }}/release/klaw
+
       - name: Build macOS dmg
         run: make package-macos-dmg
 


### PR DESCRIPTION
Fixes #48

## Summary
- add a second artifact upload step to `macos-package` after the app bundle build
- publish `target/${{ env.MACOS_TARGET }}/release/klaw` alongside the existing dmg artifact
- keep the existing macOS packaging flow unchanged apart from the extra uploaded artifact

## Test plan
- [x] validate `.github/workflows/macos-package.yml` parses as YAML
- [x] inspect the workflow diff to confirm the binary artifact path matches `scripts/macos/build_app.sh`
- [ ] run the GitHub Actions workflow on the next release publish


Made with [Cursor](https://cursor.com)