### PR TITLE
feat(gui): adopt egui_json_tree for shared payload views

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2057,6 +2057,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "egui_json_tree"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "235458e8aa8e72fe5177842c8f162270a2eb887fdc66d39c25e4e3cdaa7262af"
+dependencies = [
+ "egui",
+ "serde_json",
+]
+
+[[package]]
 name = "egui_plot"
 version = "0.34.1"
 source = "git+https://github.com/emilk/egui_plot?rev=445273e7edbb338d300b0e9e6c351d003f37a5a8#445273e7edbb338d300b0e9e6c351d003f37a5a8"
@@ -3934,6 +3944,7 @@ dependencies = [
  "egui-notify",
  "egui-phosphor",
  "egui_extras",
+ "egui_json_tree",
  "egui_plot",
  "fontdb",
  "hostname",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ base64 = "0.22"
 anyhow = "1"
 egui = "0.33.3"
 eframe = "0.33.3"
+egui_json_tree = "0.14.2"
 catppuccin-egui = { version = "5.7.0", default-features = false, features = ["egui33"] }
 egui-file-dialog = "0.12.0"
 egui-phosphor = "0.11.0"

--- a/klaw-gui/CHANGELOG.md
+++ b/klaw-gui/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- GUI 共享 `json tree` widget 已切换为 `egui_json_tree 0.14.2`，`LLM Audit Detail` 与 `Tool Logs` 等所有复用展示统一使用第三方交互式 JSON 树渲染
 - `About Klaw` 弹窗现改为居中标题布局，展示内嵌应用图标、当前版本、构建时写入的 git commit sha，以及仓库 GitHub 地址
 - `klaw-gui` 新增 crate 级 `build.rs`，在编译时把当前 `HEAD` commit sha 注入到 GUI 程序变量中供 `About` 弹窗显示
 

--- a/klaw-gui/Cargo.toml
+++ b/klaw-gui/Cargo.toml
@@ -9,6 +9,7 @@ anyhow = { workspace = true }
 catppuccin-egui = { workspace = true }
 eframe = { workspace = true }
 egui = { workspace = true }
+egui_json_tree = { workspace = true }
 egui-file-dialog = { workspace = true }
 egui-phosphor = { workspace = true }
 egui_extras = { workspace = true, features = ["chrono"] }

--- a/klaw-gui/src/widgets/json_tree.rs
+++ b/klaw-gui/src/widgets/json_tree.rs
@@ -1,69 +1,9 @@
+use egui_json_tree::JsonTree;
+
 pub fn show_json_tree(ui: &mut egui::Ui, value: &serde_json::Value) {
     show_json_tree_with_id(ui, value, "$");
 }
 
 pub fn show_json_tree_with_id(ui: &mut egui::Ui, value: &serde_json::Value, root_id: &str) {
-    show_json_value(ui, "root", value, root_id);
-}
-
-fn show_json_value(ui: &mut egui::Ui, label: &str, value: &serde_json::Value, path: &str) {
-    match value {
-        serde_json::Value::Object(map) => {
-            let header = format!("{label} {{}} ({})", map.len());
-            egui::CollapsingHeader::new(header)
-                .id_salt(path)
-                .default_open(false)
-                .show(ui, |ui| {
-                    if map.is_empty() {
-                        ui.monospace("{}");
-                    }
-                    for (key, child) in map {
-                        show_json_value(ui, key, child, &format!("{path}.{key}"));
-                    }
-                });
-        }
-        serde_json::Value::Array(items) => {
-            let header = format!("{label} [] ({})", items.len());
-            egui::CollapsingHeader::new(header)
-                .id_salt(path)
-                .default_open(false)
-                .show(ui, |ui| {
-                    if items.is_empty() {
-                        ui.monospace("[]");
-                    }
-                    for (index, child) in items.iter().enumerate() {
-                        show_json_value(
-                            ui,
-                            &format!("[{index}]"),
-                            child,
-                            &format!("{path}[{index}]"),
-                        );
-                    }
-                });
-        }
-        serde_json::Value::String(text) => {
-            ui.horizontal_wrapped(|ui| {
-                ui.strong(label);
-                ui.monospace(format!("\"{text}\""));
-            });
-        }
-        serde_json::Value::Number(number) => {
-            ui.horizontal(|ui| {
-                ui.strong(label);
-                ui.monospace(number.to_string());
-            });
-        }
-        serde_json::Value::Bool(boolean) => {
-            ui.horizontal(|ui| {
-                ui.strong(label);
-                ui.monospace(boolean.to_string());
-            });
-        }
-        serde_json::Value::Null => {
-            ui.horizontal(|ui| {
-                ui.strong(label);
-                ui.monospace("null");
-            });
-        }
-    }
+    JsonTree::new(root_id, value).show(ui);
 }


### PR DESCRIPTION
## Summary
- replace the shared GUI JSON tree widget with `egui_json_tree 0.14.2`, which stays compatible with the existing `egui 0.33.3` workspace
- update all shared JSON payload views, including `LLM Audit Detail` and `Tool Logs`, by keeping the existing wrapper API and swapping its internals
- record the GUI dependency change in the crate changelog

Fixes #130

## Test plan
- [x] `cargo check -p klaw-gui`
- [x] Manual GUI verification of `LLM Audit Detail`
- [x] Manual GUI verification of `Tool Logs` JSON sections

Made with [Cursor](https://cursor.com)