### PR TITLE
feat(gui): add workspace terminal panel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,6 +214,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "alacritty_terminal"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46319972e74179d707445f64aaa2893bbf6a111de3a9af29b7eb382f8b39e282"
+dependencies = [
+ "base64 0.22.1",
+ "bitflags 2.11.0",
+ "home",
+ "libc",
+ "log",
+ "miow",
+ "parking_lot",
+ "piper",
+ "polling",
+ "regex-automata",
+ "rustix 1.1.4",
+ "rustix-openpty",
+ "serde",
+ "signal-hook",
+ "unicode-width 0.2.2",
+ "vte",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2100,6 +2125,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "egui_term"
+version = "0.1.0"
+source = "git+https://github.com/Harzu/egui_term?rev=ececa84ef6d228036b89b93b10979c17017dcfa0#ececa84ef6d228036b89b93b10979c17017dcfa0"
+dependencies = [
+ "alacritty_terminal",
+ "anyhow",
+ "egui",
+ "open",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3614,6 +3650,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3970,6 +4025,7 @@ dependencies = [
  "egui_extras",
  "egui_json_tree",
  "egui_plot",
+ "egui_term",
  "fontdb",
  "hostname",
  "hound",
@@ -4607,6 +4663,15 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "miow"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
+dependencies = [
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5286,6 +5351,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "open"
+version = "5.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "opendal"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5560,6 +5636,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pem-rfc7468"
@@ -6496,6 +6578,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix-openpty"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de16c7c59892b870a6336f185dc10943517f1327447096bbb7bb32cd85e2393"
+dependencies = [
+ "errno",
+ "libc",
+ "rustix 1.1.4",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6781,6 +6874,16 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -8470,6 +8573,20 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vte"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5924018406ce0063cd67f8e008104968b74b563ee1b85dde3ed1f7cb87d3dbd"
+dependencies = [
+ "arrayvec",
+ "bitflags 2.11.0",
+ "cursor-icon",
+ "log",
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ base64 = "0.22"
 anyhow = "1"
 egui = "0.33.3"
 eframe = "0.33.3"
+egui_term = { git = "https://github.com/Harzu/egui_term", rev = "ececa84ef6d228036b89b93b10979c17017dcfa0" }
 egui_commonmark = { version = "0.22.0", default-features = false, features = ["pulldown_cmark"] }
 egui_json_tree = "0.14.2"
 catppuccin-egui = { version = "5.7.0", default-features = false, features = ["egui33"] }

--- a/klaw-gui/CHANGELOG.md
+++ b/klaw-gui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2026-03-31
 
+### Added
+
+- GUI `WORKSPACE` 分组新增 `Terminal` 一级面板，基于 `egui_term` 在 workbench 内嵌本地 shell 终端，并提供 Start / Restart / Stop 控制、默认 workspace 工作目录和 shell 退出提示
+
 ### Changed
 
 - GUI markdown 编辑高亮已抽成共享 `widgets::markdown` 模块，`Profile Prompt`、`Webhook` 和 `Skills Manager` 中的 markdown `TextEdit` 现在统一复用同一套 layouter
@@ -9,6 +13,7 @@
 - GUI 共享 `json tree` widget 已切换为 `egui_json_tree 0.14.2`，`LLM Audit Detail` 与 `Tool Logs` 等所有复用展示统一使用第三方交互式 JSON 树渲染
 - `About Klaw` 弹窗现改为居中标题布局，展示内嵌应用图标、当前版本、构建时写入的 git commit sha，以及仓库 GitHub 地址
 - `klaw-gui` 新增 crate 级 `build.rs`，在编译时把当前 `HEAD` commit sha 注入到 GUI 程序变量中供 `About` 弹窗显示
+- GUI workbench 的 panel registry 现在支持 tab 关闭回调，`Terminal` tab 关闭时会主动释放 PTY 会话，避免后台 shell 在面板关闭后继续存活
 
 ## 2026-03-30
 

--- a/klaw-gui/Cargo.toml
+++ b/klaw-gui/Cargo.toml
@@ -9,6 +9,7 @@ anyhow = { workspace = true }
 catppuccin-egui = { workspace = true }
 eframe = { workspace = true }
 egui = { workspace = true }
+egui_term = { workspace = true }
 egui_commonmark = { workspace = true }
 egui_json_tree = { workspace = true }
 egui-file-dialog = { workspace = true }

--- a/klaw-gui/README.md
+++ b/klaw-gui/README.md
@@ -6,7 +6,7 @@
 
 - Workbench shell with left navigation and center tab workspace
 - Left navigation groups sidebar menus by domain and sorts items alphabetically within each group
-- Workbench sidebar now includes `System` and `Settings`
+- Workbench sidebar now includes `System`, `Settings`, and `Terminal`
 - Workbench sidebar now includes dedicated `Gateway` and `Webhook` panels
 - Workbench sidebar now includes a dedicated `Voice` panel for voice config editing and split STT/TTS testing
 - Top menu bar (File/View/Window/Help)
@@ -29,6 +29,7 @@
 - Workbench panel renderers for:
   - profile (workspace markdown doc cards + editor window + runtime system prompt preview)
   - configuration
+  - terminal (embedded `egui_term` PTY view with start/restart/stop controls, default workspace working directory, and tab-close cleanup)
   - model provider (config-bound list + add/edit window)
   - channel (config-bound list + add/edit window)
   - voice (config-bound voice settings + split STT/TTS test workspace)
@@ -163,6 +164,7 @@
 - `ui/`: shell/sidebar/workbench composition
 - `panels/`: module-specific workbench panels
   - includes `logs` panel backed by a non-blocking runtime log chunk bridge
+  - includes `terminal` panel backed by `egui_term` and a lazily started local PTY session
 - `widgets/`: shared reusable UI widgets
   - includes shared markdown helpers for code-style `TextEdit` layouters and CommonMark rich rendering
 - `theme.rs`: centralized theme setup

--- a/klaw-gui/src/app/mod.rs
+++ b/klaw-gui/src/app/mod.rs
@@ -100,7 +100,8 @@ impl KlawGuiApp {
                     return;
                 }
                 let requested_provider_id = provider_id.clone();
-                self.shell.set_pending_provider_override(provider_id.clone());
+                self.shell
+                    .set_pending_provider_override(provider_id.clone());
                 self.pending_provider_override = Some(PendingProviderOverride {
                     requested_provider_id,
                     request: begin_set_provider_override_request(provider_id),
@@ -109,9 +110,13 @@ impl KlawGuiApp {
             UiAction::ShowAbout
             | UiAction::HideAbout
             | UiAction::OpenMenu(_)
-            | UiAction::ActivateTab(_)
-            | UiAction::CloseTab(_) => {
+            | UiAction::ActivateTab(_) => {
                 self.state.apply(action);
+                self.mark_state_dirty();
+            }
+            UiAction::CloseTab(tab_id) => {
+                self.shell.handle_tab_closed(tab_id);
+                self.state.apply(UiAction::CloseTab(tab_id));
                 self.mark_state_dirty();
             }
         }

--- a/klaw-gui/src/domain/menu.rs
+++ b/klaw-gui/src/domain/menu.rs
@@ -38,6 +38,7 @@ pub enum WorkbenchMenu {
     Profile,
     System,
     Setting,
+    Terminal,
     Session,
     Approval,
     Configuration,
@@ -64,10 +65,11 @@ pub enum WorkbenchMenu {
 }
 
 impl WorkbenchMenu {
-    pub const ALL: [WorkbenchMenu; 25] = [
+    pub const ALL: [WorkbenchMenu; 26] = [
         WorkbenchMenu::Profile,
         WorkbenchMenu::System,
         WorkbenchMenu::Setting,
+        WorkbenchMenu::Terminal,
         WorkbenchMenu::Session,
         WorkbenchMenu::Approval,
         WorkbenchMenu::Configuration,
@@ -97,6 +99,7 @@ impl WorkbenchMenu {
             WorkbenchMenu::Profile => "profile",
             WorkbenchMenu::System => "system",
             WorkbenchMenu::Setting => "setting",
+            WorkbenchMenu::Terminal => "terminal",
             WorkbenchMenu::Session => "session",
             WorkbenchMenu::Approval => "approval",
             WorkbenchMenu::Configuration => "configuration",
@@ -127,6 +130,7 @@ impl WorkbenchMenu {
             WorkbenchMenu::Profile => "Profile Prompt",
             WorkbenchMenu::System => "System",
             WorkbenchMenu::Setting => "Settings",
+            WorkbenchMenu::Terminal => "Terminal",
             WorkbenchMenu::Session => "Session",
             WorkbenchMenu::Approval => "Approval",
             WorkbenchMenu::Configuration => "Configuration",
@@ -157,6 +161,7 @@ impl WorkbenchMenu {
             WorkbenchMenu::Profile => regular::USER_CIRCLE,
             WorkbenchMenu::System => regular::DATABASE,
             WorkbenchMenu::Setting => regular::GEAR,
+            WorkbenchMenu::Terminal => regular::TERMINAL,
             WorkbenchMenu::Session => regular::USERS,
             WorkbenchMenu::Approval => regular::SEAL_CHECK,
             WorkbenchMenu::Configuration => regular::TOOLBOX,
@@ -191,6 +196,7 @@ impl WorkbenchMenu {
             WorkbenchMenu::Profile
             | WorkbenchMenu::System
             | WorkbenchMenu::Setting
+            | WorkbenchMenu::Terminal
             | WorkbenchMenu::Configuration => WorkbenchMenuGroup::Workspace,
             WorkbenchMenu::Provider
             | WorkbenchMenu::Llm
@@ -271,6 +277,17 @@ mod tests {
     fn voice_menu_is_registered() {
         assert!(WorkbenchMenu::ALL.contains(&WorkbenchMenu::Voice));
         assert_eq!(WorkbenchMenu::Voice.id_key(), "voice");
+    }
+
+    #[test]
+    fn terminal_menu_is_registered() {
+        assert!(WorkbenchMenu::ALL.contains(&WorkbenchMenu::Terminal));
+        assert_eq!(WorkbenchMenu::Terminal.id_key(), "terminal");
+        assert_eq!(WorkbenchMenu::Terminal.title(), "Terminal");
+        assert_eq!(
+            WorkbenchMenu::Terminal.group(),
+            WorkbenchMenuGroup::Workspace
+        );
     }
 
     #[test]

--- a/klaw-gui/src/panels/mod.rs
+++ b/klaw-gui/src/panels/mod.rs
@@ -20,6 +20,7 @@ mod setting;
 mod skills_manager;
 mod skills_registry;
 mod system;
+mod terminal;
 mod tool;
 mod voice;
 mod webhook;
@@ -39,6 +40,8 @@ pub trait PanelRenderer {
         ctx: &RenderCtx<'_>,
         notifications: &mut NotificationCenter,
     );
+
+    fn on_tab_closed(&mut self) {}
 }
 
 #[derive(Default)]
@@ -46,6 +49,7 @@ pub struct PanelRegistry {
     profile: profile::ProfilePanel,
     system: system::SystemPanel,
     setting: setting::SettingPanel,
+    terminal: terminal::TerminalPanel,
     session: session::SessionPanel,
     approval: approval::ApprovalPanel,
     acp: acp::AcpPanel,
@@ -85,6 +89,7 @@ impl PanelRegistry {
             WorkbenchMenu::Profile => self.profile.render(ui, ctx, notifications),
             WorkbenchMenu::System => self.system.render(ui, ctx, notifications),
             WorkbenchMenu::Setting => self.setting.render(ui, ctx, notifications),
+            WorkbenchMenu::Terminal => self.terminal.render(ui, ctx, notifications),
             WorkbenchMenu::Session => self.session.render(ui, ctx, notifications),
             WorkbenchMenu::Approval => self.approval.render(ui, ctx, notifications),
             WorkbenchMenu::Acp => self.acp.render(ui, ctx, notifications),
@@ -109,6 +114,37 @@ impl PanelRegistry {
                 self.analyze_dashboard.render(ui, ctx, notifications)
             }
             WorkbenchMenu::Observability => self.observability.render(ui, ctx, notifications),
+        }
+    }
+
+    pub fn handle_tab_closed(&mut self, menu: WorkbenchMenu) {
+        match menu {
+            WorkbenchMenu::Profile => self.profile.on_tab_closed(),
+            WorkbenchMenu::System => self.system.on_tab_closed(),
+            WorkbenchMenu::Setting => self.setting.on_tab_closed(),
+            WorkbenchMenu::Terminal => self.terminal.on_tab_closed(),
+            WorkbenchMenu::Session => self.session.on_tab_closed(),
+            WorkbenchMenu::Approval => self.approval.on_tab_closed(),
+            WorkbenchMenu::Configuration => self.configuration.on_tab_closed(),
+            WorkbenchMenu::Provider => self.provider.on_tab_closed(),
+            WorkbenchMenu::Llm => self.llm.on_tab_closed(),
+            WorkbenchMenu::Channel => self.channel.on_tab_closed(),
+            WorkbenchMenu::Voice => self.voice.on_tab_closed(),
+            WorkbenchMenu::Cron => self.cron.on_tab_closed(),
+            WorkbenchMenu::Heartbeat => self.heartbeat.on_tab_closed(),
+            WorkbenchMenu::Gateway => self.gateway.on_tab_closed(),
+            WorkbenchMenu::Webhook => self.webhook.on_tab_closed(),
+            WorkbenchMenu::Mcp => self.mcp.on_tab_closed(),
+            WorkbenchMenu::Acp => self.acp.on_tab_closed(),
+            WorkbenchMenu::Skill => self.skills_registry.on_tab_closed(),
+            WorkbenchMenu::SkillsManager => self.skills_manager.on_tab_closed(),
+            WorkbenchMenu::Memory => self.memory.on_tab_closed(),
+            WorkbenchMenu::Archive => self.archive.on_tab_closed(),
+            WorkbenchMenu::Tool => self.tool.on_tab_closed(),
+            WorkbenchMenu::Monitor => self.monitor.on_tab_closed(),
+            WorkbenchMenu::Logs => self.logs.on_tab_closed(),
+            WorkbenchMenu::AnalyzeDashboard => self.analyze_dashboard.on_tab_closed(),
+            WorkbenchMenu::Observability => self.observability.on_tab_closed(),
         }
     }
 }

--- a/klaw-gui/src/panels/terminal.rs
+++ b/klaw-gui/src/panels/terminal.rs
@@ -1,0 +1,226 @@
+use crate::notifications::NotificationCenter;
+use crate::panels::{PanelRenderer, RenderCtx};
+use egui_term::{BackendSettings, PtyEvent, TerminalBackend, TerminalView};
+use klaw_util::default_workspace_dir;
+use std::fs;
+use std::path::PathBuf;
+use std::sync::mpsc::{self, Receiver};
+
+const TERMINAL_ID: u64 = 0;
+const MIN_TERMINAL_HEIGHT: f32 = 220.0;
+
+struct TerminalSession {
+    backend: TerminalBackend,
+    event_rx: Receiver<(u64, PtyEvent)>,
+    pty_id: u32,
+    shell: String,
+    working_directory: PathBuf,
+}
+
+#[derive(Default)]
+pub struct TerminalPanel {
+    session: Option<TerminalSession>,
+    start_error: Option<String>,
+    exit_notice: Option<String>,
+}
+
+impl TerminalPanel {
+    fn ensure_session(&mut self, ctx: &egui::Context, notifications: &mut NotificationCenter) {
+        if self.session.is_some() || self.start_error.is_some() {
+            return;
+        }
+
+        if let Err(err) = self.start_session(ctx) {
+            self.start_error = Some(err.clone());
+            notifications.error(format!("Failed to start terminal: {err}"));
+        }
+    }
+
+    fn start_session(&mut self, ctx: &egui::Context) -> Result<(), String> {
+        let working_directory = resolve_working_directory()?;
+        let shell = default_shell();
+        let (event_tx, event_rx) = mpsc::channel();
+        let backend = TerminalBackend::new(
+            TERMINAL_ID,
+            ctx.clone(),
+            event_tx,
+            BackendSettings {
+                shell: shell.clone(),
+                args: Vec::new(),
+                working_directory: Some(working_directory.clone()),
+            },
+        )
+        .map_err(|err| err.to_string())?;
+        let pty_id = backend.pty_id();
+
+        self.exit_notice = None;
+        self.start_error = None;
+        self.session = Some(TerminalSession {
+            backend,
+            event_rx,
+            pty_id,
+            shell,
+            working_directory,
+        });
+        Ok(())
+    }
+
+    fn restart_session(&mut self, ctx: &egui::Context, notifications: &mut NotificationCenter) {
+        self.stop_session();
+        match self.start_session(ctx) {
+            Ok(()) => notifications.success("Terminal restarted"),
+            Err(err) => {
+                self.start_error = Some(err.clone());
+                notifications.error(format!("Failed to restart terminal: {err}"));
+            }
+        }
+    }
+
+    fn stop_session(&mut self) {
+        self.session = None;
+    }
+
+    fn poll_events(&mut self, notifications: &mut NotificationCenter) {
+        let mut exited = false;
+        while let Some(session) = self.session.as_mut() {
+            match session.event_rx.try_recv() {
+                Ok((_, PtyEvent::Exit)) => {
+                    exited = true;
+                    break;
+                }
+                Ok(_) => {}
+                Err(mpsc::TryRecvError::Empty) => break,
+                Err(mpsc::TryRecvError::Disconnected) => {
+                    exited = true;
+                    break;
+                }
+            }
+        }
+
+        if exited {
+            self.stop_session();
+            self.exit_notice =
+                Some("Shell exited. Start or restart the terminal to continue.".into());
+            notifications.info("Terminal shell exited");
+        }
+    }
+
+    fn render_toolbar(
+        &mut self,
+        ui: &mut egui::Ui,
+        notifications: &mut NotificationCenter,
+        ctx: &egui::Context,
+    ) {
+        let running = self.session.is_some();
+        ui.horizontal(|ui| {
+            if ui
+                .add_enabled(!running, egui::Button::new("Start"))
+                .clicked()
+            {
+                self.start_error = None;
+                self.ensure_session(ctx, notifications);
+            }
+            if ui.button("Restart").clicked() {
+                self.restart_session(ctx, notifications);
+            }
+            if ui.add_enabled(running, egui::Button::new("Stop")).clicked() {
+                self.stop_session();
+                self.exit_notice = Some("Terminal stopped.".to_string());
+                notifications.info("Terminal stopped");
+            }
+        });
+    }
+}
+
+impl PanelRenderer for TerminalPanel {
+    fn render(
+        &mut self,
+        ui: &mut egui::Ui,
+        ctx: &RenderCtx<'_>,
+        notifications: &mut NotificationCenter,
+    ) {
+        let egui_ctx = ui.ctx().clone();
+        self.ensure_session(&egui_ctx, notifications);
+        self.poll_events(notifications);
+
+        ui.heading(ctx.tab_title);
+        self.render_toolbar(ui, notifications, &egui_ctx);
+        ui.separator();
+
+        if let Some(session) = &self.session {
+            ui.horizontal_wrapped(|ui| {
+                ui.label("Shell:");
+                ui.monospace(&session.shell);
+                ui.separator();
+                ui.label("PTY:");
+                ui.monospace(session.pty_id.to_string());
+                ui.separator();
+                ui.label("Working Directory:");
+                ui.monospace(session.working_directory.display().to_string());
+            });
+            ui.add_space(8.0);
+        } else if let Some(message) = &self.exit_notice {
+            ui.label(message);
+            ui.add_space(8.0);
+        }
+
+        if let Some(message) = &self.start_error {
+            ui.colored_label(ui.visuals().error_fg_color, message);
+            return;
+        }
+
+        let Some(session) = self.session.as_mut() else {
+            ui.label("Terminal is not running.");
+            return;
+        };
+
+        let terminal_size = egui::vec2(
+            ui.available_width(),
+            ui.available_height().max(MIN_TERMINAL_HEIGHT),
+        );
+        let terminal = TerminalView::new(ui, &mut session.backend)
+            .set_focus(true)
+            .set_size(terminal_size);
+        ui.add(terminal);
+    }
+
+    fn on_tab_closed(&mut self) {
+        self.stop_session();
+        self.exit_notice = Some("Terminal closed with the tab.".to_string());
+        self.start_error = None;
+    }
+}
+
+fn resolve_working_directory() -> Result<PathBuf, String> {
+    if let Some(workspace_dir) = default_workspace_dir() {
+        fs::create_dir_all(&workspace_dir).map_err(|err| {
+            format!(
+                "failed to create workspace dir {}: {err}",
+                workspace_dir.display()
+            )
+        })?;
+        return Ok(workspace_dir);
+    }
+
+    std::env::current_dir().map_err(|err| format!("failed to resolve current directory: {err}"))
+}
+
+fn default_shell() -> String {
+    #[cfg(unix)]
+    {
+        if let Some(shell) = std::env::var_os("SHELL").filter(|shell| !shell.is_empty()) {
+            return shell.to_string_lossy().into_owned();
+        }
+        for fallback in ["/bin/zsh", "/bin/bash", "/bin/sh"] {
+            if std::path::Path::new(fallback).exists() {
+                return fallback.to_string();
+            }
+        }
+        "/bin/sh".to_string()
+    }
+
+    #[cfg(windows)]
+    {
+        "cmd.exe".to_string()
+    }
+}

--- a/klaw-gui/src/ui/shell.rs
+++ b/klaw-gui/src/ui/shell.rs
@@ -6,6 +6,7 @@ use crate::runtime_bridge::{
     ProviderRuntimeSnapshot, RuntimeRequestHandle, begin_provider_status_request,
 };
 use crate::settings::{AppSettings, SyncMode, load_settings, save_settings};
+use crate::state::workbench::TabId;
 use crate::state::{ThemeMode, UiAction, UiState};
 use crate::sync_runtime::{
     SyncRuntimeTaskKind, sync_runtime_finish_task, sync_runtime_set_last_snapshot,
@@ -105,6 +106,10 @@ impl ShellUi {
 
     pub fn clear_pending_provider_override(&mut self) {
         self.pending_provider_override_target = None;
+    }
+
+    pub fn handle_tab_closed(&mut self, tab_id: TabId) {
+        self.panels.handle_tab_closed(tab_id.menu);
     }
 
     fn should_emit_provider_override_action(&self, state: &UiState) -> bool {
@@ -362,9 +367,7 @@ impl ShellUi {
                     ui.set_min_width(360.0);
                     ui.vertical_centered(|ui| {
                         ui.add_space(10.0);
-                        ui.label(
-                            egui::RichText::new("Klaw").strong().size(22.0),
-                        );
+                        ui.label(egui::RichText::new("Klaw").strong().size(22.0));
                         ui.add_space(18.0);
 
                         if let Some(texture) = self.about_icon_texture(ctx) {

--- a/klaw-gui/src/ui/sidebar.rs
+++ b/klaw-gui/src/ui/sidebar.rs
@@ -72,6 +72,25 @@ mod tests {
     #[test]
     fn grouped_menus_are_sorted_and_keep_skills_adjacent() {
         let groups = grouped_menus();
+        let (_, workspace_group) = groups
+            .iter()
+            .find(|(group, _)| *group == WorkbenchMenuGroup::Workspace)
+            .expect("workspace group should exist");
+        let workspace_titles = workspace_group
+            .iter()
+            .map(|menu| menu.title())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            workspace_titles,
+            vec![
+                "Configuration",
+                "Profile Prompt",
+                "Settings",
+                "System",
+                "Terminal",
+            ]
+        );
+
         let (_, ai_group) = groups
             .into_iter()
             .find(|(group, _)| *group == WorkbenchMenuGroup::AiAndCapability)


### PR DESCRIPTION
## Summary
- add a new `Terminal` entry under the GUI `WORKSPACE` sidebar group and route it through the shared workbench/panel registry
- embed an `egui_term`-powered local shell session inside `klaw-gui`, defaulting to the Klaw workspace directory and exposing start/restart/stop controls
- release the PTY session when the terminal tab closes, and document the new panel in `klaw-gui` crate docs/changelog

## Test plan
- [x] `cargo test -p klaw-gui`
- [x] Launch `klaw gui` and manually verify terminal input/output in the new `WORKSPACE > Terminal` panel

Closes #134

Made with [Cursor](https://cursor.com)