### PR TITLE
fix(gui): remove panel revision labels

### DIFF
--- a/klaw-gui/src/panels/channel.rs
+++ b/klaw-gui/src/panels/channel.rs
@@ -253,7 +253,6 @@ impl ChannelRow {
 #[derive(Default)]
 pub struct ChannelPanel {
     store: Option<ConfigStore>,
-    revision: Option<u64>,
     config: AppConfig,
     form: Option<ChannelForm>,
     show_disabled_dialog: bool,
@@ -281,7 +280,6 @@ impl ChannelPanel {
     }
 
     fn apply_snapshot(&mut self, snapshot: ConfigSnapshot) {
-        self.revision = Some(snapshot.revision);
         self.disable_session_commands_input = ArrayEditor::from_vec(
             "Disable Session Commands For",
             &snapshot.config.channels.disable_session_commands_for,
@@ -827,7 +825,6 @@ impl PanelRenderer for ChannelPanel {
 
         ui.heading(ctx.tab_title);
         ui.horizontal(|ui| {
-            ui.label(format!("Revision: {}", self.revision.unwrap_or_default()));
             ui.label(format!("Channel instances: {}", rows.len()));
         });
         ui.separator();

--- a/klaw-gui/src/panels/configuration.rs
+++ b/klaw-gui/src/panels/configuration.rs
@@ -17,7 +17,6 @@ pub struct ConfigurationPanel {
     config_path: Option<PathBuf>,
     editor_raw: String,
     saved_raw: String,
-    revision: Option<u64>,
     pending_confirm: Option<ConfirmAction>,
 }
 
@@ -43,7 +42,6 @@ impl ConfigurationPanel {
         self.config_path = Some(snapshot.path);
         self.editor_raw = snapshot.raw_toml.clone();
         self.saved_raw = snapshot.raw_toml;
-        self.revision = Some(snapshot.revision);
     }
 
     fn is_dirty(&self) -> bool {
@@ -370,7 +368,6 @@ impl PanelRenderer for ConfigurationPanel {
             ui.heading(ctx.tab_title);
             ui.label(Self::status_label(this.config_path.as_deref()));
             ui.horizontal(|ui| {
-                ui.label(format!("Revision: {}", this.revision.unwrap_or_default()));
                 let dirty = this.is_dirty();
                 let dirty_label = if dirty { "Dirty: yes" } else { "Dirty: no" };
                 let color = if dirty {

--- a/klaw-gui/src/panels/mcp.rs
+++ b/klaw-gui/src/panels/mcp.rs
@@ -109,7 +109,6 @@ struct McpServerDetailWindow {
 #[derive(Default)]
 pub struct McpPanel {
     store: Option<ConfigStore>,
-    revision: Option<u64>,
     config: AppConfig,
     form: Option<McpServerForm>,
     global_settings_form: Option<String>,
@@ -143,7 +142,6 @@ impl McpPanel {
     }
 
     fn apply_snapshot(&mut self, snapshot: ConfigSnapshot) {
-        self.revision = Some(snapshot.revision);
         self.config = snapshot.config;
     }
 
@@ -606,7 +604,6 @@ impl PanelRenderer for McpPanel {
 
         ui.heading(ctx.tab_title);
         ui.horizontal(|ui| {
-            ui.label(format!("Revision: {}", self.revision.unwrap_or_default()));
             ui.label(format!("Servers: {}", self.config.mcp.servers.len()));
             if self.sync_fetch_rx.is_some() {
                 ui.spinner();

--- a/klaw-gui/src/panels/memory.rs
+++ b/klaw-gui/src/panels/memory.rs
@@ -72,7 +72,6 @@ pub struct MemoryPanel {
     stats: Option<MemoryStats>,
     store: Option<ConfigStore>,
     config_path: Option<PathBuf>,
-    revision: Option<u64>,
     config: AppConfig,
     form: Option<MemoryConfigForm>,
 }
@@ -112,7 +111,6 @@ impl MemoryPanel {
 
     fn apply_snapshot(&mut self, snapshot: ConfigSnapshot) {
         self.config_path = Some(snapshot.path);
-        self.revision = Some(snapshot.revision);
         self.config = snapshot.config;
     }
 
@@ -193,7 +191,6 @@ impl MemoryPanel {
             .show(ui.ctx(), |ui| {
                 ui.set_min_width(420.0);
                 ui.label(Self::status_label(self.config_path.as_deref()));
-                ui.label(format!("Revision: {}", self.revision.unwrap_or_default()));
                 ui.separator();
 
                 egui::Grid::new("memory-config-grid")

--- a/klaw-gui/src/panels/provider.rs
+++ b/klaw-gui/src/panels/provider.rs
@@ -96,7 +96,6 @@ impl ProviderForm {
 #[derive(Default)]
 pub struct ProviderPanel {
     store: Option<ConfigStore>,
-    revision: Option<u64>,
     config: AppConfig,
     runtime_status: Option<ProviderRuntimeSnapshot>,
     last_runtime_status_at: Option<Instant>,
@@ -137,7 +136,6 @@ impl ProviderPanel {
     }
 
     fn apply_snapshot(&mut self, snapshot: ConfigSnapshot) {
-        self.revision = Some(snapshot.revision);
         self.config = snapshot.config;
     }
 
@@ -496,7 +494,6 @@ impl PanelRenderer for ProviderPanel {
 
         ui.heading(ctx.tab_title);
         ui.horizontal(|ui| {
-            ui.label(format!("Revision: {}", self.revision.unwrap_or_default()));
             ui.colored_label(
                 egui::Color32::LIGHT_GREEN,
                 format!("Config default: {}", self.config.model_provider),

--- a/klaw-gui/src/panels/skills_manager.rs
+++ b/klaw-gui/src/panels/skills_manager.rs
@@ -26,7 +26,6 @@ struct InstallSkillWindow {
 
 pub struct SkillsManagerPanel {
     config_store: Option<ConfigStore>,
-    revision: Option<u64>,
     config: AppConfig,
     skill_root: Option<PathBuf>,
     loaded: bool,
@@ -44,7 +43,6 @@ impl Default for SkillsManagerPanel {
     fn default() -> Self {
         Self {
             config_store: None,
-            revision: None,
             config: AppConfig::default(),
             skill_root: None,
             loaded: false,
@@ -82,7 +80,6 @@ impl SkillsManagerPanel {
     }
 
     fn apply_snapshot(&mut self, snapshot: ConfigSnapshot) {
-        self.revision = Some(snapshot.revision);
         self.config = snapshot.config;
     }
 
@@ -740,7 +737,6 @@ impl PanelRenderer for SkillsManagerPanel {
 
         ui.heading(ctx.tab_title);
         ui.horizontal(|ui| {
-            ui.label(format!("Revision: {}", self.revision.unwrap_or_default()));
             ui.label(format!("Installed: {}", self.items.len()));
             ui.label(format!(
                 "Registries: {}",

--- a/klaw-gui/src/panels/skills_registry.rs
+++ b/klaw-gui/src/panels/skills_registry.rs
@@ -68,7 +68,6 @@ impl SkillsRegistryForm {
 #[derive(Default)]
 pub struct SkillsRegistryPanel {
     store: Option<ConfigStore>,
-    revision: Option<u64>,
     config: AppConfig,
     form: Option<SkillsRegistryForm>,
     config_window_open: bool,
@@ -104,7 +103,6 @@ impl SkillsRegistryPanel {
     }
 
     fn apply_snapshot(&mut self, snapshot: ConfigSnapshot) {
-        self.revision = Some(snapshot.revision);
         self.sync_timeout_text = snapshot.config.skills.sync_timeout.to_string();
         self.config = snapshot.config;
     }
@@ -535,7 +533,6 @@ impl PanelRenderer for SkillsRegistryPanel {
 
         ui.heading(ctx.tab_title);
         ui.horizontal(|ui| {
-            ui.label(format!("Revision: {}", self.revision.unwrap_or_default()));
             ui.label(format!(
                 "Registries: {}",
                 self.config.skills.registries.len()

--- a/klaw-gui/src/panels/tool.rs
+++ b/klaw-gui/src/panels/tool.rs
@@ -23,7 +23,6 @@ use tokio::runtime::Builder;
 
 pub struct ToolPanel {
     store: Option<ConfigStore>,
-    revision: Option<u64>,
     config: AppConfig,
     form: Option<ToolForm>,
     runtime_definitions: Vec<ToolDefinition>,
@@ -190,7 +189,6 @@ impl Default for ToolPanel {
         let one_month_ago = today - chrono::Duration::days(30);
         Self {
             store: None,
-            revision: None,
             config: AppConfig::default(),
             form: None,
             runtime_definitions: Vec::new(),
@@ -479,7 +477,6 @@ impl ToolPanel {
     }
 
     fn apply_snapshot(&mut self, snapshot: ConfigSnapshot) {
-        self.revision = Some(snapshot.revision);
         self.config = snapshot.config;
     }
 
@@ -1630,7 +1627,6 @@ impl PanelRenderer for ToolPanel {
 
         ui.heading(ctx.tab_title);
         ui.horizontal(|ui| {
-            ui.label(format!("Revision: {}", self.revision.unwrap_or_default()));
             ui.label("Manage tool enablement and per-tool settings.");
             if ui.button("Reload").clicked() {
                 self.reload(notifications);


### PR DESCRIPTION
Fixes #102

## Summary
- remove `Revision` labels from GUI panel headers and related config views
- drop panel-local `revision` state that only existed to render those labels
- keep config revision persistence logic unchanged

## Test plan
- [x] `cargo check -p klaw-gui`

Made with [Cursor](https://cursor.com)