### PR TITLE
feat(cron): add missed run policy

### DIFF
--- a/klaw-cli/CHANGELOG.md
+++ b/klaw-cli/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - runtime shutdown 现在会同时关闭 MCP server 和 ACP agent manager，避免外部 agent 生命周期泄漏
 - ACP proxy tool 现在会实际通过 stdio 调起外部 ACP agent，并代理文件读写、终端与权限请求所需的客户端能力
+- 后台 cron runtime 现在会读取 `cron.missed_run_policy`；默认按 `skip` 跳过停机期间错过的执行窗口，只有显式配置 `catch_up` 时才会逐次补偿
 
 ## 2026-03-29
 

--- a/klaw-cli/src/runtime/service_loop.rs
+++ b/klaw-cli/src/runtime/service_loop.rs
@@ -1,9 +1,9 @@
 use super::{RuntimeBundle, drain_runtime_queue};
 use klaw_channel::dingtalk::{DingtalkProxyConfig, send_session_webhook_markdown_via_proxy};
 use klaw_channel::telegram::dispatch_background_outbound as dispatch_telegram_background_outbound;
-use klaw_config::AppConfig;
+use klaw_config::{AppConfig, CronMissedRunPolicy};
 use klaw_core::{Envelope, InboundMessage, OutboundMessage};
-use klaw_cron::{CronWorker, CronWorkerConfig};
+use klaw_cron::{CronWorker, CronWorkerConfig, MissedRunPolicy};
 use klaw_heartbeat::{HeartbeatWorker, HeartbeatWorkerConfig};
 use klaw_storage::DefaultSessionStore;
 use std::{
@@ -27,6 +27,7 @@ pub struct BackgroundServiceConfig {
     pub runtime_tick_interval: Duration,
     pub runtime_drain_batch: usize,
     pub cron_batch_limit: i64,
+    pub cron_missed_run_policy: MissedRunPolicy,
     pub dingtalk_titles: BTreeMap<String, String>,
     pub dingtalk_proxies: BTreeMap<String, DingtalkProxyConfig>,
     pub telegram_configs: BTreeMap<String, klaw_config::TelegramConfig>,
@@ -39,6 +40,10 @@ impl BackgroundServiceConfig {
             runtime_tick_interval: Duration::from_millis(config.cron.runtime_tick_ms),
             runtime_drain_batch: config.cron.runtime_drain_batch,
             cron_batch_limit: config.cron.batch_limit,
+            cron_missed_run_policy: match config.cron.missed_run_policy {
+                CronMissedRunPolicy::Skip => MissedRunPolicy::Skip,
+                CronMissedRunPolicy::CatchUp => MissedRunPolicy::CatchUp,
+            },
             dingtalk_titles: config
                 .channels
                 .dingtalk
@@ -76,6 +81,7 @@ impl Default for BackgroundServiceConfig {
             runtime_tick_interval: Duration::from_millis(200),
             runtime_drain_batch: 8,
             cron_batch_limit: 64,
+            cron_missed_run_policy: MissedRunPolicy::Skip,
             dingtalk_titles: BTreeMap::new(),
             dingtalk_proxies: BTreeMap::new(),
             telegram_configs: BTreeMap::new(),
@@ -101,6 +107,7 @@ impl BackgroundServices {
             CronWorkerConfig {
                 poll_interval: Duration::from_secs(1),
                 batch_limit: config.cron_batch_limit,
+                missed_run_policy: config.cron_missed_run_policy,
             },
         );
         let heartbeat_worker = HeartbeatWorker::new(

--- a/klaw-config/CHANGELOG.md
+++ b/klaw-config/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - 默认 ACP agent 模板现在预填两套 Zed adapter：`npx -y @zed-industries/claude-agent-acp` 与 `npx -y @zed-industries/codex-acp`
 - ACP agent 配置不再持久化独立 `cwd`；实际运行目录统一由调用时传入的 `working_directory` 决定
+- `cron` 配置新增 `missed_run_policy`，默认值为 `skip`，用于控制服务停机后重启时是否补偿错过的定时触发
 
 ## 2026-03-29
 

--- a/klaw-config/src/lib.rs
+++ b/klaw-config/src/lib.rs
@@ -1551,6 +1551,8 @@ pub struct CronConfig {
     pub runtime_drain_batch: usize,
     #[serde(default = "default_cron_batch_limit")]
     pub batch_limit: i64,
+    #[serde(default)]
+    pub missed_run_policy: CronMissedRunPolicy,
 }
 
 impl Default for CronConfig {
@@ -1560,8 +1562,17 @@ impl Default for CronConfig {
             runtime_tick_ms: default_cron_runtime_tick_ms(),
             runtime_drain_batch: default_cron_runtime_drain_batch(),
             batch_limit: default_cron_batch_limit(),
+            missed_run_policy: CronMissedRunPolicy::default(),
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum CronMissedRunPolicy {
+    #[default]
+    Skip,
+    CatchUp,
 }
 
 fn default_cron_tick_ms() -> u64 {

--- a/klaw-config/src/tests.rs
+++ b/klaw-config/src/tests.rs
@@ -103,6 +103,10 @@ fn parse_default_template_succeeds() {
     assert_eq!(parsed.cron.runtime_tick_ms, 200);
     assert_eq!(parsed.cron.runtime_drain_batch, 8);
     assert_eq!(parsed.cron.batch_limit, 64);
+    assert_eq!(
+        parsed.cron.missed_run_policy,
+        crate::CronMissedRunPolicy::Skip
+    );
     assert!(parsed.heartbeat.defaults.enabled);
     assert_eq!(parsed.heartbeat.defaults.every, "30m");
     assert_eq!(parsed.heartbeat.defaults.silent_ack_token, "HEARTBEAT_OK");
@@ -143,6 +147,14 @@ fn parse_default_template_succeeds() {
     assert!(!parsed.gateway.webhook.agents.enabled);
     assert_eq!(parsed.gateway.webhook.agents.max_body_bytes, 262_144);
     validate(&parsed).expect("default template should be valid");
+}
+
+#[test]
+fn parse_cron_missed_run_policy_override() {
+    let parsed: CronConfig =
+        toml::from_str("missed_run_policy = \"catch_up\"").expect("cron config should parse");
+    assert_eq!(parsed.missed_run_policy, CronMissedRunPolicy::CatchUp);
+    assert_eq!(parsed.tick_ms, 1_000);
 }
 
 #[test]

--- a/klaw-cron/CHANGELOG.md
+++ b/klaw-cron/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 2026-03-30
+
+### Changed
+
+- `CronWorker` 新增 `MissedRunPolicy`；默认 `Skip` 会在服务恢复后直接跳到当前时间之后的下一次触发，显式启用 `CatchUp` 时才会逐次补偿停机期间错过的执行点
+
 ## 2026-03-29
 
 ### Fixed

--- a/klaw-cron/src/lib.rs
+++ b/klaw-cron/src/lib.rs
@@ -8,4 +8,4 @@ pub use error::CronError;
 pub use klaw_storage::{CronJob, CronScheduleKind, CronTaskRun, NewCronJob, UpdateCronJobPatch};
 pub use manager::{CronListQuery, SqliteCronManager};
 pub use schedule::ScheduleSpec;
-pub use worker::{CronWorker, CronWorkerConfig};
+pub use worker::{CronWorker, CronWorkerConfig, MissedRunPolicy};

--- a/klaw-cron/src/worker.rs
+++ b/klaw-cron/src/worker.rs
@@ -8,6 +8,7 @@ use uuid::Uuid;
 pub struct CronWorkerConfig {
     pub poll_interval: Duration,
     pub batch_limit: i64,
+    pub missed_run_policy: MissedRunPolicy,
 }
 
 impl Default for CronWorkerConfig {
@@ -15,8 +16,16 @@ impl Default for CronWorkerConfig {
         Self {
             poll_interval: Duration::from_secs(1),
             batch_limit: 64,
+            missed_run_policy: MissedRunPolicy::default(),
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum MissedRunPolicy {
+    #[default]
+    Skip,
+    CatchUp,
 }
 
 #[derive(Clone)]
@@ -49,8 +58,12 @@ where
 
         for job in due_jobs {
             let schedule = ScheduleSpec::from_job(&job)?;
+            let next_run_seed_ms = match self.config.missed_run_policy {
+                MissedRunPolicy::Skip => now,
+                MissedRunPolicy::CatchUp => job.next_run_at_ms,
+            };
             let next_run_at_ms =
-                schedule.next_run_after_ms_in_timezone(job.next_run_at_ms, &job.timezone)?;
+                schedule.next_run_after_ms_in_timezone(next_run_seed_ms, &job.timezone)?;
             let claimed = self
                 .storage
                 .claim_next_run(&job.id, job.next_run_at_ms, next_run_at_ms, now)
@@ -253,7 +266,8 @@ fn infer_telegram_base_session_key(session_key: &str, chat_id: &str) -> Option<S
 #[cfg(test)]
 mod tests {
     use super::{
-        CronWorker, CronWorkerConfig, infer_base_session_key, infer_dingtalk_base_session_key,
+        CronWorker, CronWorkerConfig, MissedRunPolicy, infer_base_session_key,
+        infer_dingtalk_base_session_key,
         infer_telegram_base_session_key,
     };
     use crate::time::now_ms;
@@ -1018,10 +1032,21 @@ mod tests {
         storage: &Arc<FakeStorage>,
         transport: &Arc<TestTransport>,
     ) -> CronWorker<FakeStorage, TestTransport> {
+        test_worker_with_policy(storage, transport, MissedRunPolicy::Skip)
+    }
+
+    fn test_worker_with_policy(
+        storage: &Arc<FakeStorage>,
+        transport: &Arc<TestTransport>,
+        missed_run_policy: MissedRunPolicy,
+    ) -> CronWorker<FakeStorage, TestTransport> {
         CronWorker::new(
             storage.clone(),
             transport.clone(),
-            CronWorkerConfig::default(),
+            CronWorkerConfig {
+                missed_run_policy,
+                ..CronWorkerConfig::default()
+            },
         )
     }
 
@@ -1080,11 +1105,68 @@ mod tests {
             .await
             .expect("create job");
 
-        let worker = test_worker(&storage, &transport);
+        let worker = test_worker_with_policy(&storage, &transport, MissedRunPolicy::CatchUp);
         worker.run_tick().await.expect("tick");
 
         let job = storage.get_cron("job-tz").await.expect("job");
         assert_eq!(job.next_run_at_ms, 3_600_000);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn run_tick_skips_missed_runs_by_default() {
+        let storage = Arc::new(FakeStorage::default());
+        let transport = Arc::new(InMemoryTransport::new());
+        let overdue_next_run_at_ms = now_ms().saturating_sub(60_000);
+        insert_job_with_next_run(
+            &storage,
+            "job-skip",
+            "cron",
+            "cron:chat1",
+            "{}",
+            overdue_next_run_at_ms,
+        )
+        .await;
+
+        let before_tick = now_ms();
+        let worker = test_worker(&storage, &transport);
+        worker.run_tick().await.expect("tick");
+
+        let job = storage.get_cron("job-skip").await.expect("job");
+        assert!(job.next_run_at_ms >= before_tick + 5_000);
+        assert!(job.next_run_at_ms > overdue_next_run_at_ms + 5_000);
+
+        let runs = storage.list_task_runs("job-skip", 10, 0).await.expect("runs");
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].scheduled_at_ms, overdue_next_run_at_ms);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn run_tick_can_catch_up_missed_runs_when_enabled() {
+        let storage = Arc::new(FakeStorage::default());
+        let transport = Arc::new(InMemoryTransport::new());
+        let overdue_next_run_at_ms = now_ms().saturating_sub(60_000);
+        insert_job_with_next_run(
+            &storage,
+            "job-catch-up",
+            "cron",
+            "cron:chat1",
+            "{}",
+            overdue_next_run_at_ms,
+        )
+        .await;
+
+        let worker = test_worker_with_policy(&storage, &transport, MissedRunPolicy::CatchUp);
+        worker.run_tick().await.expect("tick");
+
+        let job = storage.get_cron("job-catch-up").await.expect("job");
+        assert_eq!(job.next_run_at_ms, overdue_next_run_at_ms + 5_000);
+
+        let runs = storage
+            .list_task_runs("job-catch-up", 10, 0)
+            .await
+            .expect("runs");
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].scheduled_at_ms, overdue_next_run_at_ms);
     }
 
     #[tokio::test(flavor = "current_thread")]


### PR DESCRIPTION
Closes #114

## Summary
- add `cron.missed_run_policy` with `skip` and `catch_up` modes, defaulting to `skip`
- thread the configured policy through the CLI background runtime into `CronWorker`
- add regression tests for default skip behavior and explicit catch-up behavior, and update changelogs

## Test plan
- [x] `cargo test -p klaw-config --lib`
- [x] `cargo test -p klaw-cron --lib`
- [x] `cargo check -p klaw-cli`

## Risk
- changes the default restart behavior for cron missed runs from implicit catch-up to explicit opt-in catch-up
- existing users who rely on historical replay will need to set `cron.missed_run_policy = \"catch_up\"`

Made with [Cursor](https://cursor.com)