### PR TITLE
fix(tool): stabilize sub-agent delegated execution

### DIFF
--- a/docs/src/tools/advanced/sub_agent.md
+++ b/docs/src/tools/advanced/sub_agent.md
@@ -111,6 +111,15 @@ exclude_tools = ["sub_agent"]
 - Provider 调用失败：`ToolError::ExecutionFailed`
 - 子代理触发 `approval_required` / `stop`：通过结构化错误把信号继续透传给父 Agent，而不是在 `sub_agent` 边界吞掉
 
+## 审计持久化
+
+- 子代理执行仍然直接复用 `run_agent_execution`，因此会生成 `request_audits` / `request_usages`。
+- 当 runtime 为 `sub_agent` 注入审计 sink 时，子代理产生的 LLM 审计会按父 session 落库。
+- 落库记录的 `llm_audit.metadata_json` 会包含：
+  - `sub_agent = true`
+  - `sub_agent.parent_session_key`
+  - `sub_agent.child_session_key`
+
 ## 测试覆盖
 
 `sub_agent` 单测已覆盖：

--- a/klaw-cli/CHANGELOG.md
+++ b/klaw-cli/CHANGELOG.md
@@ -11,6 +11,7 @@
 - provider config 热更新现在会同步刷新 running runtime 的 live provider registry/default route，并在 provider 被删除或替换后自动清理失效的 runtime override，避免新增 provider 后底部切换报 `unknown runtime provider` 或必须重启才生效
 - runtime 现在会把入站 DingTalk 的最新 `session_webhook` / `bot_title` 持久化到 active session，供 cron/后台流程后续复用当前会话回复出口
 - `/new` 创建的 DingTalk 子 session 现在会继承当前会话的回复元数据，避免切到新 session 后 cron 仍回落到旧 `session_webhook`
+- runtime 现在会把 `sub_agent` 的 LLM 审计按父 session 落库，并在审计 metadata 中标记 `sub_agent.parent_session_key` / `sub_agent.child_session_key`
 
 ### Changed
 

--- a/klaw-cli/README.md
+++ b/klaw-cli/README.md
@@ -65,6 +65,7 @@
 - runtime 审批命令与工具审批流统一通过 `klaw-approval` manager 层处理状态流转与消费
 - runtime 对 `approval_required` 工具结果会直接透传审批提示，不再包装成通用的 tool failure 文案
 - runtime 对 `stop` 工具信号会立即结束当前轮次，并在 outbound metadata 中写入 `turn.stopped` / `turn.stop_signal`
+- runtime 现在会把 `sub_agent` 的 LLM 审计按父 session 持久化，并在审计记录 metadata 中附带 parent/child session 关联信息
 - runtime 和 `klaw session` 命令的会话状态/历史操作统一通过 `klaw-session` manager 层处理
 - 普通消息默认按 Base Session -> Active Session 路由；全局默认 provider/model 从当前配置实时解析，session 里的 `model_provider` / `model` 只表示显式 override，不再在建会话时复制默认值
 - gateway runtime 现同时支持结构化 `POST /webhook/events` 与模板驱动的 `POST /webhook/agents`；后者通过 URL query 接收 `hook_id` / `session_key` / `provider` / `model` 等控制参数，HTTP body 则保持原始 JSON 并在模板尾部追加为 request JSON 代码块

--- a/klaw-cli/src/runtime/mod.rs
+++ b/klaw-cli/src/runtime/mod.rs
@@ -4,8 +4,9 @@ pub mod service_loop;
 pub mod webhook;
 
 use klaw_agent::{
-    AgentExecutionStreamEvent, ConversationMessage, ConversationSummary, build_compression_prompt,
-    build_provider_from_config, merge_or_reset_summary, parse_conversation_summary,
+    AgentExecutionOutput, AgentExecutionStreamEvent, ConversationMessage, ConversationSummary,
+    build_compression_prompt, build_provider_from_config, merge_or_reset_summary,
+    parse_conversation_summary,
 };
 use klaw_approval::{
     ApprovalManager, ApprovalResolveDecision, ApprovalStatus, SqliteApprovalManager,
@@ -40,8 +41,9 @@ use klaw_skill::{
 use klaw_storage::{DefaultSessionStore, open_default_store};
 use klaw_tool::{
     ApplyPatchTool, ApprovalTool, ArchiveTool, CronManagerTool, HeartbeatManagerTool,
-    LocalSearchTool, MemoryTool, ShellTool, SkillsManagerTool, SkillsRegistryTool, SubAgentTool,
-    TerminalMultiplexerTool, ToolContext, ToolRegistry, VoiceTool, WebFetchTool, WebSearchTool,
+    LocalSearchTool, MemoryTool, ShellTool, SkillsManagerTool, SkillsRegistryTool,
+    SubAgentAuditSink, SubAgentTool, TerminalMultiplexerTool, ToolContext, ToolRegistry, VoiceTool,
+    WebFetchTool, WebSearchTool,
 };
 use klaw_util::EnvironmentCheckReport;
 use serde_json::{Value, json};
@@ -452,9 +454,29 @@ fn enqueue_llm_audit_records_from_outcome(
     ) else {
         return;
     };
-    for (index, record) in outcome.llm_audits.iter().enumerate() {
+    enqueue_llm_audit_records(
+        &runtime.llm_audit_tx,
+        session_key,
+        chat_id,
+        turn_index,
+        &message_id.to_string(),
+        &outcome.llm_audits,
+        None,
+    );
+}
+
+fn enqueue_llm_audit_records(
+    llm_audit_tx: &std::sync::mpsc::SyncSender<NewLlmAuditRecord>,
+    session_key: &str,
+    chat_id: &str,
+    turn_index: i64,
+    id_prefix: &str,
+    audits: &[klaw_llm::LlmAuditPayload],
+    metadata_json: Option<String>,
+) {
+    for (index, record) in audits.iter().enumerate() {
         let payload = NewLlmAuditRecord {
-            id: format!("{message_id}:audit:{}", index + 1),
+            id: format!("{id_prefix}:audit:{}", index + 1),
             session_key: session_key.to_string(),
             chat_id: chat_id.to_string(),
             turn_index,
@@ -472,10 +494,11 @@ fn enqueue_llm_audit_records_from_outcome(
             provider_response_id: record.provider_response_id.clone(),
             request_body_json: serialize_json_string(&record.request_body),
             response_body_json: record.response_body.as_ref().map(serialize_json_string),
+            metadata_json: metadata_json.clone(),
             requested_at_ms: record.requested_at_ms,
             responded_at_ms: record.responded_at_ms,
         };
-        if let Err(err) = runtime.llm_audit_tx.try_send(payload) {
+        if let Err(err) = llm_audit_tx.try_send(payload) {
             warn!(error = %err, session_key, "llm audit queue full or disconnected; dropping record");
         }
     }
@@ -483,6 +506,66 @@ fn enqueue_llm_audit_records_from_outcome(
 
 fn serialize_json_string(value: &serde_json::Value) -> String {
     serde_json::to_string(value).unwrap_or_else(|_| "null".to_string())
+}
+
+#[derive(Clone)]
+struct RuntimeSubAgentAuditSink {
+    session_store: DefaultSessionStore,
+    llm_audit_tx: std::sync::mpsc::SyncSender<NewLlmAuditRecord>,
+}
+
+impl RuntimeSubAgentAuditSink {
+    fn new(
+        session_store: DefaultSessionStore,
+        llm_audit_tx: std::sync::mpsc::SyncSender<NewLlmAuditRecord>,
+    ) -> Self {
+        Self {
+            session_store,
+            llm_audit_tx,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl SubAgentAuditSink for RuntimeSubAgentAuditSink {
+    async fn persist_sub_agent_audits(
+        &self,
+        parent_session_key: &str,
+        child_session_key: &str,
+        output: &AgentExecutionOutput,
+    ) -> Result<(), String> {
+        if output.request_audits.is_empty() {
+            return Ok(());
+        }
+
+        let sessions = SqliteSessionManager::from_store(self.session_store.clone());
+        let session = sessions
+            .get_session(parent_session_key)
+            .await
+            .map_err(|err| format!("load parent session failed: {err}"))?;
+        let metadata_json = serde_json::to_string(&json!({
+            "sub_agent": true,
+            "sub_agent.parent_session_key": parent_session_key,
+            "sub_agent.child_session_key": child_session_key,
+            "sub_agent.source_tool": "sub_agent",
+        }))
+        .map_err(|err| format!("serialize sub-agent audit metadata failed: {err}"))?;
+        let audits = output
+            .request_audits
+            .iter()
+            .map(|record| record.payload.clone())
+            .collect::<Vec<_>>();
+        enqueue_llm_audit_records(
+            &self.llm_audit_tx,
+            parent_session_key,
+            &session.chat_id,
+            session.turn_count,
+            child_session_key,
+            &audits,
+            Some(metadata_json),
+        );
+        Ok(())
+    }
 }
 
 async fn execute_approved_shell(
@@ -860,6 +943,7 @@ async fn register_configured_tools(
     tools: &mut ToolRegistry,
     config: &AppConfig,
     session_store: DefaultSessionStore,
+    sub_agent_audit_sink: Option<Arc<dyn SubAgentAuditSink>>,
 ) -> Result<(), Box<dyn Error>> {
     if config.tools.archive.enabled() {
         tools.register(ArchiveTool::open_default(config).await?);
@@ -926,7 +1010,11 @@ async fn register_configured_tools(
     }
     if config.tools.sub_agent.enabled() {
         let parent_tools = tools.clone();
-        tools.register(SubAgentTool::new(Arc::new(config.clone()), parent_tools));
+        tools.register(SubAgentTool::with_audit_sink(
+            Arc::new(config.clone()),
+            parent_tools,
+            sub_agent_audit_sink,
+        ));
     }
     Ok(())
 }
@@ -969,7 +1057,17 @@ pub async fn sync_runtime_tools(
     config: &AppConfig,
 ) -> Result<Vec<String>, Box<dyn Error>> {
     let mut next_tools = ToolRegistry::default();
-    register_configured_tools(&mut next_tools, config, runtime.session_store.clone()).await?;
+    let sub_agent_audit_sink: Arc<dyn SubAgentAuditSink> = Arc::new(RuntimeSubAgentAuditSink::new(
+        runtime.session_store.clone(),
+        runtime.llm_audit_tx.clone(),
+    ));
+    register_configured_tools(
+        &mut next_tools,
+        config,
+        runtime.session_store.clone(),
+        Some(sub_agent_audit_sink),
+    )
+    .await?;
     let builtin_tool_names = builtin_tool_names(config);
     let builtin_tool_name_refs: Vec<&str> = builtin_tool_names.iter().map(String::as_str).collect();
 
@@ -1542,8 +1640,19 @@ pub async fn build_runtime_bundle(config: &AppConfig) -> Result<RuntimeBundle, B
     let default_provider = Arc::clone(&provider_runtime.default_provider);
     let default_model = provider_runtime.default_model.clone();
     let session_store = open_default_store().await?;
+    let llm_audit_tx = spawn_llm_audit_writer(session_store.clone());
     let mut tools = ToolRegistry::default();
-    register_configured_tools(&mut tools, config, session_store.clone()).await?;
+    let sub_agent_audit_sink: Arc<dyn SubAgentAuditSink> = Arc::new(RuntimeSubAgentAuditSink::new(
+        session_store.clone(),
+        llm_audit_tx.clone(),
+    ));
+    register_configured_tools(
+        &mut tools,
+        config,
+        session_store.clone(),
+        Some(sub_agent_audit_sink),
+    )
+    .await?;
 
     let configured_mcp_servers = config
         .mcp
@@ -1564,7 +1673,6 @@ pub async fn build_runtime_bundle(config: &AppConfig) -> Result<RuntimeBundle, B
     let system_prompt = build_runtime_system_prompt(loaded_skills.skill_entries);
 
     let observability = init_observability_from_config(config).await;
-    let llm_audit_tx = spawn_llm_audit_writer(session_store.clone());
     let telemetry: Option<Arc<dyn AgentTelemetry>> = observability.as_ref().map(|handle| {
         Arc::new(OtelAgentTelemetry::from_handle(handle, "klaw")) as Arc<dyn AgentTelemetry>
     });
@@ -2701,7 +2809,7 @@ mod tests {
         should_trigger_compression, spawn_llm_audit_writer, spawn_mcp_init, submit_and_get_output,
         sync_runtime_providers, sync_runtime_tools, trim_conversation_history,
     };
-    use klaw_agent::ConversationSummary;
+    use klaw_agent::{AgentExecutionOutput, AgentRequestAudit, ConversationSummary};
     use klaw_config::{AppConfig, McpConfig, ModelProviderConfig};
     use klaw_core::{
         CircuitBreakerPolicy, DeadLetterPolicy, Envelope, EnvelopeHeader,
@@ -2709,11 +2817,11 @@ mod tests {
         InMemoryTransport, OutboundMessage, QueueStrategy, RunLimits, SessionSchedulingPolicy,
         Subscription,
     };
-    use klaw_llm::{ChatOptions, LlmError, LlmProvider};
+    use klaw_llm::{ChatOptions, LlmAuditPayload, LlmError, LlmProvider};
     use klaw_session::{ChatRecord, SessionManager, SqliteSessionManager};
     use klaw_storage::ApprovalStatus;
     use klaw_storage::{DefaultSessionStore, StoragePaths};
-    use klaw_tool::ToolRegistry;
+    use klaw_tool::{SubAgentAuditSink, ToolRegistry};
     use klaw_util::EnvironmentCheckReport;
     use serde_json::{Value, json};
     use std::{
@@ -2839,6 +2947,91 @@ mod tests {
                 checked_at: OffsetDateTime::UNIX_EPOCH,
             },
         }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn runtime_sub_agent_audit_sink_persists_audits_on_parent_session() {
+        let provider = Arc::new(BootstrapCaptureProvider::default());
+        let runtime = build_test_runtime(provider).await;
+        let sessions = super::session_manager(&runtime);
+        sessions
+            .touch_session("parent-session", "chat-parent", "stdio")
+            .await
+            .expect("parent session should exist");
+        sessions
+            .complete_turn("parent-session", "chat-parent", "stdio")
+            .await
+            .expect("turn count should increment");
+
+        let sink = super::RuntimeSubAgentAuditSink::new(
+            runtime.session_store.clone(),
+            runtime.llm_audit_tx.clone(),
+        );
+        let output = AgentExecutionOutput {
+            content: "done".to_string(),
+            reasoning: None,
+            tool_signals: Vec::new(),
+            request_usages: Vec::new(),
+            request_audits: vec![AgentRequestAudit {
+                request_seq: 1,
+                payload: LlmAuditPayload {
+                    provider: "openai".to_string(),
+                    model: "gpt-4.1-mini".to_string(),
+                    wire_api: "responses".to_string(),
+                    status: klaw_llm::LlmAuditStatus::Success,
+                    error_code: None,
+                    error_message: None,
+                    request_body: json!({"input":"delegate"}),
+                    response_body: Some(json!({"output":"done"})),
+                    requested_at_ms: 10,
+                    responded_at_ms: Some(20),
+                    provider_request_id: Some("req-sub".to_string()),
+                    provider_response_id: Some("resp-sub".to_string()),
+                },
+            }],
+        };
+        sink.persist_sub_agent_audits("parent-session", "parent-session:subagent:test", &output)
+            .await
+            .expect("sink should persist audits");
+
+        let mut rows = Vec::new();
+        for _ in 0..20 {
+            rows = sessions
+                .list_llm_audit(&klaw_storage::LlmAuditQuery {
+                    session_key: Some("parent-session".to_string()),
+                    provider: None,
+                    requested_from_ms: None,
+                    requested_to_ms: None,
+                    limit: 10,
+                    offset: 0,
+                    sort_order: klaw_storage::LlmAuditSortOrder::RequestedAtDesc,
+                })
+                .await
+                .expect("audit rows should list");
+            if !rows.is_empty() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].session_key, "parent-session");
+        assert_eq!(rows[0].chat_id, "chat-parent");
+        assert_eq!(rows[0].turn_index, 1);
+        let metadata = rows[0]
+            .metadata_json
+            .as_ref()
+            .and_then(|value| serde_json::from_str::<Value>(value).ok())
+            .expect("metadata json should parse");
+        assert_eq!(metadata.get("sub_agent"), Some(&Value::Bool(true)));
+        assert_eq!(
+            metadata.get("sub_agent.parent_session_key"),
+            Some(&Value::String("parent-session".to_string()))
+        );
+        assert_eq!(
+            metadata.get("sub_agent.child_session_key"),
+            Some(&Value::String("parent-session:subagent:test".to_string()))
+        );
     }
 
     fn test_provider_config(default_model: &str) -> ModelProviderConfig {

--- a/klaw-cron/src/worker.rs
+++ b/klaw-cron/src/worker.rs
@@ -707,6 +707,7 @@ mod tests {
                 provider_response_id: input.provider_response_id.clone(),
                 request_body_json: input.request_body_json.clone(),
                 response_body_json: input.response_body_json.clone(),
+                metadata_json: input.metadata_json.clone(),
                 requested_at_ms: input.requested_at_ms,
                 responded_at_ms: input.responded_at_ms,
                 created_at_ms: now_ms(),

--- a/klaw-storage/CHANGELOG.md
+++ b/klaw-storage/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - added persisted `delivery_metadata_json` session state so runtimes can retain channel-specific reply metadata such as the latest DingTalk `session_webhook`
 - added persisted session-route explicitness flags so runtimes can distinguish user-chosen provider/model overrides from legacy default-route residue during routing normalization
+- added optional `metadata_json` on `llm_audit` records so runtimes can annotate persisted model requests with execution-context details such as delegated sub-agent lineage
 
 ## 2026-03-25
 

--- a/klaw-storage/README.md
+++ b/klaw-storage/README.md
@@ -35,6 +35,7 @@
 - `tmp/` is the dedicated temporary data directory under the Klaw data root
 - session records support Base Session -> Active Session routing
 - `model_provider` / `model` now represent per-session routing state, and the persisted explicitness flags let runtimes distinguish user-chosen overrides from legacy default-route residue during normalization
+- `llm_audit` records support optional `metadata_json`, which runtimes can use to annotate model requests with delegated execution context such as sub-agent parent/child session lineage
 - heartbeat records keep session-bound autonomous wakeups separate from isolated cron jobs
 - `DefaultMemoryDb` provides a generic SQL interface for `klaw-memory`
 - `DefaultArchiveDb` provides a generic SQL interface for `klaw-archive`

--- a/klaw-storage/src/backend/sqlx.rs
+++ b/klaw-storage/src/backend/sqlx.rs
@@ -181,6 +181,7 @@ struct LlmAuditRow {
     provider_response_id: Option<String>,
     request_body_json: String,
     response_body_json: Option<String>,
+    metadata_json: Option<String>,
     requested_at_ms: i64,
     responded_at_ms: Option<i64>,
     created_at_ms: i64,
@@ -427,6 +428,7 @@ impl TryFrom<LlmAuditRow> for LlmAuditRecord {
             provider_response_id: value.provider_response_id,
             request_body_json: value.request_body_json,
             response_body_json: value.response_body_json,
+            metadata_json: value.metadata_json,
             requested_at_ms: value.requested_at_ms,
             responded_at_ms: value.responded_at_ms,
             created_at_ms: value.created_at_ms,
@@ -640,6 +642,7 @@ impl SqlxSessionStore {
                 provider_response_id TEXT,
                 request_body_json TEXT NOT NULL,
                 response_body_json TEXT,
+                metadata_json TEXT,
                 requested_at_ms INTEGER NOT NULL,
                 responded_at_ms INTEGER,
                 created_at_ms INTEGER NOT NULL,
@@ -649,6 +652,11 @@ impl SqlxSessionStore {
         .execute(&self.pool)
         .await
         .map_err(StorageError::backend)?;
+        self.ensure_llm_audit_column(
+            "metadata_json",
+            "ALTER TABLE llm_audit ADD COLUMN metadata_json TEXT",
+        )
+        .await?;
         sqlx::query(
             "CREATE INDEX IF NOT EXISTS idx_llm_audit_session_requested
              ON llm_audit(session_key, requested_at_ms DESC)",
@@ -968,6 +976,22 @@ impl SqlxSessionStore {
                 }
                 Err(StorageError::backend(format!(
                     "failed to ensure approvals.{column} column: {message}"
+                )))
+            }
+        }
+    }
+
+    async fn ensure_llm_audit_column(&self, column: &str, sql: &str) -> Result<(), StorageError> {
+        let result = sqlx::query(sql).execute(&self.pool).await;
+        match result {
+            Ok(_) => Ok(()),
+            Err(err) => {
+                let message = err.to_string();
+                if message.contains("duplicate column name") {
+                    return Ok(());
+                }
+                Err(StorageError::backend(format!(
+                    "failed to ensure llm_audit.{column} column: {message}"
                 )))
             }
         }
@@ -1664,8 +1688,8 @@ impl SessionStorage for SqlxSessionStore {
             "INSERT INTO llm_audit (
                 id, session_key, chat_id, turn_index, request_seq, provider, model, wire_api,
                 status, error_code, error_message, provider_request_id, provider_response_id,
-                request_body_json, response_body_json, requested_at_ms, responded_at_ms, created_at_ms
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)",
+                request_body_json, response_body_json, metadata_json, requested_at_ms, responded_at_ms, created_at_ms
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19)",
         )
         .bind(&input.id)
         .bind(&input.session_key)
@@ -1682,6 +1706,7 @@ impl SessionStorage for SqlxSessionStore {
         .bind(&input.provider_response_id)
         .bind(&input.request_body_json)
         .bind(&input.response_body_json)
+        .bind(&input.metadata_json)
         .bind(input.requested_at_ms)
         .bind(input.responded_at_ms)
         .bind(now)
@@ -1691,7 +1716,7 @@ impl SessionStorage for SqlxSessionStore {
         let row = sqlx::query_as::<_, LlmAuditRow>(
             "SELECT id, session_key, chat_id, turn_index, request_seq, provider, model, wire_api,
                     status, error_code, error_message, provider_request_id, provider_response_id,
-                    request_body_json, response_body_json, requested_at_ms, responded_at_ms, created_at_ms
+                    request_body_json, response_body_json, metadata_json, requested_at_ms, responded_at_ms, created_at_ms
              FROM llm_audit
              WHERE id = ?1",
         )
@@ -1713,7 +1738,7 @@ impl SessionStorage for SqlxSessionStore {
         let rows = sqlx::query_as::<_, LlmAuditRow>(&format!(
             "SELECT id, session_key, chat_id, turn_index, request_seq, provider, model, wire_api,
                     status, error_code, error_message, provider_request_id, provider_response_id,
-                    request_body_json, response_body_json, requested_at_ms, responded_at_ms, created_at_ms
+                    request_body_json, response_body_json, metadata_json, requested_at_ms, responded_at_ms, created_at_ms
              FROM llm_audit
              WHERE (?1 IS NULL OR session_key = ?1)
                AND (?2 IS NULL OR provider = ?2)

--- a/klaw-storage/src/backend/turso.rs
+++ b/klaw-storage/src/backend/turso.rs
@@ -126,6 +126,7 @@ impl TursoSessionStore {
                     provider_response_id TEXT,
                     request_body_json TEXT NOT NULL,
                     response_body_json TEXT,
+                    metadata_json TEXT,
                     requested_at_ms INTEGER NOT NULL,
                     responded_at_ms INTEGER,
                     created_at_ms INTEGER NOT NULL,
@@ -294,6 +295,8 @@ impl TursoSessionStore {
             .await?;
         self.ensure_session_column("delivery_metadata_json", "TEXT")
             .await?;
+        self.ensure_llm_audit_column("metadata_json", "TEXT")
+            .await?;
         self.ensure_session_column("compression_last_len", "INTEGER NOT NULL DEFAULT 0")
             .await?;
         self.ensure_session_column("compression_summary_json", "TEXT")
@@ -349,6 +352,32 @@ impl TursoSessionStore {
                 }
                 Err(StorageError::backend(format!(
                     "failed to ensure approvals.{column} column: {message}"
+                )))
+            }
+        }
+    }
+
+    async fn ensure_llm_audit_column(
+        &self,
+        column: &str,
+        column_type: &str,
+    ) -> Result<(), StorageError> {
+        let sql = format!("ALTER TABLE llm_audit ADD COLUMN {column} {column_type}");
+        let conn = self.connection().await?;
+        let result = conn.execute(&sql, ()).await;
+        match result {
+            Ok(_) => Ok(()),
+            Err(err) => {
+                let message = err.to_string();
+                if message.contains("duplicate column name")
+                    || message.contains("already exists")
+                    || message.contains("duplicate")
+                    || message.contains("no such table")
+                {
+                    return Ok(());
+                }
+                Err(StorageError::backend(format!(
+                    "failed to ensure llm_audit.{column} column: {message}"
                 )))
             }
         }
@@ -1085,8 +1114,8 @@ impl SessionStorage for TursoSessionStore {
             "INSERT INTO llm_audit (
                 id, session_key, chat_id, turn_index, request_seq, provider, model, wire_api,
                 status, error_code, error_message, provider_request_id, provider_response_id,
-                request_body_json, response_body_json, requested_at_ms, responded_at_ms, created_at_ms
-            ) VALUES ('{}', '{}', '{}', {}, {}, '{}', '{}', '{}', '{}', {}, {}, {}, {}, '{}', {}, {}, {}, {})",
+                request_body_json, response_body_json, metadata_json, requested_at_ms, responded_at_ms, created_at_ms
+            ) VALUES ('{}', '{}', '{}', {}, {}, '{}', '{}', '{}', '{}', {}, {}, {}, {}, '{}', {}, {}, {}, {}, {})",
             escape_sql_text(&input.id),
             escape_sql_text(&input.session_key),
             escape_sql_text(&input.chat_id),
@@ -1102,6 +1131,7 @@ impl SessionStorage for TursoSessionStore {
             opt_string_sql(input.provider_response_id.as_deref()),
             escape_sql_text(&input.request_body_json),
             opt_string_sql(input.response_body_json.as_deref()),
+            opt_sql_text(input.metadata_json.as_deref()),
             input.requested_at_ms,
             opt_i64_sql(input.responded_at_ms),
             now
@@ -1113,7 +1143,7 @@ impl SessionStorage for TursoSessionStore {
         let query_sql = format!(
             "SELECT id, session_key, chat_id, turn_index, request_seq, provider, model, wire_api,
                     status, error_code, error_message, provider_request_id, provider_response_id,
-                    request_body_json, response_body_json, requested_at_ms, responded_at_ms, created_at_ms
+                    request_body_json, response_body_json, metadata_json, requested_at_ms, responded_at_ms, created_at_ms
              FROM llm_audit
              WHERE id = '{}'
              LIMIT 1",
@@ -1170,7 +1200,7 @@ impl SessionStorage for TursoSessionStore {
         let sql = format!(
             "SELECT id, session_key, chat_id, turn_index, request_seq, provider, model, wire_api,
                     status, error_code, error_message, provider_request_id, provider_response_id,
-                    request_body_json, response_body_json, requested_at_ms, responded_at_ms, created_at_ms
+                    request_body_json, response_body_json, metadata_json, requested_at_ms, responded_at_ms, created_at_ms
              FROM llm_audit
              {where_clause}
              ORDER BY {sort_order}
@@ -2603,9 +2633,10 @@ fn row_to_llm_audit(row: &Row) -> Result<LlmAuditRecord, StorageError> {
         ),
         request_body_json: value_to_string(row.get_value(13).map_err(StorageError::backend)?)?,
         response_body_json: value_to_opt_string(row.get_value(14).map_err(StorageError::backend)?),
-        requested_at_ms: value_to_i64(row.get_value(15).map_err(StorageError::backend)?)?,
-        responded_at_ms: value_to_opt_i64(row.get_value(16).map_err(StorageError::backend)?)?,
-        created_at_ms: value_to_i64(row.get_value(17).map_err(StorageError::backend)?)?,
+        metadata_json: value_to_opt_string(row.get_value(15).map_err(StorageError::backend)?),
+        requested_at_ms: value_to_i64(row.get_value(16).map_err(StorageError::backend)?)?,
+        responded_at_ms: value_to_opt_i64(row.get_value(17).map_err(StorageError::backend)?)?,
+        created_at_ms: value_to_i64(row.get_value(18).map_err(StorageError::backend)?)?,
     })
 }
 

--- a/klaw-storage/src/lib.rs
+++ b/klaw-storage/src/lib.rs
@@ -394,6 +394,7 @@ mod tests {
                 provider_response_id: Some("resp-1".to_string()),
                 request_body_json: "{\"input\":\"hello\"}".to_string(),
                 response_body_json: Some("{\"output\":\"world\"}".to_string()),
+                metadata_json: Some("{\"sub_agent\":true}".to_string()),
                 requested_at_ms: 1_000,
                 responded_at_ms: Some(1_100),
             })
@@ -416,6 +417,7 @@ mod tests {
                 provider_response_id: None,
                 request_body_json: "{\"input\":\"retry\"}".to_string(),
                 response_body_json: None,
+                metadata_json: None,
                 requested_at_ms: 2_000,
                 responded_at_ms: Some(2_050),
             })
@@ -437,6 +439,7 @@ mod tests {
         assert_eq!(filtered.len(), 1);
         assert_eq!(filtered[0].id, "audit-2");
         assert_eq!(filtered[0].status, LlmAuditStatus::Failed);
+        assert_eq!(filtered[0].metadata_json, None);
 
         let descending = store
             .list_llm_audit(&LlmAuditQuery {
@@ -453,6 +456,10 @@ mod tests {
         assert_eq!(descending.len(), 2);
         assert_eq!(descending[0].id, "audit-2");
         assert_eq!(descending[1].id, "audit-1");
+        assert_eq!(
+            descending[1].metadata_json.as_deref(),
+            Some("{\"sub_agent\":true}")
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -484,6 +491,7 @@ mod tests {
                 provider_response_id: None,
                 request_body_json: "{}".to_string(),
                 response_body_json: Some("{}".to_string()),
+                metadata_json: None,
                 requested_at_ms: 1_000,
                 responded_at_ms: Some(1_100),
             })
@@ -506,6 +514,7 @@ mod tests {
                 provider_response_id: None,
                 request_body_json: "{}".to_string(),
                 response_body_json: Some("{}".to_string()),
+                metadata_json: None,
                 requested_at_ms: 2_000,
                 responded_at_ms: Some(2_100),
             })
@@ -528,6 +537,7 @@ mod tests {
                 provider_response_id: None,
                 request_body_json: "{}".to_string(),
                 response_body_json: None,
+                metadata_json: None,
                 requested_at_ms: 3_000,
                 responded_at_ms: Some(3_100),
             })

--- a/klaw-storage/src/types.rs
+++ b/klaw-storage/src/types.rs
@@ -198,6 +198,8 @@ pub struct LlmAuditRecord {
     pub provider_response_id: Option<String>,
     pub request_body_json: String,
     pub response_body_json: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata_json: Option<String>,
     pub requested_at_ms: i64,
     pub responded_at_ms: Option<i64>,
     pub created_at_ms: i64,
@@ -220,6 +222,7 @@ pub struct NewLlmAuditRecord {
     pub provider_response_id: Option<String>,
     pub request_body_json: String,
     pub response_body_json: Option<String>,
+    pub metadata_json: Option<String>,
     pub requested_at_ms: i64,
     pub responded_at_ms: Option<i64>,
 }

--- a/klaw-tool/CHANGELOG.md
+++ b/klaw-tool/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 - `shell`、`local_search` 与 `terminal_multiplexer` 在按命令名启动 `sh`/`rg`/`grep`/`tmux` 时现在会统一注入共享增强后的 PATH，改善 macOS GUI 启动下的外部命令发现能力
 - `sub_agent` now re-surfaces delegated `approval_required` / `stop` signals to the parent agent instead of swallowing them at the tool boundary
+- `sub_agent` now forwards delegated LLM audit payloads to the runtime audit sink so parent-session observability can include child agent model requests
 
 ## 2026-03-25
 

--- a/klaw-tool/README.md
+++ b/klaw-tool/README.md
@@ -26,7 +26,7 @@
 - the `cron_manager` tool supports a high-level `message` shortcut for scheduled prompts in the current conversation, auto-filling channel/chat/session defaults from tool context unless explicitly overridden
 - the `message` shortcut now defaults to an isolated cron session key like `cron:<job_id>` so scheduled runs do not silently accumulate the current chat's conversation history
 - the `heartbeat_manager` tool manages session-bound heartbeat jobs directly from storage, with session/channel/chat defaults inferred from current tool context when possible
-- sub-agent execution currently opts out of live streaming, inherits parent provider/model/system prompt and live tool availability, auto-generates an isolated child session key, and now re-surfaces delegated `approval_required` / `stop` signals back to the parent agent
+- sub-agent execution currently opts out of live streaming, inherits parent provider/model/system prompt and live tool availability, auto-generates an isolated child session key, re-surfaces delegated `approval_required` / `stop` signals back to the parent agent, and can forward delegated LLM audits through a runtime-provided sink
 - `skills_registry` now manages registry sources end to end: `add` persists `[skills.<source>]` into config, `sync` refreshes local mirrors, `delete` removes config + local clone + manifest state, and `list/show/search` browse synced registry skills
 - `skills_manager` owns installed-skill lifecycle actions, including `install_from_registry`
 - `local_search` uses `rg` first and falls back to BSD-compatible `grep` when ripgrep is not installed, while still honoring `include_pattern` and the default `.git` / `node_modules` exclusions

--- a/klaw-tool/src/lib.rs
+++ b/klaw-tool/src/lib.rs
@@ -30,7 +30,7 @@ pub use memory::MemoryTool;
 pub use shell::ShellTool;
 pub use skills_manager::SkillsManagerTool;
 pub use skills_registry::SkillsRegistryTool;
-pub use sub_agent::SubAgentTool;
+pub use sub_agent::{SubAgentAuditSink, SubAgentTool};
 pub use terminal_multiplexers::TerminalMultiplexerTool;
 pub use voice::VoiceTool;
 pub use web_fetch::WebFetchTool;

--- a/klaw-tool/src/sub_agent.rs
+++ b/klaw-tool/src/sub_agent.rs
@@ -25,6 +25,17 @@ pub struct SubAgentTool {
     config: Arc<AppConfig>,
     parent_tools: ToolRegistry,
     sub_config: SubAgentConfig,
+    audit_sink: Option<Arc<dyn SubAgentAuditSink>>,
+}
+
+#[async_trait]
+pub trait SubAgentAuditSink: Send + Sync {
+    async fn persist_sub_agent_audits(
+        &self,
+        parent_session_key: &str,
+        child_session_key: &str,
+        output: &AgentExecutionOutput,
+    ) -> Result<(), String>;
 }
 
 #[derive(Debug, Deserialize)]
@@ -37,10 +48,19 @@ struct SubAgentRequest {
 
 impl SubAgentTool {
     pub fn new(config: Arc<AppConfig>, parent_tools: ToolRegistry) -> Self {
+        Self::with_audit_sink(config, parent_tools, None)
+    }
+
+    pub fn with_audit_sink(
+        config: Arc<AppConfig>,
+        parent_tools: ToolRegistry,
+        audit_sink: Option<Arc<dyn SubAgentAuditSink>>,
+    ) -> Self {
         Self {
             sub_config: config.tools.sub_agent.clone(),
             config,
             parent_tools,
+            audit_sink,
         }
     }
 
@@ -321,6 +341,7 @@ impl Tool for SubAgentTool {
             tools: &child_tools,
         };
         let child_context = request.context.unwrap_or_else(|| json!({}));
+        let child_session_key = Self::build_child_session_key(&parent_session);
 
         let mut child_metadata = ctx.metadata.clone();
         child_metadata.insert(
@@ -338,7 +359,7 @@ impl Tool for SubAgentTool {
                 user_content: request.task,
                 user_media: Vec::new(),
                 conversation_history: Vec::new(),
-                session_key: Self::build_child_session_key(&parent_session),
+                session_key: child_session_key.clone(),
                 tool_metadata: child_metadata,
                 model: Some(model),
             },
@@ -361,6 +382,20 @@ impl Tool for SubAgentTool {
                 ToolError::ExecutionFailed("sub-agent exceeded token budget".to_string())
             }
         })?;
+
+        if let Some(audit_sink) = &self.audit_sink {
+            if let Err(err) = audit_sink
+                .persist_sub_agent_audits(&parent_session, &child_session_key, &output)
+                .await
+            {
+                debug!(
+                    parent_session = parent_session,
+                    child_session = child_session_key,
+                    error = %err,
+                    "failed to persist sub-agent audit records"
+                );
+            }
+        }
 
         Self::finalize_output(output)
     }


### PR DESCRIPTION
## Summary
- remove planner-provided `context.session` from `sub_agent` and bind delegated runs to the current tool session instead
- generate a unique child session key per delegated execution while preserving provider/model/system prompt/tool inheritance
- re-surface delegated `approval_required` and `stop` signals to the parent agent, and document the updated behavior

## Test plan
- [x] `cargo test -p klaw-tool`

Fixes #75

Made with [Cursor](https://cursor.com)