### PR TITLE
feat(gui): add persistent theme presets to settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1034,6 +1034,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "catppuccin-egui"
+version = "5.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "119005543bcd5cc74f76323d40801bb29baf1b062e84f86eb42fb0b2a3fe61e9"
+dependencies = [
+ "egui",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3811,6 +3820,7 @@ name = "klaw-gui"
 version = "0.1.3"
 dependencies = [
  "anyhow",
+ "catppuccin-egui",
  "chrono",
  "cpal 0.16.0",
  "eframe",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ base64 = "0.22"
 anyhow = "1"
 egui = "0.33.3"
 eframe = "0.33.3"
+catppuccin-egui = { version = "5.7.0", default-features = false, features = ["egui33"] }
 egui-file-dialog = "0.12.0"
 egui-phosphor = "0.11.0"
 egui_extras = "0.33.3"

--- a/klaw-gui/CHANGELOG.md
+++ b/klaw-gui/CHANGELOG.md
@@ -2,8 +2,13 @@
 
 ## 2026-03-26
 
+### Added
+
+- `Settings > General` 新增 Light/Dark 主题预设下拉框，支持在保留默认 egui 主题的基础上为 light 模式选择 `Latte`，为 dark 模式选择 `Frappé`、`Macchiato`、`Mocha`
+
 ### Changed
 
+- GUI 底部状态栏的主题切换从循环点击改为显式 `Theme Mode` 下拉框，并会结合已保存的 Light/Dark 预设应用实际配色且在重启后恢复
 - `MCP` 面板的全局设置弹窗移除了 `enabled` 开关，仅保留 `startup_timeout_seconds`；运行时现在默认总是持有可热重载的 MCP manager
 
 ### Fixed

--- a/klaw-gui/Cargo.toml
+++ b/klaw-gui/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+catppuccin-egui = { workspace = true }
 eframe = { workspace = true }
 egui = { workspace = true }
 egui-file-dialog = { workspace = true }

--- a/klaw-gui/README.md
+++ b/klaw-gui/README.md
@@ -11,13 +11,13 @@
 - Workbench sidebar now includes a dedicated `Voice` panel for voice config editing and split STT/TTS testing
 - Top menu bar (File/View/Window/Help)
   - File menu includes `Force Persist Layout` to immediately flush layout state to disk
-- Bottom status bar with version and theme-mode switcher
+- Bottom status bar with version and theme-mode dropdown
   - Runtime provider override dropdown on the right (select from `model_providers` without editing config; applies immediately to the running runtime's default provider for new routes and `/new`)
 - System tray / macOS menu bar icon loaded from embedded PNG assets at runtime
   - tray menu includes `Open Klaw`, `Settings`, `About`, and `Quit Klaw`
   - `Settings` opens the in-app settings workbench
 - UI state persistence across restart (`~/.klaw/gui_state.json`)
-  - includes tabs/theme/fullscreen and window size
+  - includes tabs/theme mode/light-dark theme presets/fullscreen and window size
 - macOS app icon is loaded from embedded image bytes at startup, so both `.app` bundles and standalone binaries keep the custom icon
 - System CJK font fallback via `fontdb` to avoid Chinese text missing-glyph rendering
 - Strongly typed menu model for workspace modules
@@ -116,6 +116,7 @@
   - show per-server runtime state and discovered tool counts directly in the table
   - open a detail popup that renders the cached MCP `tools/list` response for the selected server
 - Settings panel features:
+  - configure GUI theme presets in `General`, with `Default`/`Latte` for light mode and `Default`/`Frappé`/`Macchiato`/`Mocha` for dark mode
   - persist sync settings in `settings.json`, including S3 endpoint/region/bucket/prefix, backup scope, retention, schedule, hostname-based device ID, and both direct or env-backed credentials
   - trigger manual manifest sync runs against the remote blob store
   - show a live progress bar plus stage/detail text while manual sync is reconciling, uploading blobs, publishing manifests, and pruning remote history
@@ -154,8 +155,7 @@
   - includes `logs` panel backed by a non-blocking runtime log chunk bridge
 - `widgets/`: shared reusable UI widgets
 - `theme.rs`: centralized theme setup
-  - system-follow default
-  - light/dark/system cycling
+  - system-follow mode selection plus configurable light/dark theme presets
 - `state/persistence.rs`: local UI state load/save with schema versioning and atomic writes
 
 ## Running

--- a/klaw-gui/src/app/mod.rs
+++ b/klaw-gui/src/app/mod.rs
@@ -37,7 +37,7 @@ impl KlawGuiApp {
             last_state_save_at: Instant::now(),
         };
         theme::install_fonts(&creation_ctx.egui_ctx);
-        theme::apply_theme(&creation_ctx.egui_ctx, app.state.theme_mode);
+        theme::apply_theme(&creation_ctx.egui_ctx, &app.state);
         creation_ctx
             .egui_ctx
             .send_viewport_cmd(egui::ViewportCommand::Fullscreen(app.state.fullscreen));
@@ -66,6 +66,12 @@ impl KlawGuiApp {
                 ctx.send_viewport_cmd(egui::ViewportCommand::Fullscreen(self.state.fullscreen));
                 self.mark_state_dirty();
             }
+            UiAction::SetThemeMode(theme_mode) => {
+                self.sync_theme_presets_from_disk();
+                self.state.apply(UiAction::SetThemeMode(theme_mode));
+                theme::apply_theme(ctx, &self.state);
+                self.save_state_now();
+            }
             UiAction::MinimizeWindow => {
                 ctx.send_viewport_cmd(egui::ViewportCommand::Minimized(true));
             }
@@ -74,11 +80,6 @@ impl KlawGuiApp {
             }
             UiAction::StartWindowDrag => {
                 ctx.send_viewport_cmd(egui::ViewportCommand::StartDrag);
-            }
-            UiAction::CycleTheme => {
-                self.state.apply(action);
-                theme::apply_theme(ctx, self.state.theme_mode);
-                self.mark_state_dirty();
             }
             UiAction::SetRuntimeProviderOverride(provider_id) => {
                 match request_set_provider_override(provider_id.clone()) {
@@ -112,10 +113,17 @@ impl KlawGuiApp {
     }
 
     fn save_state_now(&mut self) {
+        self.sync_theme_presets_from_disk();
         if persistence::save_ui_state(&self.state).is_ok() {
             self.state_dirty = false;
             self.last_state_save_at = Instant::now();
         }
+    }
+
+    fn sync_theme_presets_from_disk(&mut self) {
+        let disk_state = persistence::load_ui_state();
+        self.state.light_theme = disk_state.light_theme;
+        self.state.dark_theme = disk_state.dark_theme;
     }
 
     fn handle_tray_command(&mut self, ctx: &egui::Context, command: TrayCommand) {
@@ -190,7 +198,6 @@ impl eframe::App for KlawGuiApp {
         self.drain_tray_commands(ctx);
         self.sync_fullscreen_from_viewport(ctx);
         self.sync_window_size_from_viewport(ctx);
-        theme::apply_theme(ctx, self.state.theme_mode);
         let actions = self.shell.render(ctx, &self.state);
         for action in actions {
             self.handle_action(ctx, action);

--- a/klaw-gui/src/panels/setting.rs
+++ b/klaw-gui/src/panels/setting.rs
@@ -4,12 +4,15 @@ use crate::settings::{
     AppSettings, ProxyMode, S3SyncConfig, SyncItem, SyncMode, SyncProvider, load_settings,
     save_settings,
 };
+use crate::state::persistence;
+use crate::state::{DarkThemePreset, LightThemePreset, UiState};
 use crate::sync_runtime::{
     SyncRuntimeProgress, SyncRuntimeSnapshot, SyncRuntimeTaskKind, sync_runtime_finish_task,
     sync_runtime_set_last_snapshot, sync_runtime_set_remote_snapshots,
     sync_runtime_set_remote_update, sync_runtime_set_task_progress, sync_runtime_snapshot,
     sync_runtime_sync_from_settings, sync_runtime_try_start_task,
 };
+use crate::theme;
 use crate::time_format::format_optional_timestamp_millis;
 use egui_extras::{Size, StripBuilder};
 use klaw_storage::{
@@ -68,6 +71,7 @@ enum SyncTaskMessage {
 
 pub struct SettingPanel {
     settings: AppSettings,
+    theme_state: UiState,
     active_section: SettingsSection,
     save_error: Option<String>,
     sync_task_rx: Option<Receiver<SyncTaskMessage>>,
@@ -80,6 +84,7 @@ impl Default for SettingPanel {
         let settings = load_settings();
         Self {
             settings,
+            theme_state: persistence::load_ui_state(),
             active_section: SettingsSection::General,
             save_error: None,
             sync_task_rx: None,
@@ -189,6 +194,29 @@ impl PanelRenderer for SettingPanel {
 }
 
 impl SettingPanel {
+    fn sync_theme_state(&mut self) {
+        let persisted = persistence::load_ui_state();
+        self.theme_state.theme_mode = persisted.theme_mode;
+        self.theme_state.light_theme = persisted.light_theme;
+        self.theme_state.dark_theme = persisted.dark_theme;
+    }
+
+    fn save_theme_state(&mut self, ctx: &egui::Context) {
+        match persistence::update_ui_state(|state| {
+            state.light_theme = self.theme_state.light_theme;
+            state.dark_theme = self.theme_state.dark_theme;
+        }) {
+            Ok(state) => {
+                self.theme_state = state;
+                theme::apply_theme(ctx, &self.theme_state);
+                self.save_error = None;
+            }
+            Err(err) => {
+                self.save_error = Some(err.to_string());
+            }
+        }
+    }
+
     fn try_save(&mut self) -> bool {
         match save_settings(&self.settings) {
             Ok(()) => {
@@ -476,6 +504,7 @@ impl SettingPanel {
     }
 
     fn render_general_section(&mut self, ui: &mut egui::Ui) {
+        self.sync_theme_state();
         ui.strong("General Settings");
         ui.add_space(8.0);
 
@@ -494,6 +523,75 @@ impl SettingPanel {
 
         ui.add_space(8.0);
         ui.label("Automatically start Klaw when you log in to your computer.");
+
+        ui.add_space(16.0);
+        ui.separator();
+        ui.add_space(12.0);
+        ui.label(format!(
+            "Current theme mode: {} (change from the bottom status bar).",
+            self.theme_state.theme_mode.label()
+        ));
+        ui.add_space(8.0);
+
+        let mut theme_changed = false;
+        egui::Grid::new("general-theme-grid")
+            .num_columns(2)
+            .spacing([8.0, 8.0])
+            .show(ui, |ui| {
+                ui.label("Light Theme:");
+                egui::ComboBox::from_id_salt("settings-light-theme")
+                    .width(160.0)
+                    .selected_text(self.theme_state.light_theme.label())
+                    .show_ui(ui, |ui| {
+                        for preset in [LightThemePreset::Default, LightThemePreset::Latte] {
+                            if ui
+                                .selectable_label(
+                                    self.theme_state.light_theme == preset,
+                                    preset.label(),
+                                )
+                                .clicked()
+                            {
+                                self.theme_state.light_theme = preset;
+                                theme_changed = true;
+                                ui.close();
+                            }
+                        }
+                    });
+                ui.end_row();
+
+                ui.label("Dark Theme:");
+                egui::ComboBox::from_id_salt("settings-dark-theme")
+                    .width(160.0)
+                    .selected_text(self.theme_state.dark_theme.label())
+                    .show_ui(ui, |ui| {
+                        for preset in [
+                            DarkThemePreset::Default,
+                            DarkThemePreset::Frappe,
+                            DarkThemePreset::Macchiato,
+                            DarkThemePreset::Mocha,
+                        ] {
+                            if ui
+                                .selectable_label(
+                                    self.theme_state.dark_theme == preset,
+                                    preset.label(),
+                                )
+                                .clicked()
+                            {
+                                self.theme_state.dark_theme = preset;
+                                theme_changed = true;
+                                ui.close();
+                            }
+                        }
+                    });
+                ui.end_row();
+            });
+
+        ui.add_space(8.0);
+        ui.small("Default keeps the existing egui light/dark visuals.");
+
+        if theme_changed {
+            self.save_theme_state(ui.ctx());
+        }
     }
 
     fn render_privacy_section(&mut self, ui: &mut egui::Ui) {

--- a/klaw-gui/src/state/mod.rs
+++ b/klaw-gui/src/state/mod.rs
@@ -11,6 +11,7 @@ pub enum UiAction {
     ActivateTab(TabId),
     CloseTab(TabId),
     SetRuntimeProviderOverride(Option<String>),
+    SetThemeMode(ThemeMode),
     CloseWindow,
     ForcePersistLayout,
     ToggleFullscreen,
@@ -19,22 +20,61 @@ pub enum UiAction {
     StartWindowDrag,
     ShowAbout,
     HideAbout,
-    CycleTheme,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
 pub enum ThemeMode {
+    #[default]
     System,
     Light,
     Dark,
 }
 
 impl ThemeMode {
-    pub fn next(self) -> Self {
+    pub const fn label(self) -> &'static str {
         match self {
-            ThemeMode::System => ThemeMode::Light,
-            ThemeMode::Light => ThemeMode::Dark,
-            ThemeMode::Dark => ThemeMode::System,
+            ThemeMode::System => "System",
+            ThemeMode::Light => "Light",
+            ThemeMode::Dark => "Dark",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum LightThemePreset {
+    #[default]
+    Default,
+    Latte,
+}
+
+impl LightThemePreset {
+    pub const fn label(self) -> &'static str {
+        match self {
+            LightThemePreset::Default => "Default",
+            LightThemePreset::Latte => "Latte",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum DarkThemePreset {
+    #[default]
+    Default,
+    Frappe,
+    Macchiato,
+    Mocha,
+}
+
+impl DarkThemePreset {
+    pub const fn label(self) -> &'static str {
+        match self {
+            DarkThemePreset::Default => "Default",
+            DarkThemePreset::Frappe => "Frappé",
+            DarkThemePreset::Macchiato => "Macchiato",
+            DarkThemePreset::Mocha => "Mocha",
         }
     }
 }
@@ -42,7 +82,12 @@ impl ThemeMode {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UiState {
     pub workbench: workbench::WorkbenchState,
+    #[serde(default)]
     pub theme_mode: ThemeMode,
+    #[serde(default)]
+    pub light_theme: LightThemePreset,
+    #[serde(default)]
+    pub dark_theme: DarkThemePreset,
     pub fullscreen: bool,
     #[serde(default)]
     pub runtime_provider_override: Option<String>,
@@ -62,6 +107,8 @@ impl Default for UiState {
         Self {
             workbench: workbench::WorkbenchState::new_with_default(WorkbenchMenu::Profile),
             theme_mode: ThemeMode::System,
+            light_theme: LightThemePreset::Default,
+            dark_theme: DarkThemePreset::Default,
             fullscreen: false,
             runtime_provider_override: None,
             window_size: None,
@@ -79,6 +126,9 @@ impl UiState {
             UiAction::SetRuntimeProviderOverride(provider_id) => {
                 self.runtime_provider_override = provider_id;
             }
+            UiAction::SetThemeMode(theme_mode) => {
+                self.theme_mode = theme_mode;
+            }
             UiAction::ToggleFullscreen => {
                 self.fullscreen = !self.fullscreen;
             }
@@ -87,9 +137,6 @@ impl UiState {
             }
             UiAction::HideAbout => {
                 self.show_about = false;
-            }
-            UiAction::CycleTheme => {
-                self.theme_mode = self.theme_mode.next();
             }
             UiAction::CloseWindow
             | UiAction::ForcePersistLayout
@@ -102,13 +149,24 @@ impl UiState {
 
 #[cfg(test)]
 mod tests {
-    use super::{ThemeMode, UiAction, UiState};
+    use super::{DarkThemePreset, LightThemePreset, ThemeMode, UiAction, UiState};
 
     #[test]
-    fn theme_mode_cycles_system_light_dark() {
-        assert_eq!(ThemeMode::System.next(), ThemeMode::Light);
-        assert_eq!(ThemeMode::Light.next(), ThemeMode::Dark);
-        assert_eq!(ThemeMode::Dark.next(), ThemeMode::System);
+    fn ui_state_defaults_to_default_theme_presets() {
+        let state = UiState::default();
+
+        assert_eq!(state.theme_mode, ThemeMode::System);
+        assert_eq!(state.light_theme, LightThemePreset::Default);
+        assert_eq!(state.dark_theme, DarkThemePreset::Default);
+    }
+
+    #[test]
+    fn theme_mode_can_be_set_explicitly() {
+        let mut state = UiState::default();
+
+        state.apply(UiAction::SetThemeMode(ThemeMode::Dark));
+
+        assert_eq!(state.theme_mode, ThemeMode::Dark);
     }
 
     #[test]

--- a/klaw-gui/src/state/persistence.rs
+++ b/klaw-gui/src/state/persistence.rs
@@ -38,6 +38,22 @@ pub fn save_ui_state(state: &UiState) -> io::Result<()> {
     save_ui_state_to_path(&path, state)
 }
 
+pub fn update_ui_state<F>(mutate: F) -> io::Result<UiState>
+where
+    F: FnOnce(&mut UiState),
+{
+    let Some(path) = default_state_path() else {
+        let mut state = UiState::default();
+        mutate(&mut state);
+        return Ok(state);
+    };
+
+    let mut state = load_ui_state_from_path(&path).unwrap_or_default();
+    mutate(&mut state);
+    save_ui_state_to_path(&path, &state)?;
+    Ok(state)
+}
+
 fn load_ui_state_from_path(path: &Path) -> io::Result<UiState> {
     let raw = fs::read_to_string(path)?;
     let persisted: PersistedUiState = serde_json::from_str(&raw)
@@ -81,7 +97,7 @@ mod tests {
     use super::{load_ui_state_from_path, save_ui_state_to_path};
     use crate::domain::menu::WorkbenchMenu;
     use crate::state::workbench::TabId;
-    use crate::state::{ThemeMode, UiAction, UiState};
+    use crate::state::{DarkThemePreset, LightThemePreset, ThemeMode, UiAction, UiState};
     use std::fs;
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -91,6 +107,8 @@ mod tests {
         let path = unique_test_path();
         let mut state = UiState::default();
         state.theme_mode = ThemeMode::Dark;
+        state.light_theme = LightThemePreset::Latte;
+        state.dark_theme = DarkThemePreset::Mocha;
         state.apply(UiAction::OpenMenu(WorkbenchMenu::Provider));
         state.apply(UiAction::ActivateTab(TabId::from_menu(
             WorkbenchMenu::Provider,
@@ -100,6 +118,8 @@ mod tests {
         let restored = load_ui_state_from_path(&path).expect("load ui state");
 
         assert_eq!(restored.theme_mode, ThemeMode::Dark);
+        assert_eq!(restored.light_theme, LightThemePreset::Latte);
+        assert_eq!(restored.dark_theme, DarkThemePreset::Mocha);
         assert_eq!(restored.workbench.active_tab, state.workbench.active_tab);
         assert_eq!(restored.workbench.tabs.len(), state.workbench.tabs.len());
 
@@ -116,6 +136,41 @@ mod tests {
         let restored = load_ui_state_from_path(&path).expect("load ui state");
 
         assert_eq!(restored.workbench.tabs[0].title, "Profile Prompt");
+
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn load_ui_state_backfills_missing_theme_presets() {
+        let path = unique_test_path();
+        let json = r#"{
+          "schema_version": 1,
+          "state": {
+            "workbench": {
+              "tabs": [
+                {
+                  "id": { "menu": "Profile" },
+                  "menu": "Profile",
+                  "title": "Profile",
+                  "closable": true
+                }
+              ],
+              "active_tab": { "menu": "Profile" }
+            },
+            "theme_mode": "dark",
+            "fullscreen": false,
+            "show_about": false
+          }
+        }"#;
+        fs::create_dir_all(path.parent().expect("legacy ui state parent"))
+            .expect("create legacy ui state parent");
+        fs::write(&path, json).expect("write legacy ui state");
+
+        let restored = load_ui_state_from_path(&path).expect("load ui state");
+
+        assert_eq!(restored.theme_mode, ThemeMode::Dark);
+        assert_eq!(restored.light_theme, LightThemePreset::Default);
+        assert_eq!(restored.dark_theme, DarkThemePreset::Default);
 
         let _ = fs::remove_file(path);
     }

--- a/klaw-gui/src/state/workbench.rs
+++ b/klaw-gui/src/state/workbench.rs
@@ -59,6 +59,7 @@ impl WorkbenchState {
             UiAction::ActivateTab(tab_id) => self.activate(tab_id),
             UiAction::CloseTab(tab_id) => self.close(tab_id),
             UiAction::SetRuntimeProviderOverride(_)
+            | UiAction::SetThemeMode(_)
             | UiAction::CloseWindow
             | UiAction::ForcePersistLayout
             | UiAction::ToggleFullscreen
@@ -66,8 +67,7 @@ impl WorkbenchState {
             | UiAction::ZoomWindow
             | UiAction::StartWindowDrag
             | UiAction::ShowAbout
-            | UiAction::HideAbout
-            | UiAction::CycleTheme => {}
+            | UiAction::HideAbout => {}
         }
     }
 

--- a/klaw-gui/src/theme.rs
+++ b/klaw-gui/src/theme.rs
@@ -1,4 +1,4 @@
-use crate::state::ThemeMode;
+use crate::state::{DarkThemePreset, LightThemePreset, ThemeMode, UiState};
 use std::collections::HashSet;
 use std::path::Path;
 
@@ -17,13 +17,42 @@ pub fn install_fonts(ctx: &egui::Context) {
     ctx.set_fonts(fonts);
 }
 
-pub fn apply_theme(ctx: &egui::Context, theme_mode: ThemeMode) {
-    let preference = match theme_mode {
+pub fn apply_theme(ctx: &egui::Context, state: &UiState) {
+    let preference = match state.theme_mode {
         ThemeMode::System => egui::ThemePreference::System,
         ThemeMode::Light => egui::ThemePreference::Light,
         ThemeMode::Dark => egui::ThemePreference::Dark,
     };
     ctx.set_theme(preference);
+    ctx.set_visuals_of(egui::Theme::Light, light_visuals(state.light_theme));
+    ctx.set_visuals_of(egui::Theme::Dark, dark_visuals(state.dark_theme));
+}
+
+fn light_visuals(preset: LightThemePreset) -> egui::Visuals {
+    match preset {
+        LightThemePreset::Default => egui::Visuals::light(),
+        LightThemePreset::Latte => catppuccin_visuals(catppuccin_egui::LATTE, false),
+    }
+}
+
+fn dark_visuals(preset: DarkThemePreset) -> egui::Visuals {
+    match preset {
+        DarkThemePreset::Default => egui::Visuals::dark(),
+        DarkThemePreset::Frappe => catppuccin_visuals(catppuccin_egui::FRAPPE, true),
+        DarkThemePreset::Macchiato => catppuccin_visuals(catppuccin_egui::MACCHIATO, true),
+        DarkThemePreset::Mocha => catppuccin_visuals(catppuccin_egui::MOCHA, true),
+    }
+}
+
+fn catppuccin_visuals(theme: catppuccin_egui::Theme, dark_mode: bool) -> egui::Visuals {
+    let mut style = egui::Style::default();
+    style.visuals = if dark_mode {
+        egui::Visuals::dark()
+    } else {
+        egui::Visuals::light()
+    };
+    catppuccin_egui::set_style_theme(&mut style, theme);
+    style.visuals
 }
 
 fn install_system_cjk_fallbacks(fonts: &mut egui::FontDefinitions) {
@@ -146,9 +175,10 @@ fn is_preferred_cjk_family(family_name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        LXGW_WENKAI_MONOSPACE_NAME, LXGW_WENKAI_PROPORTIONAL_NAME,
-        install_embedded_preferred_fonts, is_preferred_cjk_family,
+        LXGW_WENKAI_MONOSPACE_NAME, LXGW_WENKAI_PROPORTIONAL_NAME, dark_visuals,
+        install_embedded_preferred_fonts, is_preferred_cjk_family, light_visuals,
     };
+    use crate::state::{DarkThemePreset, LightThemePreset};
 
     #[test]
     fn preferred_cjk_family_match_is_case_insensitive() {
@@ -172,5 +202,16 @@ mod tests {
             fonts.families[&egui::FontFamily::Monospace].first(),
             Some(&LXGW_WENKAI_MONOSPACE_NAME.to_string())
         );
+    }
+
+    #[test]
+    fn non_default_theme_presets_override_base_visuals() {
+        let default_light = light_visuals(LightThemePreset::Default);
+        let latte = light_visuals(LightThemePreset::Latte);
+        let default_dark = dark_visuals(DarkThemePreset::Default);
+        let mocha = dark_visuals(DarkThemePreset::Mocha);
+
+        assert_ne!(latte.panel_fill, default_light.panel_fill);
+        assert_ne!(mocha.panel_fill, default_dark.panel_fill);
     }
 }

--- a/klaw-gui/src/ui/shell.rs
+++ b/klaw-gui/src/ui/shell.rs
@@ -201,12 +201,22 @@ impl ShellUi {
                     ThemeMode::Dark => regular::MOON,
                 };
 
-                let response = ui
-                    .add(egui::Label::new(theme_icon).sense(egui::Sense::click()))
-                    .on_hover_text("Theme: System -> Light -> Dark");
-                if response.clicked() {
-                    actions.push(UiAction::CycleTheme);
-                }
+                ui.label(theme_icon);
+                ui.label("Theme Mode:");
+                egui::ComboBox::from_id_salt("status-theme-mode")
+                    .width(110.0)
+                    .selected_text(state.theme_mode.label())
+                    .show_ui(ui, |ui| {
+                        for mode in [ThemeMode::System, ThemeMode::Light, ThemeMode::Dark] {
+                            if ui
+                                .selectable_label(state.theme_mode == mode, mode.label())
+                                .clicked()
+                            {
+                                actions.push(UiAction::SetThemeMode(mode));
+                                ui.close();
+                            }
+                        }
+                    });
 
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                     let version_label = format!("{} v{}", regular::INFO, env!("CARGO_PKG_VERSION"));


### PR DESCRIPTION
## Summary
- add persistent light and dark theme presets to `Settings > General`, including `Latte` for light mode and `Frappé` / `Macchiato` / `Mocha` for dark mode
- replace the status-bar theme toggle with an explicit `Theme Mode` dropdown and apply the saved preset for the active light/dark mode
- wire theme preset persistence into `UiState` save/load flow and document the new GUI behavior in `klaw-gui` docs

Closes #69

## Test plan
- [x] `cargo test -p klaw-gui`
- [x] Open the GUI and verify `Settings > General` theme dropdowns update the active visuals
- [x] Switch the bottom status bar between `System`, `Light`, and `Dark` and confirm the configured preset is applied
- [x] Restart the GUI and confirm the selected mode and theme presets persist


Made with [Cursor](https://cursor.com)