### PR TITLE
fix(gui): align macOS tray and close behavior

### DIFF
--- a/klaw-gui/CHANGELOG.md
+++ b/klaw-gui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2026-03-28
 
+### Changed
+
+- macOS 顶部状态栏图标现在改为左键直接显示并激活主窗口、右键仅弹出 `About` / `Quit Klaw` 菜单；窗口关闭动作同时改为隐藏到状态栏而非直接退出
+
 ### Fixed
 
 - macOS `Settings > General > Launch at startup` now manages a real user `LaunchAgent`, only enables from the packaged `Klaw.app` bundle, and re-syncs stale login-item state on GUI startup

--- a/klaw-gui/README.md
+++ b/klaw-gui/README.md
@@ -14,11 +14,12 @@
 - Bottom status bar with version and theme-mode dropdown
   - Runtime provider override dropdown on the right (select from `model_providers` without editing config; applies immediately to the running runtime's default provider for new routes and `/new`)
 - System tray / macOS menu bar icon loaded from embedded PNG assets at runtime
-  - tray menu includes `Open Klaw`, `Settings`, `About`, and `Quit Klaw`
-  - `Settings` opens the in-app settings workbench
+  - macOS menu bar icon now uses left click to show and activate the main window
+  - right click opens a compact menu with `About` and `Quit Klaw`
 - UI state persistence across restart (`~/.klaw/gui_state.json`)
   - includes tabs/theme mode/light-dark theme presets/fullscreen and window size
 - macOS app icon is loaded from embedded image bytes at startup, so both `.app` bundles and standalone binaries keep the custom icon
+- macOS window close requests now hide the app to the menu bar instead of quitting; tray `Quit Klaw` remains the explicit full-exit path
 - macOS `Launch at startup` now provisions a user `LaunchAgent` from the packaged `.app` bundle and re-syncs stale login-item state on startup
 - System CJK font fallback via `fontdb` to avoid Chinese text missing-glyph rendering
 - Strongly typed menu model for workspace modules

--- a/klaw-gui/src/app/mod.rs
+++ b/klaw-gui/src/app/mod.rs
@@ -1,10 +1,10 @@
-use crate::domain::menu::WorkbenchMenu;
 use crate::runtime_bridge::request_set_provider_override;
 use crate::state::persistence;
 use crate::state::{UiAction, UiState, WindowSize};
 use crate::theme;
 use crate::tray::{self, TrayCommand, TrayIntegration};
 use crate::ui::shell::ShellUi;
+use crate::{hide_macos_app, show_macos_app};
 use std::time::{Duration, Instant};
 
 const UI_STATE_SAVE_DEBOUNCE: Duration = Duration::from_millis(500);
@@ -12,9 +12,8 @@ const UI_STATE_SAVE_DEBOUNCE: Duration = Duration::from_millis(500);
 fn tray_command_ui_action(command: TrayCommand) -> Option<UiAction> {
     match command {
         TrayCommand::OpenKlaw => None,
-        TrayCommand::OpenSettings => Some(UiAction::OpenMenu(WorkbenchMenu::Setting)),
         TrayCommand::ShowAbout => Some(UiAction::ShowAbout),
-        TrayCommand::QuitKlaw => Some(UiAction::CloseWindow),
+        TrayCommand::QuitKlaw => Some(UiAction::QuitApp),
     }
 }
 
@@ -24,6 +23,7 @@ pub struct KlawGuiApp {
     tray: Option<TrayIntegration>,
     state_dirty: bool,
     last_state_save_at: Instant,
+    should_quit: bool,
 }
 
 impl KlawGuiApp {
@@ -35,6 +35,7 @@ impl KlawGuiApp {
             tray: tray::install(&creation_ctx.egui_ctx).ok().flatten(),
             state_dirty: false,
             last_state_save_at: Instant::now(),
+            should_quit: false,
         };
         theme::install_fonts(&creation_ctx.egui_ctx);
         theme::apply_theme(&creation_ctx.egui_ctx, &app.state);
@@ -54,8 +55,12 @@ impl KlawGuiApp {
 
     fn handle_action(&mut self, ctx: &egui::Context, action: UiAction) {
         match action {
-            UiAction::CloseWindow => {
+            UiAction::HideWindow => {
+                self.hide_window(ctx);
+            }
+            UiAction::QuitApp => {
                 self.save_state_now();
+                self.should_quit = true;
                 ctx.send_viewport_cmd(egui::ViewportCommand::Close);
             }
             UiAction::ForcePersistLayout => {
@@ -110,6 +115,19 @@ impl KlawGuiApp {
         }
     }
 
+    fn show_window(&self, ctx: &egui::Context) {
+        show_macos_app();
+        ctx.send_viewport_cmd(egui::ViewportCommand::Visible(true));
+        ctx.send_viewport_cmd(egui::ViewportCommand::Minimized(false));
+        ctx.send_viewport_cmd(egui::ViewportCommand::Focus);
+    }
+
+    fn hide_window(&mut self, ctx: &egui::Context) {
+        self.save_state_now();
+        ctx.send_viewport_cmd(egui::ViewportCommand::Visible(false));
+        hide_macos_app();
+    }
+
     fn mark_state_dirty(&mut self) {
         self.state_dirty = true;
     }
@@ -132,19 +150,10 @@ impl KlawGuiApp {
     fn handle_tray_command(&mut self, ctx: &egui::Context, command: TrayCommand) {
         match command {
             TrayCommand::OpenKlaw => {
-                ctx.send_viewport_cmd(egui::ViewportCommand::Visible(true));
-                ctx.send_viewport_cmd(egui::ViewportCommand::Minimized(false));
-                ctx.send_viewport_cmd(egui::ViewportCommand::Focus);
-            }
-            TrayCommand::OpenSettings => {
-                ctx.send_viewport_cmd(egui::ViewportCommand::Visible(true));
-                ctx.send_viewport_cmd(egui::ViewportCommand::Minimized(false));
-                ctx.send_viewport_cmd(egui::ViewportCommand::Focus);
+                self.show_window(ctx);
             }
             TrayCommand::ShowAbout => {
-                ctx.send_viewport_cmd(egui::ViewportCommand::Visible(true));
-                ctx.send_viewport_cmd(egui::ViewportCommand::Minimized(false));
-                ctx.send_viewport_cmd(egui::ViewportCommand::Focus);
+                self.show_window(ctx);
             }
             TrayCommand::QuitKlaw => {}
         }
@@ -214,7 +223,12 @@ impl eframe::App for KlawGuiApp {
 
         let close_requested = ctx.input(|input| input.viewport().close_requested());
         if close_requested {
-            self.save_state_now();
+            if self.should_quit {
+                self.save_state_now();
+            } else {
+                ctx.send_viewport_cmd(egui::ViewportCommand::CancelClose);
+                self.hide_window(ctx);
+            }
         }
     }
 }
@@ -222,17 +236,8 @@ impl eframe::App for KlawGuiApp {
 #[cfg(test)]
 mod tests {
     use super::tray_command_ui_action;
-    use crate::domain::menu::WorkbenchMenu;
     use crate::state::UiAction;
     use crate::tray::TrayCommand;
-
-    #[test]
-    fn tray_settings_command_opens_setting_menu() {
-        assert_eq!(
-            tray_command_ui_action(TrayCommand::OpenSettings),
-            Some(UiAction::OpenMenu(WorkbenchMenu::Setting))
-        );
-    }
 
     #[test]
     fn tray_about_and_quit_commands_keep_expected_actions() {
@@ -242,7 +247,7 @@ mod tests {
         );
         assert_eq!(
             tray_command_ui_action(TrayCommand::QuitKlaw),
-            Some(UiAction::CloseWindow)
+            Some(UiAction::QuitApp)
         );
         assert_eq!(tray_command_ui_action(TrayCommand::OpenKlaw), None);
     }

--- a/klaw-gui/src/lib.rs
+++ b/klaw-gui/src/lib.rs
@@ -83,3 +83,38 @@ fn install_macos_app_icon() {
         app.setApplicationIconImage(Some(&icon));
     }
 }
+
+#[cfg(target_os = "macos")]
+pub(crate) fn show_macos_app() {
+    use objc2_app_kit::{NSApplication, NSApplicationActivationPolicy};
+    use objc2_foundation::MainThreadMarker;
+
+    let Some(mtm) = MainThreadMarker::new() else {
+        return;
+    };
+
+    let app = NSApplication::sharedApplication(mtm);
+    unsafe {
+        app.setActivationPolicy(NSApplicationActivationPolicy::Regular);
+        app.activate();
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn show_macos_app() {}
+
+#[cfg(target_os = "macos")]
+pub(crate) fn hide_macos_app() {
+    use objc2_app_kit::{NSApplication, NSApplicationActivationPolicy};
+    use objc2_foundation::MainThreadMarker;
+
+    let Some(mtm) = MainThreadMarker::new() else {
+        return;
+    };
+
+    let app = NSApplication::sharedApplication(mtm);
+    app.setActivationPolicy(NSApplicationActivationPolicy::Accessory);
+}
+
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn hide_macos_app() {}

--- a/klaw-gui/src/state/mod.rs
+++ b/klaw-gui/src/state/mod.rs
@@ -12,7 +12,8 @@ pub enum UiAction {
     CloseTab(TabId),
     SetRuntimeProviderOverride(Option<String>),
     SetThemeMode(ThemeMode),
-    CloseWindow,
+    HideWindow,
+    QuitApp,
     ForcePersistLayout,
     ToggleFullscreen,
     MinimizeWindow,
@@ -170,7 +171,8 @@ impl UiState {
             UiAction::HideAbout => {
                 self.show_about = false;
             }
-            UiAction::CloseWindow
+            UiAction::HideWindow
+            | UiAction::QuitApp
             | UiAction::ForcePersistLayout
             | UiAction::MinimizeWindow
             | UiAction::ZoomWindow

--- a/klaw-gui/src/state/workbench.rs
+++ b/klaw-gui/src/state/workbench.rs
@@ -60,7 +60,8 @@ impl WorkbenchState {
             UiAction::CloseTab(tab_id) => self.close(tab_id),
             UiAction::SetRuntimeProviderOverride(_)
             | UiAction::SetThemeMode(_)
-            | UiAction::CloseWindow
+            | UiAction::HideWindow
+            | UiAction::QuitApp
             | UiAction::ForcePersistLayout
             | UiAction::ToggleFullscreen
             | UiAction::MinimizeWindow

--- a/klaw-gui/src/tray.rs
+++ b/klaw-gui/src/tray.rs
@@ -2,19 +2,16 @@ use crate::icon;
 use anyhow::Context;
 use std::sync::mpsc::{self, Receiver};
 use tray_icon::{
-    TrayIcon,
+    MouseButton, MouseButtonState, TrayIcon, TrayIconEvent,
     menu::{Menu, MenuEvent, MenuItem, PredefinedMenuItem},
 };
 
-const MENU_OPEN_KLAW_ID: &str = "tray.open_klaw";
-const MENU_OPEN_SETTINGS_ID: &str = "tray.open_settings";
 const MENU_SHOW_ABOUT_ID: &str = "tray.show_about";
 const MENU_QUIT_KLAW_ID: &str = "tray.quit_klaw";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TrayCommand {
     OpenKlaw,
-    OpenSettings,
     ShowAbout,
     QuitKlaw,
 }
@@ -30,6 +27,8 @@ pub fn install(egui_ctx: &egui::Context) -> anyhow::Result<Option<TrayIntegratio
     let menu = build_tray_menu()?;
     let (command_tx, command_rx) = mpsc::channel();
     let repaint_ctx = egui_ctx.clone();
+    let tray_click_tx = command_tx.clone();
+    let tray_click_repaint_ctx = repaint_ctx.clone();
 
     MenuEvent::set_event_handler(Some(move |event: MenuEvent| {
         if let Some(command) = tray_command_for_menu_id(event.id().0.as_str()) {
@@ -38,11 +37,18 @@ pub fn install(egui_ctx: &egui::Context) -> anyhow::Result<Option<TrayIntegratio
         }
     }));
 
+    TrayIconEvent::set_event_handler(Some(move |event: TrayIconEvent| {
+        if let Some(command) = tray_command_for_icon_event(event) {
+            let _ = tray_click_tx.send(command);
+            tray_click_repaint_ctx.request_repaint();
+        }
+    }));
+
     let tray_icon = tray_icon::TrayIconBuilder::new()
         .with_tooltip("Klaw")
         .with_menu(Box::new(menu))
         .with_icon(icon)
-        .with_menu_on_left_click(true)
+        .with_menu_on_left_click(false)
         .build()
         .context("failed to create tray icon")?;
 
@@ -58,30 +64,31 @@ fn load_tray_icon() -> anyhow::Result<tray_icon::Icon> {
 
 fn build_tray_menu() -> anyhow::Result<Menu> {
     let menu = Menu::new();
-    let open_item = MenuItem::with_id(MENU_OPEN_KLAW_ID, "Open Klaw", true, None);
-    let settings_item = MenuItem::with_id(MENU_OPEN_SETTINGS_ID, "Setting", true, None);
     let about_item = MenuItem::with_id(MENU_SHOW_ABOUT_ID, "About", true, None);
     let quit_item = MenuItem::with_id(MENU_QUIT_KLAW_ID, "Quit Klaw", true, None);
     let separator = PredefinedMenuItem::separator();
 
-    menu.append_items(&[
-        &open_item,
-        &settings_item,
-        &about_item,
-        &separator,
-        &quit_item,
-    ])
-    .context("failed to build tray menu")?;
+    menu.append_items(&[&about_item, &separator, &quit_item])
+        .context("failed to build tray menu")?;
 
     Ok(menu)
 }
 
 fn tray_command_for_menu_id(menu_id: &str) -> Option<TrayCommand> {
     match menu_id {
-        MENU_OPEN_KLAW_ID => Some(TrayCommand::OpenKlaw),
-        MENU_OPEN_SETTINGS_ID => Some(TrayCommand::OpenSettings),
         MENU_SHOW_ABOUT_ID => Some(TrayCommand::ShowAbout),
         MENU_QUIT_KLAW_ID => Some(TrayCommand::QuitKlaw),
+        _ => None,
+    }
+}
+
+fn tray_command_for_icon_event(event: TrayIconEvent) -> Option<TrayCommand> {
+    match event {
+        TrayIconEvent::Click {
+            button: MouseButton::Left,
+            button_state: MouseButtonState::Up,
+            ..
+        } => Some(TrayCommand::OpenKlaw),
         _ => None,
     }
 }
@@ -89,20 +96,14 @@ fn tray_command_for_menu_id(menu_id: &str) -> Option<TrayCommand> {
 #[cfg(test)]
 mod tests {
     use super::{
-        MENU_OPEN_KLAW_ID, MENU_OPEN_SETTINGS_ID, MENU_QUIT_KLAW_ID, MENU_SHOW_ABOUT_ID,
-        TrayCommand, tray_command_for_menu_id,
+        MENU_QUIT_KLAW_ID, MENU_SHOW_ABOUT_ID, TrayCommand, tray_command_for_icon_event,
+        tray_command_for_menu_id,
     };
+    use tray_icon::dpi::{PhysicalPosition, PhysicalSize};
+    use tray_icon::{MouseButton, MouseButtonState, Rect, TrayIconEvent, TrayIconId};
 
     #[test]
     fn tray_menu_ids_map_to_expected_commands() {
-        assert_eq!(
-            tray_command_for_menu_id(MENU_OPEN_KLAW_ID),
-            Some(TrayCommand::OpenKlaw)
-        );
-        assert_eq!(
-            tray_command_for_menu_id(MENU_OPEN_SETTINGS_ID),
-            Some(TrayCommand::OpenSettings)
-        );
         assert_eq!(
             tray_command_for_menu_id(MENU_SHOW_ABOUT_ID),
             Some(TrayCommand::ShowAbout)
@@ -112,5 +113,40 @@ mod tests {
             Some(TrayCommand::QuitKlaw)
         );
         assert_eq!(tray_command_for_menu_id("tray.unknown"), None);
+    }
+
+    #[test]
+    fn left_click_release_opens_klaw() {
+        let event = TrayIconEvent::Click {
+            id: TrayIconId::new("klaw"),
+            position: PhysicalPosition::new(0.0, 0.0),
+            rect: Rect {
+                position: PhysicalPosition::new(0.0, 0.0),
+                size: PhysicalSize::new(16_u32, 16_u32),
+            },
+            button: MouseButton::Left,
+            button_state: MouseButtonState::Up,
+        };
+
+        assert_eq!(
+            tray_command_for_icon_event(event),
+            Some(TrayCommand::OpenKlaw)
+        );
+    }
+
+    #[test]
+    fn non_left_click_release_does_not_open_klaw() {
+        let event = TrayIconEvent::Click {
+            id: TrayIconId::new("klaw"),
+            position: PhysicalPosition::new(0.0, 0.0),
+            rect: Rect {
+                position: PhysicalPosition::new(0.0, 0.0),
+                size: PhysicalSize::new(16_u32, 16_u32),
+            },
+            button: MouseButton::Right,
+            button_state: MouseButtonState::Up,
+        };
+
+        assert_eq!(tray_command_for_icon_event(event), None);
     }
 }

--- a/klaw-gui/src/ui/shell.rs
+++ b/klaw-gui/src/ui/shell.rs
@@ -124,8 +124,8 @@ impl ShellUi {
                         ui.close();
                     }
                     ui.separator();
-                    if ui.button("Close Windows").clicked() {
-                        actions.push(UiAction::CloseWindow);
+                    if ui.button("Hide Window").clicked() {
+                        actions.push(UiAction::HideWindow);
                         ui.close();
                     }
                 });
@@ -165,12 +165,8 @@ impl ShellUi {
                     egui::vec2(ui.available_width(), row_height),
                     egui::Layout::right_to_left(egui::Align::Center),
                     |ui| {
-                        if ui
-                            .button(regular::X)
-                            .on_hover_text("Close Window")
-                            .clicked()
-                        {
-                            actions.push(UiAction::CloseWindow);
+                        if ui.button(regular::X).on_hover_text("Hide Window").clicked() {
+                            actions.push(UiAction::HideWindow);
                         }
 
                         let zoom_icon = if state.fullscreen {


### PR DESCRIPTION
## Summary
- split GUI window actions into hide vs quit so macOS close requests now hide the window instead of exiting the app
- update the macOS menu bar integration so left click restores and activates Klaw while right click shows a compact `About` / `Quit Klaw` menu
- document the new tray-first behavior in `klaw-gui` crate docs and changelog

## Test plan
- [x] `cargo test -p klaw-gui`
- [x] `cargo check --workspace`

Fixes #93

Made with [Cursor](https://cursor.com)