### PR TITLE
fix(gui): sync gateway reload state and add start action

### DIFF
--- a/klaw-cli/CHANGELOG.md
+++ b/klaw-cli/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+## 2026-03-25
+
+### Fixed
+
+- `klaw gui` 的 gateway 状态查询现在会在返回前同步磁盘最新配置中的 `enabled` / `auth` / `tailscale` 元数据，避免 `Gateway` 面板在配置 reload 后继续显示旧状态
+- gateway runtime 的配置持久化 helper 现在统一走 `ConfigStore::update_config`，避免 stale snapshot 整体回写覆盖其他已落盘的配置修改
+
+### Added
+
+- GUI runtime 新增 `StartGateway` 命令，允许 `Gateway` 面板按当前磁盘配置直接启动 gateway，而不必先走 restart/enable 流程
+
 ## 2026-03-24
 
 ### Added

--- a/klaw-cli/README.md
+++ b/klaw-cli/README.md
@@ -74,6 +74,7 @@
 - `gateway` 在收到终止信号时会执行 runtime shutdown，确保 MCP/bootstrap 资源收尾
 - `klaw gui` 现在会在技能安装、卸载和 registry sync 后向 GUI runtime 发送技能 prompt 热重载命令，使后续请求可立即看到最新 skills
 - `klaw gui` / `klaw gateway` 通过共享 `ChannelManager` 管理运行中的 channel 实例；GUI 保存 channel 配置后会立即发送通用 `SyncChannels` 事件，由 runtime 按最新快照执行 keep/start/stop/restart
+- `klaw gui` 的 gateway 状态查询现在会先从磁盘最新配置同步 `configured_enabled` / `auth_configured` / `tailscale_mode` 元数据，避免面板状态停留在旧快照；同时运行时新增按当前配置单独启动 gateway 的命令通道
 - runtime 现在会在构建 channel driver factory 时按配置装配共享 `VoiceService`，供 Telegram 等 channel 在入站媒体阶段直接调用 STT
 - `klaw gui` 的 MCP 面板现在通过只读运行时快照读取 server 状态和缓存的 `tools/list` 响应，避免状态轮询误触发完整 MCP 同步
 - runtime system prompt 采用“skills shortlist + workspace docs list + lazy-load instructions”模式，不再注入 `SKILL.md` 全文

--- a/klaw-cli/src/commands/gui.rs
+++ b/klaw-cli/src/commands/gui.rs
@@ -192,7 +192,14 @@ impl GuiCommand {
                                                 let _ = response.send(env_check);
                                             }
                                             Some(klaw_gui::RuntimeCommand::GetGatewayStatus { response }) => {
+                                                if let Err(err) = gateway_manager.refresh_from_store() {
+                                                    warn!(error = %err, "failed to refresh gateway config metadata");
+                                                }
                                                 let _ = response.send(gateway_manager.snapshot());
+                                            }
+                                            Some(klaw_gui::RuntimeCommand::StartGateway { response }) => {
+                                                let result = gateway_manager.start_from_store().await;
+                                                let _ = response.send(result);
                                             }
                                             Some(klaw_gui::RuntimeCommand::SetGatewayEnabled { enabled, response }) => {
                                                 let result = gateway_manager.set_enabled(enabled).await;

--- a/klaw-cli/src/runtime/gateway_manager.rs
+++ b/klaw-cli/src/runtime/gateway_manager.rs
@@ -1,7 +1,8 @@
 use super::{RuntimeBundle, webhook};
-use klaw_config::{AppConfig, ConfigStore, TailscaleMode};
+use klaw_config::{AppConfig, ConfigError, ConfigStore, TailscaleMode};
 use klaw_gateway::{GatewayHandle, spawn_gateway_with_options};
 use klaw_gui::GatewayStatusSnapshot;
+use std::path::Path;
 use std::sync::Arc;
 use tracing::warn;
 
@@ -41,13 +42,17 @@ impl GatewayManager {
         }
     }
 
+    fn sync_metadata_from_config(&mut self, config: &AppConfig) {
+        self.configured_enabled = config.gateway.enabled;
+        self.tailscale_mode = config.gateway.tailscale.mode;
+        self.auth_configured = config.gateway.auth.is_enabled();
+    }
+
     pub async fn start_from_config(
         &mut self,
         config: &AppConfig,
     ) -> Result<GatewayStatusSnapshot, String> {
-        self.configured_enabled = config.gateway.enabled;
-        self.tailscale_mode = config.gateway.tailscale.mode;
-        self.auth_configured = config.gateway.auth.is_enabled();
+        self.sync_metadata_from_config(config);
 
         if self.handle.is_some() {
             return Ok(self.snapshot());
@@ -99,18 +104,33 @@ impl GatewayManager {
         &mut self,
         config: &AppConfig,
     ) -> Result<GatewayStatusSnapshot, String> {
-        self.configured_enabled = config.gateway.enabled;
+        self.sync_metadata_from_config(config);
         if !config.gateway.enabled {
             return Ok(self.snapshot());
         }
         self.start_from_config(config).await
     }
 
+    pub fn refresh_from_store(&mut self) -> Result<GatewayStatusSnapshot, String> {
+        let config = load_config_from_store()?;
+        self.sync_metadata_from_config(&config);
+        Ok(self.snapshot())
+    }
+
+    pub async fn start_from_store(&mut self) -> Result<GatewayStatusSnapshot, String> {
+        let config = load_config_from_store()?;
+        self.sync_metadata_from_config(&config);
+        if !config.gateway.enabled {
+            let message = "gateway is disabled in config".to_string();
+            self.last_error = Some(message.clone());
+            return Err(message);
+        }
+        self.start_from_config(&config).await
+    }
+
     pub async fn restart_from_store(&mut self) -> Result<GatewayStatusSnapshot, String> {
         let config = load_config_from_store()?;
-        self.configured_enabled = config.gateway.enabled;
-        self.tailscale_mode = config.gateway.tailscale.mode;
-        self.auth_configured = config.gateway.auth.is_enabled();
+        self.sync_metadata_from_config(&config);
 
         if !config.gateway.enabled {
             let message = "gateway is disabled in config".to_string();
@@ -182,19 +202,152 @@ fn load_config_from_store() -> Result<AppConfig, String> {
 }
 
 fn save_gateway_enabled(enabled: bool) -> Result<AppConfig, String> {
-    let store = ConfigStore::open(None).map_err(|err| err.to_string())?;
-    let mut next = store.snapshot().config;
-    next.gateway.enabled = enabled;
-    let raw = toml::to_string_pretty(&next).map_err(|err| err.to_string())?;
-    let saved = store.save_raw_toml(&raw).map_err(|err| err.to_string())?;
-    Ok(saved.config)
+    update_gateway_config(None, |config| {
+        config.gateway.enabled = enabled;
+        Ok(())
+    })
 }
 
 fn save_tailscale_mode(mode: TailscaleMode) -> Result<AppConfig, String> {
-    let store = ConfigStore::open(None).map_err(|err| err.to_string())?;
-    let mut next = store.snapshot().config;
-    next.gateway.tailscale.mode = mode;
-    let raw = toml::to_string_pretty(&next).map_err(|err| err.to_string())?;
-    let saved = store.save_raw_toml(&raw).map_err(|err| err.to_string())?;
-    Ok(saved.config)
+    update_gateway_config(None, |config| {
+        config.gateway.tailscale.mode = mode;
+        Ok(())
+    })
+}
+
+fn update_gateway_config<F>(config_path: Option<&Path>, mutate: F) -> Result<AppConfig, String>
+where
+    F: FnOnce(&mut AppConfig) -> Result<(), String>,
+{
+    let store = ConfigStore::open(config_path).map_err(|err| err.to_string())?;
+    store
+        .update_config(|config| {
+            mutate(config).map_err(ConfigError::InvalidConfig)?;
+            Ok(())
+        })
+        .map(|(snapshot, ())| snapshot.config)
+        .map_err(|err| err.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::update_gateway_config;
+    use klaw_config::{ConfigStore, TailscaleMode};
+    use std::env;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_config_path() -> std::path::PathBuf {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be after epoch")
+            .as_nanos();
+        env::temp_dir()
+            .join(format!("klaw-gateway-manager-test-{suffix}"))
+            .join("config.toml")
+    }
+
+    fn write_gateway_config(path: &std::path::Path) {
+        let root = path.parent().expect("temp config should have a parent");
+        fs::create_dir_all(root).expect("should create temp root");
+        fs::write(
+            path,
+            r#"
+model_provider = "openai"
+
+[model_providers.openai]
+base_url = "https://api.openai.com/v1"
+wire_api = "chat_completions"
+default_model = "gpt-4o-mini"
+env_key = "OPENAI_API_KEY"
+
+[gateway]
+enabled = false
+listen_ip = "127.0.0.1"
+listen_port = 0
+
+[gateway.auth]
+enabled = true
+env_key = "KLAW_GATEWAY_TOKEN"
+
+[gateway.tailscale]
+mode = "off"
+reset_on_exit = false
+"#,
+        )
+        .expect("should write source config");
+    }
+
+    #[test]
+    fn gateway_helper_updates_enabled_without_clobbering_other_gateway_fields() {
+        let path = temp_config_path();
+        let root = path
+            .parent()
+            .expect("temp config path should have root directory")
+            .to_path_buf();
+        write_gateway_config(&path);
+
+        let stale_store = ConfigStore::open(Some(&path)).expect("stale store should open");
+        stale_store
+            .update_config(|config| {
+                config.gateway.auth.enabled = false;
+                config.gateway.auth.env_key = Some("UPDATED_GATEWAY_TOKEN".to_string());
+                Ok(())
+            })
+            .expect("stale store update should succeed");
+
+        let saved = update_gateway_config(Some(&path), |config| {
+            config.gateway.enabled = true;
+            Ok(())
+        })
+        .expect("gateway enabled update should succeed");
+
+        assert!(saved.gateway.enabled);
+        assert!(!saved.gateway.auth.enabled);
+        assert_eq!(
+            saved.gateway.auth.env_key.as_deref(),
+            Some("UPDATED_GATEWAY_TOKEN")
+        );
+
+        let disk_raw = fs::read_to_string(&path).expect("saved config should be readable");
+        assert!(disk_raw.contains("enabled = true"));
+        assert!(disk_raw.contains("env_key = \"UPDATED_GATEWAY_TOKEN\""));
+
+        let _ = fs::remove_file(&path);
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn gateway_helper_updates_tailscale_mode_without_clobbering_auth_changes() {
+        let path = temp_config_path();
+        let root = path
+            .parent()
+            .expect("temp config path should have root directory")
+            .to_path_buf();
+        write_gateway_config(&path);
+
+        let stale_store = ConfigStore::open(Some(&path)).expect("stale store should open");
+        stale_store
+            .update_config(|config| {
+                config.gateway.auth.token = Some("secret-token".to_string());
+                Ok(())
+            })
+            .expect("stale store update should succeed");
+
+        let saved = update_gateway_config(Some(&path), |config| {
+            config.gateway.tailscale.mode = TailscaleMode::Serve;
+            Ok(())
+        })
+        .expect("tailscale mode update should succeed");
+
+        assert_eq!(saved.gateway.tailscale.mode, TailscaleMode::Serve);
+        assert_eq!(saved.gateway.auth.token.as_deref(), Some("secret-token"));
+
+        let disk_raw = fs::read_to_string(&path).expect("saved config should be readable");
+        assert!(disk_raw.contains("mode = \"serve\""));
+        assert!(disk_raw.contains("token = \"secret-token\""));
+
+        let _ = fs::remove_file(&path);
+        let _ = fs::remove_dir_all(&root);
+    }
 }

--- a/klaw-gui/CHANGELOG.md
+++ b/klaw-gui/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- `Gateway` 面板的 `Reload` 现在会在重新加载磁盘配置后同步刷新运行时 gateway 状态摘要，避免 `Configured` / `Auth` / `Tailscale` 继续停留在旧快照
 - `Profile Prompt` 面板 `Workspace Markdown Files` 表格右键菜单新增橙色 `Reset` 操作，仅对内置模板文件显示，并在确认后将目标文件重置为默认模板并同步已打开的编辑/预览状态
 - `Provider`、`Memory`、`Gateway`、`Channel`、`MCP`、`Tool`、`Voice`、`Webhook`、`Skills Registry` 与 `Skills Manager` 面板现在都会基于磁盘最新配置做局部更新，避免 stale snapshot 在后续保存时把已落盘的 provider 或其他配置覆盖掉
 - `Model Provider` 面板表格现在在内容超出宽度时提供横向滚动、在可视高度不足时提供纵向滚动，避免长列内容被截断后难以浏览
@@ -19,6 +20,8 @@
 - GUI startup no longer runs remote retention cleanup when sync is enabled but automatic backup is disabled
 
 ### Added
+
+- `Gateway` 面板新增 `Start` 按钮，用于按当前磁盘配置启动 gateway；当服务已运行或正在过渡时按钮会自动禁用
 
 - `Profile Prompt` 面板新增只读 `System Prompt Preview` 区块，使用 markdown 高亮渲染当前 runtime system prompt，并以固定剩余高度显示、内容过长时在框内滚动
 

--- a/klaw-gui/README.md
+++ b/klaw-gui/README.md
@@ -31,7 +31,7 @@
   - voice (config-bound voice settings + microphone transcription test)
   - cron (db-bound list + add/edit window)
   - heartbeat (db-backed heartbeat list + add/edit/delete/run-now)
-  - gateway (runtime-backed gateway status, enable/disable, restart, and base address display)
+- gateway (runtime-backed gateway status, disk-config reload sync, start, restart, and base address display)
   - webhook (db-backed webhook event list, filters, detail inspection, and `gateway.webhook` config editing)
   - mcp (config-bound list + add/edit window)
   - skill (installed skill management with list/detail/remove/sync actions)

--- a/klaw-gui/src/lib.rs
+++ b/klaw-gui/src/lib.rs
@@ -21,7 +21,7 @@ pub use runtime_bridge::{
     drain_log_chunks, install_log_receiver, install_runtime_command_sender, request_env_check,
     request_gateway_status, request_mcp_status, request_restart_gateway, request_run_cron_now,
     request_run_heartbeat_now, request_set_gateway_enabled, request_set_tailscale_mode,
-    request_sync_channels, request_sync_mcp,
+    request_start_gateway, request_sync_channels, request_sync_mcp,
 };
 pub use state::UiAction;
 pub use state::workbench::{TabId, WorkbenchState, WorkbenchTab};

--- a/klaw-gui/src/panels/gateway.rs
+++ b/klaw-gui/src/panels/gateway.rs
@@ -3,7 +3,7 @@ use crate::panels::{PanelRenderer, RenderCtx};
 use crate::time_format::format_timestamp_seconds;
 use crate::{
     GatewayStatusSnapshot, request_gateway_status, request_restart_gateway,
-    request_set_tailscale_mode,
+    request_set_tailscale_mode, request_start_gateway,
 };
 use klaw_config::{
     AppConfig, ConfigError, ConfigSnapshot, ConfigStore, GatewayConfig, TailscaleMode,
@@ -189,6 +189,7 @@ impl GatewayPanel {
         }) {
             Ok((snapshot, ())) => {
                 self.apply_snapshot(snapshot);
+                self.refresh(notifications, false);
                 self.config_window_open = false;
                 let running = self.status.as_ref().map(|s| s.running).unwrap_or(false);
                 if running {
@@ -210,9 +211,28 @@ impl GatewayPanel {
         match store.reload() {
             Ok(snapshot) => {
                 self.apply_snapshot(snapshot);
+                self.refresh(notifications, false);
                 notifications.success("Config reloaded from disk");
             }
             Err(err) => notifications.error(format!("Reload failed: {err}")),
+        }
+    }
+
+    fn start(&mut self, notifications: &mut NotificationCenter) {
+        match request_start_gateway() {
+            Ok(status) => {
+                let message = status
+                    .info
+                    .as_ref()
+                    .map(|info| format!("Gateway started at {}", info.ws_url))
+                    .unwrap_or_else(|| "Gateway started".to_string());
+                self.status = Some(status);
+                notifications.success(message);
+            }
+            Err(err) => {
+                notifications.error(format!("Failed to start gateway: {err}"));
+                self.refresh(notifications, false);
+            }
         }
     }
 
@@ -374,6 +394,16 @@ impl PanelRenderer for GatewayPanel {
 
             if ui.button("Config").clicked() {
                 self.open_config_window();
+            }
+
+            if ui
+                .add_enabled(
+                    !status.transitioning && !status.running,
+                    egui::Button::new("Start"),
+                )
+                .clicked()
+            {
+                self.start(notifications);
             }
 
             if ui

--- a/klaw-gui/src/runtime_bridge.rs
+++ b/klaw-gui/src/runtime_bridge.rs
@@ -47,6 +47,9 @@ pub enum RuntimeCommand {
     GetGatewayStatus {
         response: mpsc::Sender<GatewayStatusSnapshot>,
     },
+    StartGateway {
+        response: mpsc::Sender<Result<GatewayStatusSnapshot, String>>,
+    },
     SetGatewayEnabled {
         enabled: bool,
         response: mpsc::Sender<Result<GatewayStatusSnapshot, String>>,
@@ -243,6 +246,24 @@ pub fn request_gateway_status() -> Result<GatewayStatusSnapshot, String> {
     response_rx
         .recv()
         .map_err(|_| "runtime command response channel closed".to_string())
+}
+
+pub fn request_start_gateway() -> Result<GatewayStatusSnapshot, String> {
+    let sender = sender_slot()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone()
+        .ok_or_else(|| "runtime command channel is not available".to_string())?;
+    let (response_tx, response_rx) = mpsc::channel();
+    sender
+        .send(RuntimeCommand::StartGateway {
+            response: response_tx,
+        })
+        .map_err(|_| "failed to send runtime command".to_string())?;
+
+    response_rx
+        .recv()
+        .map_err(|_| "runtime command response channel closed".to_string())?
 }
 
 pub fn request_set_gateway_enabled(enabled: bool) -> Result<GatewayStatusSnapshot, String> {


### PR DESCRIPTION
Closes #54

## Summary
- sync GUI gateway status reads with the latest on-disk gateway config so `Reload` updates `Configured`, `Auth`, and `Tailscale` metadata instead of leaving stale runtime values on screen
- add a dedicated `Start` action to the `Gateway` panel and disable it while the gateway is already running or transitioning
- move gateway config persistence helpers onto `ConfigStore::update_config` and add regression tests so gateway writes do not clobber unrelated config changes

## Test plan
- [x] `cargo test -p klaw-cli gateway_helper_updates`
- [x] `cargo test -p klaw-gui`

Made with [Cursor](https://cursor.com)