### PR TITLE
fix(runtime): require manager tool calls for schedule changes

### DIFF
--- a/klaw-agent/CHANGELOG.md
+++ b/klaw-agent/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-03-25
+
+### Changed
+- `run_agent_execution` now honors `agent.required_tool_name` metadata by narrowing the advertised tool list to a single named tool and forcing `tool_choice="required"` for that turn, preventing manager-style requests from succeeding without an actual tool call
+
 ## 2026-03-24
 
 ### Changed

--- a/klaw-agent/src/lib.rs
+++ b/klaw-agent/src/lib.rs
@@ -23,6 +23,7 @@ pub use context_compression::{
 
 const META_SYSTEM_PROMPT_KEY: &str = "agent.system_prompt";
 const META_TOOL_CHOICE_KEY: &str = "agent.tool_choice";
+const META_REQUIRED_TOOL_NAME_KEY: &str = "agent.required_tool_name";
 const APPROVAL_REQUIRED_SIGNAL: &str = "approval_required";
 const STOP_SIGNAL: &str = "stop";
 const STOPPED_TURN_MESSAGE: &str = "Current turn stopped. No further tool calls were made.";
@@ -246,7 +247,13 @@ pub async fn run_agent_execution(
     limits: AgentExecutionLimits,
     stream: Option<UnboundedSender<AgentExecutionStreamEvent>>,
 ) -> Result<AgentExecutionOutput, AgentExecutionError> {
-    let tool_defs = tools.definitions();
+    let mut tool_defs = tools.definitions();
+    let force_required_tool =
+        extract_required_tool_name(&input.tool_metadata).is_some_and(|name| {
+            let before = tool_defs.len();
+            tool_defs.retain(|tool| tool.name == name);
+            tool_defs.len() == 1 && before > 0
+        });
     let mut llm_messages = Vec::new();
     if let Some(system_prompt) = extract_system_prompt(&input.tool_metadata) {
         llm_messages.push(LlmMessage {
@@ -300,7 +307,11 @@ pub async fn run_agent_execution(
             include: None,
             store: None,
             parallel_tool_calls: None,
-            tool_choice: extract_tool_choice(&input.tool_metadata),
+            tool_choice: if force_required_tool {
+                Some(Value::String("required".to_string()))
+            } else {
+                extract_tool_choice(&input.tool_metadata)
+            },
             text: None,
             reasoning: None,
             truncation: None,
@@ -461,6 +472,14 @@ fn extract_tool_choice(metadata: &BTreeMap<String, Value>) -> Option<Value> {
         .get(META_TOOL_CHOICE_KEY)
         .cloned()
         .filter(|value| !value.is_null())
+}
+
+fn extract_required_tool_name(metadata: &BTreeMap<String, Value>) -> Option<&str> {
+    metadata
+        .get(META_REQUIRED_TOOL_NAME_KEY)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
 }
 
 fn is_supported_history_role(role: &str) -> bool {
@@ -694,6 +713,7 @@ mod tests {
     struct CaptureFirstMessageProvider {
         first_message_role: Arc<Mutex<Option<String>>>,
         tool_choice: Arc<Mutex<Option<Value>>>,
+        tool_names: Arc<Mutex<Vec<String>>>,
     }
 
     #[async_trait]
@@ -709,7 +729,7 @@ mod tests {
         async fn chat(
             &self,
             messages: Vec<LlmMessage>,
-            _tools: Vec<ToolDefinition>,
+            tools: Vec<ToolDefinition>,
             _model: Option<&str>,
             options: ChatOptions,
         ) -> Result<LlmResponse, LlmError> {
@@ -722,6 +742,11 @@ mod tests {
                 .tool_choice
                 .lock()
                 .expect("mutex poisoned for tool choice") = options.tool_choice;
+            *self
+                .tool_names
+                .lock()
+                .expect("mutex poisoned for tool names") =
+                tools.into_iter().map(|tool| tool.name).collect();
             Ok(LlmResponse {
                 content: "ok".to_string(),
                 reasoning: None,
@@ -807,6 +832,83 @@ mod tests {
             .expect("mutex poisoned for tool choice assert")
             .clone();
         assert_eq!(tool_choice, Some(Value::String("required".to_string())));
+    }
+
+    #[derive(Default)]
+    struct MultiToolExecutor;
+
+    #[async_trait]
+    impl ToolExecutor for MultiToolExecutor {
+        fn definitions(&self) -> Vec<ToolDefinition> {
+            vec![
+                ToolDefinition {
+                    name: "echo_tool".to_string(),
+                    description: "echo".to_string(),
+                    parameters: serde_json::json!({"type":"object"}),
+                },
+                ToolDefinition {
+                    name: "other_tool".to_string(),
+                    description: "other".to_string(),
+                    parameters: serde_json::json!({"type":"object"}),
+                },
+            ]
+        }
+
+        async fn execute(
+            &self,
+            _name: &str,
+            _arguments: Value,
+            _session_key: &str,
+            _metadata: &BTreeMap<String, Value>,
+        ) -> ToolInvocationResult {
+            ToolInvocationResult::success("tool-result".to_string())
+        }
+    }
+
+    #[tokio::test]
+    async fn run_agent_execution_limits_tools_when_required_tool_name_is_set() {
+        let provider = CaptureFirstMessageProvider::default();
+        let tools = MultiToolExecutor;
+        let mut metadata = BTreeMap::new();
+        metadata.insert(
+            META_REQUIRED_TOOL_NAME_KEY.to_string(),
+            Value::String("echo_tool".to_string()),
+        );
+
+        let _ = run_agent_execution(
+            &provider,
+            &tools,
+            AgentExecutionInput {
+                user_content: "hello".to_string(),
+                user_media: Vec::new(),
+                conversation_history: Vec::new(),
+                session_key: "s1".to_string(),
+                tool_metadata: metadata,
+                model: None,
+            },
+            AgentExecutionLimits {
+                max_tool_iterations: 2,
+                max_tool_calls: 2,
+                token_budget: 0,
+            },
+            None,
+        )
+        .await
+        .expect("agent execution should succeed");
+
+        let tool_choice = provider
+            .tool_choice
+            .lock()
+            .expect("mutex poisoned for tool choice assert")
+            .clone();
+        let tool_names = provider
+            .tool_names
+            .lock()
+            .expect("mutex poisoned for tool names assert")
+            .clone();
+
+        assert_eq!(tool_choice, Some(Value::String("required".to_string())));
+        assert_eq!(tool_names, vec!["echo_tool".to_string()]);
     }
 
     #[derive(Default)]

--- a/klaw-cli/CHANGELOG.md
+++ b/klaw-cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 2026-03-25
+
+### Fixed
+
+- runtime now detects direct and follow-up cron / heartbeat management requests and injects `agent.required_tool_name`, so schedule mutations are forced through the corresponding manager tool instead of allowing text-only fake success replies
+
 ## 2026-03-24
 
 ### Added

--- a/klaw-cli/src/runtime/mod.rs
+++ b/klaw-cli/src/runtime/mod.rs
@@ -338,6 +338,204 @@ fn now_ms() -> i64 {
         .unwrap_or(0)
 }
 
+fn maybe_inject_required_manager_tool(
+    runtime: &RuntimeBundle,
+    input: &str,
+    recent_history: &[ChatRecord],
+    metadata: &mut BTreeMap<String, Value>,
+) {
+    if metadata.contains_key(META_TOOL_CHOICE_KEY)
+        || metadata.contains_key("agent.required_tool_name")
+    {
+        return;
+    }
+
+    let Some(tool_name) = infer_required_manager_tool_name(runtime, input, recent_history) else {
+        return;
+    };
+    metadata.insert(
+        "agent.required_tool_name".to_string(),
+        Value::String(tool_name.to_string()),
+    );
+}
+
+fn infer_required_manager_tool_name(
+    runtime: &RuntimeBundle,
+    input: &str,
+    recent_history: &[ChatRecord],
+) -> Option<&'static str> {
+    let input_lower = input.trim().to_ascii_lowercase();
+    if input_lower.is_empty() || is_manager_capability_question(&input_lower) {
+        return None;
+    }
+
+    let recent_context = recent_history
+        .iter()
+        .rev()
+        .take(6)
+        .map(|record| record.content.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let recent_lower = recent_context.to_ascii_lowercase();
+
+    if tool_is_available(runtime, "cron_manager")
+        && should_require_cron_manager(&input_lower, &recent_lower)
+    {
+        return Some("cron_manager");
+    }
+    if tool_is_available(runtime, "heartbeat_manager")
+        && should_require_heartbeat_manager(&input_lower, &recent_lower)
+    {
+        return Some("heartbeat_manager");
+    }
+    None
+}
+
+fn tool_is_available(runtime: &RuntimeBundle, tool_name: &str) -> bool {
+    runtime
+        .startup_report
+        .tool_names
+        .iter()
+        .any(|name| name == tool_name)
+}
+
+fn should_require_cron_manager(input_lower: &str, recent_lower: &str) -> bool {
+    let domain_in_input = contains_any(input_lower, CRON_DOMAIN_TERMS);
+    let domain_in_recent = contains_any(recent_lower, CRON_DOMAIN_TERMS)
+        || contains_any(recent_lower, CRON_CONTEXT_TERMS);
+    let direct_request = contains_any(input_lower, MANAGER_ACTION_TERMS)
+        && (domain_in_input || contains_any(input_lower, SCHEDULE_HINT_TERMS));
+    let contextual_adjustment = domain_in_recent && contains_any(input_lower, CRON_FOLLOW_UP_TERMS);
+    direct_request || contextual_adjustment
+}
+
+fn should_require_heartbeat_manager(input_lower: &str, recent_lower: &str) -> bool {
+    let domain_in_input = contains_any(input_lower, HEARTBEAT_DOMAIN_TERMS);
+    let domain_in_recent = contains_any(recent_lower, HEARTBEAT_DOMAIN_TERMS);
+    let direct_request = contains_any(input_lower, MANAGER_ACTION_TERMS)
+        && (domain_in_input || contains_any(input_lower, HEARTBEAT_HINT_TERMS));
+    let contextual_adjustment =
+        domain_in_recent && contains_any(input_lower, HEARTBEAT_FOLLOW_UP_TERMS);
+    direct_request || contextual_adjustment
+}
+
+fn is_manager_capability_question(input_lower: &str) -> bool {
+    contains_any(
+        input_lower,
+        &[
+            "有哪些能力",
+            "什么能力",
+            "哪些能力",
+            "怎么用",
+            "是什么",
+            "what can",
+            "capabilities",
+            "ability",
+        ],
+    )
+}
+
+fn contains_any(haystack: &str, needles: &[&str]) -> bool {
+    needles.iter().any(|needle| haystack.contains(needle))
+}
+
+const MANAGER_ACTION_TERMS: &[&str] = &[
+    "create",
+    "add",
+    "new",
+    "update",
+    "modify",
+    "change",
+    "adjust",
+    "set",
+    "delete",
+    "remove",
+    "enable",
+    "disable",
+    "pause",
+    "resume",
+    "list",
+    "show",
+    "get",
+    "query",
+    "run now",
+    "创建",
+    "新增",
+    "添加",
+    "新建",
+    "更新",
+    "修改",
+    "改成",
+    "改为",
+    "调整",
+    "设置",
+    "删除",
+    "移除",
+    "启用",
+    "禁用",
+    "暂停",
+    "恢复",
+    "查看",
+    "列出",
+    "查询",
+    "立即执行",
+];
+
+const SCHEDULE_HINT_TERMS: &[&str] = &[
+    "cron",
+    "schedule",
+    "expr",
+    "表达式",
+    "调度",
+    "频率",
+    "每分钟",
+    "每小时",
+    "每天",
+    "每周",
+    "每月",
+    "任务",
+];
+
+const CRON_DOMAIN_TERMS: &[&str] = &[
+    "cron",
+    "定时任务",
+    "计划任务",
+    "调度任务",
+    "调度表达式",
+    "运行记录",
+];
+
+const CRON_CONTEXT_TERMS: &[&str] = &[
+    "任务 id",
+    "schedule_expr",
+    "已更新定时任务",
+    "已成功创建定时任务",
+];
+
+const CRON_FOLLOW_UP_TERMS: &[&str] = &[
+    "重新",
+    "调整",
+    "改",
+    "更新",
+    "表达式",
+    "频率",
+    "时间",
+    "交易时间",
+    "开盘",
+    "收盘",
+    "分钟",
+    "小时",
+    "每天",
+];
+
+const HEARTBEAT_DOMAIN_TERMS: &[&str] = &["heartbeat", "心跳", "会话唤醒", "提醒"];
+
+const HEARTBEAT_HINT_TERMS: &[&str] = &["every", "prompt", "提醒", "唤醒", "间隔", "频率"];
+
+const HEARTBEAT_FOLLOW_UP_TERMS: &[&str] = &[
+    "重新", "调整", "改", "提醒", "唤醒", "间隔", "频率", "prompt",
+];
+
 fn extract_llm_usage_records(
     metadata: &BTreeMap<String, serde_json::Value>,
 ) -> Vec<PersistedLlmUsageMetadata> {
@@ -1937,6 +2135,8 @@ pub async fn submit_and_get_output(
 ) -> Result<Option<AssistantOutput>, Box<dyn std::error::Error>> {
     let sessions = session_manager(runtime);
     let full_history = sessions.read_chat_records(&session_key).await?;
+    let mut request_metadata = request_metadata;
+    maybe_inject_required_manager_tool(runtime, &input, &full_history, &mut request_metadata);
     let summary = maybe_refresh_summary(
         runtime,
         &session_key,
@@ -2075,6 +2275,8 @@ pub async fn submit_and_stream_output(
 ) -> Result<Option<AssistantOutput>, Box<dyn std::error::Error>> {
     let sessions = session_manager(runtime);
     let full_history = sessions.read_chat_records(&session_key).await?;
+    let mut request_metadata = request_metadata;
+    maybe_inject_required_manager_tool(runtime, &input, &full_history, &mut request_metadata);
     let summary = maybe_refresh_summary(
         runtime,
         &session_key,
@@ -2442,10 +2644,10 @@ mod tests {
         build_new_session_bootstrap_user_message, build_unavailable_provider,
         compression_trigger_interval, configured_default_model, extract_skill_short_description,
         first_arg_token, format_approve_already_handled_message,
-        format_new_session_started_message, handle_im_command, normalize_runtime_provider_override,
-        parse_im_command, resolve_new_session_target_from_config, resolve_session_route,
-        should_emit_outbound, should_trigger_compression, spawn_llm_audit_writer,
-        trim_conversation_history,
+        format_new_session_started_message, handle_im_command, infer_required_manager_tool_name,
+        normalize_runtime_provider_override, parse_im_command,
+        resolve_new_session_target_from_config, resolve_session_route, should_emit_outbound,
+        should_trigger_compression, spawn_llm_audit_writer, trim_conversation_history,
     };
     use klaw_agent::ConversationSummary;
     use klaw_config::{AppConfig, ModelProviderConfig};
@@ -2831,6 +3033,68 @@ A .docx file is a ZIP archive containing XML files.
         let err = normalize_runtime_provider_override(&providers, "openai", Some("missing"))
             .expect_err("unknown provider should fail");
         assert!(err.to_string().contains("unknown runtime provider"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn infer_required_manager_tool_name_matches_direct_cron_request() {
+        let provider = Arc::new(BootstrapCaptureProvider::default());
+        let mut runtime = build_test_runtime(provider).await;
+        runtime.startup_report.tool_names = vec!["cron_manager".to_string()];
+
+        let inferred = infer_required_manager_tool_name(
+            &runtime,
+            "请修改定时任务 stock-snapshot-10m 的调度表达式并启用",
+            &[],
+        );
+
+        assert_eq!(inferred, Some("cron_manager"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn infer_required_manager_tool_name_matches_cron_follow_up_context() {
+        let provider = Arc::new(BootstrapCaptureProvider::default());
+        let mut runtime = build_test_runtime(provider).await;
+        runtime.startup_report.tool_names = vec!["cron_manager".to_string()];
+        let history = vec![ChatRecord::new(
+            "assistant",
+            "已更新定时任务：任务 ID：stock-snapshot-10m，新调度表达式：*/10 9-15 * * *",
+            None,
+        )];
+
+        let inferred = infer_required_manager_tool_name(
+            &runtime,
+            "股市交易时间是 9:30-11:30 和 13:00-15:00",
+            &history,
+        );
+
+        assert_eq!(inferred, Some("cron_manager"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn infer_required_manager_tool_name_skips_capability_questions() {
+        let provider = Arc::new(BootstrapCaptureProvider::default());
+        let mut runtime = build_test_runtime(provider).await;
+        runtime.startup_report.tool_names =
+            vec!["cron_manager".to_string(), "heartbeat_manager".to_string()];
+
+        let inferred = infer_required_manager_tool_name(&runtime, "cron_manager 有哪些能力", &[]);
+
+        assert_eq!(inferred, None);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn infer_required_manager_tool_name_matches_heartbeat_request() {
+        let provider = Arc::new(BootstrapCaptureProvider::default());
+        let mut runtime = build_test_runtime(provider).await;
+        runtime.startup_report.tool_names = vec!["heartbeat_manager".to_string()];
+
+        let inferred = infer_required_manager_tool_name(
+            &runtime,
+            "请把这个会话的 heartbeat 提醒改成每 30 分钟",
+            &[],
+        );
+
+        assert_eq!(inferred, Some("heartbeat_manager"));
     }
 
     #[test]

--- a/klaw-llm/CHANGELOG.md
+++ b/klaw-llm/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-03-25
+
+### Fixed
+- OpenAI-compatible `chat_completions` requests now serialize and send `tool_choice`, matching the existing Responses API behavior so runtime-enforced tool requirements actually reach chat-completions providers
+
 ## 2026-03-21
 
 ### Added

--- a/klaw-llm/src/providers/openai_compatible.rs
+++ b/klaw-llm/src/providers/openai_compatible.rs
@@ -296,6 +296,7 @@ impl OpenAiCompatibleProvider {
             max_tokens: options.max_tokens,
             stream: None,
             user: options.user,
+            tool_choice: options.tool_choice,
             messages: messages
                 .into_iter()
                 .map(|m| OpenAiMessage {
@@ -426,6 +427,7 @@ impl OpenAiCompatibleProvider {
             max_tokens: options.max_tokens,
             stream: Some(true),
             user: options.user,
+            tool_choice: options.tool_choice,
             messages: messages
                 .into_iter()
                 .map(|m| OpenAiMessage {
@@ -1271,6 +1273,8 @@ struct OpenAiChatCompletionRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     user: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    tool_choice: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     tools: Option<Vec<OpenAiToolDefinition>>,
 }
 
@@ -1703,6 +1707,27 @@ mod tests {
         assert_eq!(usage.total_tokens, 27);
         assert_eq!(usage.cached_input_tokens, Some(4));
         assert_eq!(usage.reasoning_tokens, Some(1));
+    }
+
+    #[test]
+    fn chat_completion_request_serializes_tool_choice_when_present() {
+        let request = OpenAiChatCompletionRequest {
+            model: "test-model".to_string(),
+            messages: Vec::new(),
+            temperature: 0.2,
+            max_tokens: None,
+            stream: None,
+            user: None,
+            tool_choice: Some(serde_json::json!("required")),
+            tools: None,
+        };
+
+        let value = serde_json::to_value(request).expect("request should serialize");
+
+        assert_eq!(
+            value.get("tool_choice"),
+            Some(&serde_json::json!("required"))
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #50

## Summary
- detect direct and follow-up cron/heartbeat management requests in the runtime and tag them with `agent.required_tool_name`
- make agent execution narrow the available tools to the required manager and force `tool_choice=required` for that turn
- pass `tool_choice` through the OpenAI-compatible `chat_completions` path and add regression tests for the new routing behavior

## Test plan
- [x] `cargo test -p klaw-agent -p klaw-cli -p klaw-llm`
- [ ] Reproduce an in-chat cron update against a live runtime session


Made with [Cursor](https://cursor.com)