### PR TITLE
feat(cli): make /start create a new session

### DIFF
--- a/docs/src/channels/telegram.md
+++ b/docs/src/channels/telegram.md
@@ -29,8 +29,8 @@ url = "http://127.0.0.1:8888"
 - 会话键格式：`telegram:{account_id}:{chat_id}`
 - `chat_id` 直接使用 Telegram Bot API 的 chat id
 - 私聊和群聊都按 chat 级别建会话
-- `/new`、`/help`、`/model_provider`、`/model` 等通用命令仍由 runtime 统一处理
-- `/start` 会兼容映射到帮助页，适配 Telegram 机器人默认入口习惯
+- `/new`、`/start`、`/help`、`/model_provider`、`/model` 等通用命令仍由 runtime 统一处理
+- `/start` 会兼容映射到新会话流程，等同于 `/new`，适配 Telegram 机器人默认入口习惯
 
 ## 入站能力
 

--- a/klaw-channel/CHANGELOG.md
+++ b/klaw-channel/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 2026-03-27
+
+### Changed
+
+- `telegram` channel 注册的 `/start` bot command 现在与 runtime 里的新会话语义对齐，触发效果等同于 `/new`
+
 ## 2026-03-24
 
 ### Changed

--- a/klaw-channel/README.md
+++ b/klaw-channel/README.md
@@ -26,10 +26,10 @@
 ## IM Channel 适配契约
 
 - channel 只负责把平台消息规范化为 `ChannelRequest`（文本、chat_id、session_key）
-- 统一会话命令（`/new`、`/help`、`/model_provider`、`/model`）由 runtime 处理，不在 channel 层实现业务分支
+- 统一会话命令（`/new`、`/start`、`/help`、`/model_provider`、`/model`）由 runtime 处理，不在 channel 层实现业务分支
 - channel 仅消费 `ChannelResponse` 并回发，不持有 provider/model 路由策略
 - `dingtalk` 通道会在响应中检测 `approval_id` 并渲染 ActionCard，把卡片回调映射为 `/approve` 或 `/reject` 指令回送 runtime
-- `telegram` 通道现在使用目录模块拆分（`telegram/`），并提供 Telegram 专用 HTML 渲染、面向常见 Markdown 的格式映射（标题、引用、列表、链接、行内样式、代码块）、`/start` 兼容、图片/文件/音视频媒体入站、以及基于 inline keyboard 的审批回调
+- `telegram` 通道现在使用目录模块拆分（`telegram/`），并提供 Telegram 专用 HTML 渲染、面向常见 Markdown 的格式映射（标题、引用、列表、链接、行内样式、代码块）、`/start` 新会话兼容、图片/文件/音视频媒体入站、以及基于 inline keyboard 的审批回调
 
 ## Stdio Interaction
 

--- a/klaw-channel/src/telegram/mod.rs
+++ b/klaw-channel/src/telegram/mod.rs
@@ -104,7 +104,7 @@ impl TelegramChannel {
     async fn register_bot_commands(&self) -> ChannelResult<()> {
         self.client
             .set_my_commands(vec![
-                BotCommand::new("start", "Show help and available commands"),
+                BotCommand::new("start", "Start a new session context"),
                 BotCommand::new("help", "Show help and available commands"),
                 BotCommand::new("new", "Start a new session context"),
                 BotCommand::new("model_provider", "List or switch model providers"),

--- a/klaw-cli/CHANGELOG.md
+++ b/klaw-cli/CHANGELOG.md
@@ -114,7 +114,7 @@
 - `/approve <approval_id>` now returns a user-facing “already approved and executed” message for consumed shell approvals instead of exposing the internal `consumed` status word
 - `klaw gui` / `klaw gateway` 现在通过 `klaw-channel::ChannelManager` 托管 channel 生命周期，并统一用 `SyncChannels` 配置快照同步代替 dingtalk 专用重载逻辑
 - `klaw gui` / `klaw gateway` 现在也可通过同一 `ChannelManager` 生命周期层启动和同步 `telegram` channel 实例
-- IM 命令路由现在兼容 `/start`，会返回与 `/help` 相同的帮助内容，适配 Telegram 机器人默认入口
+- IM 命令路由现在兼容 `/start`，会执行与 `/new` 相同的新会话创建流程，适配 Telegram 机器人默认入口
 - `/new` 现在显式读取当前全局 active provider 及其默认模型创建新会话，不再继承当前会话里已持久化的 provider/model
 
 ## 2026-03-19

--- a/klaw-cli/README.md
+++ b/klaw-cli/README.md
@@ -60,7 +60,7 @@
 ## Runtime Integration
 
 - `stdio` 和 `gateway` 复用 runtime bundle 构建逻辑
-- runtime 内置通用 IM 会话命令路由：`/help`、`/stop`、`/new`、`/model-provider`、`/model`
+- runtime 内置通用 IM 会话命令路由：`/help`、`/stop`、`/new`、`/start`、`/model-provider`、`/model`
 - runtime 内置审批命令：`/approve <approval_id>`、`/reject <approval_id>`
 - runtime 审批命令与工具审批流统一通过 `klaw-approval` manager 层处理状态流转与消费
 - runtime 对 `approval_required` 工具结果会直接透传审批提示，不再包装成通用的 tool failure 文案

--- a/klaw-cli/src/runtime/mod.rs
+++ b/klaw-cli/src/runtime/mod.rs
@@ -1217,6 +1217,10 @@ fn render_help_text(runtime: &RuntimeBundle) -> String {
         "```text".to_string(),
     ];
     lines.push(format!("{:<24}{}", "/new", "Start a new session context"));
+    lines.push(format!(
+        "{:<24}{}",
+        "/start", "Alias of /new for a fresh session"
+    ));
     lines.push(format!("{:<24}{}", "/help", "Show this help"));
     lines.push(format!(
         "{:<24}{}",
@@ -1345,7 +1349,7 @@ async fn handle_im_command(
     };
     let route = resolve_session_route(runtime, &channel, &base_session_key, &chat_id).await?;
     let response = match command {
-        "help" | "start" => ChannelResponse {
+        "help" => ChannelResponse {
             content: render_help_text(runtime),
             reasoning: None,
             metadata: BTreeMap::new(),
@@ -1355,7 +1359,7 @@ async fn handle_im_command(
             reasoning: None,
             metadata: stopped_turn_metadata("manual stop command", "im_command"),
         },
-        "new" => {
+        "new" | "start" => {
             let new_session_key = format!("{base_session_key}:{}", Uuid::new_v4().simple());
             let (new_session_provider, new_session_model) = resolve_new_session_target(runtime);
             let sessions = session_manager(runtime);
@@ -3985,6 +3989,59 @@ A .docx file is a ZIP archive containing XML files.
             .unwrap_or_else(|err| err.into_inner())
             .clone();
         assert_eq!(tool_choice, Some(Value::String("required".to_string())));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn start_command_writes_bootstrap_user_message_into_new_session() {
+        let provider = Arc::new(BootstrapCaptureProvider::default());
+        let runtime = build_test_runtime(provider.clone()).await;
+        let channel = "telegram".to_string();
+        let base_session_key = "telegram:chat-start".to_string();
+        let chat_id = "chat-start".to_string();
+        let sessions = test_session_manager(&runtime);
+        sessions
+            .get_or_create_session_state(
+                &base_session_key,
+                &chat_id,
+                &channel,
+                "test-provider",
+                "test-model",
+            )
+            .await
+            .expect("base session should exist");
+
+        let response = handle_im_command(
+            &runtime,
+            channel.clone(),
+            base_session_key.clone(),
+            chat_id.clone(),
+            "/start".to_string(),
+            BTreeMap::new(),
+        )
+        .await
+        .expect("start command should succeed")
+        .expect("start command should return a response");
+
+        assert!(response.content.contains("New session started"));
+        assert!(response.content.contains("bootstrap reply"));
+
+        let route = resolve_session_route(&runtime, &channel, &base_session_key, &chat_id)
+            .await
+            .expect("start command route should resolve");
+        assert_ne!(route.active_session_key, base_session_key);
+
+        let new_history = sessions
+            .read_chat_records(&route.active_session_key)
+            .await
+            .expect("new session history should load");
+        assert_eq!(new_history.len(), 2);
+        assert_eq!(new_history[0].role, "user");
+        assert_eq!(
+            new_history[0].content,
+            build_new_session_bootstrap_user_message()
+        );
+        assert_eq!(new_history[1].role, "assistant");
+        assert_eq!(new_history[1].content, "bootstrap reply");
     }
 
     #[tokio::test(flavor = "current_thread")]


### PR DESCRIPTION
## Summary
- route `/start` through the same runtime new-session bootstrap flow as `/new`
- update Telegram bot command metadata so `/start` is described as starting a fresh session
- refresh CLI/channel/docs wording to document `/start` as the `/new` alias

## Test plan
- [x] `cargo test -p klaw-cli`
- [x] `cargo test -p klaw-channel`

Closes #87

Made with [Cursor](https://cursor.com)