### PR TITLE
fix(storage): fail missing cron mutations

### DIFF
--- a/klaw-storage/CHANGELOG.md
+++ b/klaw-storage/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-03-31
+
+### Fixed
+- cron `set_enabled` and `delete` mutations in both SQLx and Turso backends now fail with explicit not-found errors when the target cron id does not exist, instead of silently reporting success after a zero-row write
+
 ## 2026-03-30
 
 ### Added

--- a/klaw-storage/src/backend/sqlx.rs
+++ b/klaw-storage/src/backend/sqlx.rs
@@ -2476,22 +2476,32 @@ impl CronStorage for SqlxSessionStore {
     }
 
     async fn set_enabled(&self, cron_id: &str, enabled: bool) -> Result<(), StorageError> {
-        sqlx::query("UPDATE cron SET enabled = ?1, updated_at_ms = ?2 WHERE id = ?3")
+        let updated = sqlx::query("UPDATE cron SET enabled = ?1, updated_at_ms = ?2 WHERE id = ?3")
             .bind(if enabled { 1_i64 } else { 0_i64 })
             .bind(now_ms())
             .bind(cron_id)
             .execute(&self.pool)
             .await
             .map_err(StorageError::backend)?;
+        if updated.rows_affected() == 0 {
+            return Err(StorageError::backend(format!(
+                "cron job '{cron_id}' not found when setting enabled"
+            )));
+        }
         Ok(())
     }
 
     async fn delete_cron(&self, cron_id: &str) -> Result<(), StorageError> {
-        sqlx::query("DELETE FROM cron WHERE id = ?1")
+        let deleted = sqlx::query("DELETE FROM cron WHERE id = ?1")
             .bind(cron_id)
             .execute(&self.pool)
             .await
             .map_err(StorageError::backend)?;
+        if deleted.rows_affected() == 0 {
+            return Err(StorageError::backend(format!(
+                "cron job '{cron_id}' not found when deleting"
+            )));
+        }
         Ok(())
     }
 

--- a/klaw-storage/src/backend/turso.rs
+++ b/klaw-storage/src/backend/turso.rs
@@ -2044,18 +2044,30 @@ impl CronStorage for TursoSessionStore {
             escape_sql_text(cron_id)
         );
         let conn = self.connection().await?;
-        conn.execute(&sql, ())
+        let affected = conn
+            .execute(&sql, ())
             .await
             .map_err(StorageError::backend)?;
+        if affected == 0 {
+            return Err(StorageError::backend(format!(
+                "cron job '{cron_id}' not found when setting enabled"
+            )));
+        }
         Ok(())
     }
 
     async fn delete_cron(&self, cron_id: &str) -> Result<(), StorageError> {
         let sql = format!("DELETE FROM cron WHERE id = '{}'", escape_sql_text(cron_id));
         let conn = self.connection().await?;
-        conn.execute(&sql, ())
+        let affected = conn
+            .execute(&sql, ())
             .await
             .map_err(StorageError::backend)?;
+        if affected == 0 {
+            return Err(StorageError::backend(format!(
+                "cron job '{cron_id}' not found when deleting"
+            )));
+        }
         Ok(())
     }
 

--- a/klaw-storage/src/lib.rs
+++ b/klaw-storage/src/lib.rs
@@ -784,6 +784,29 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    async fn cron_missing_id_mutations_return_not_found_errors() {
+        let store = create_store().await;
+
+        let err = store
+            .set_enabled("missing-cron", false)
+            .await
+            .expect_err("set_enabled should fail for missing cron");
+        assert!(
+            err.to_string()
+                .contains("cron job 'missing-cron' not found when setting enabled")
+        );
+
+        let err = store
+            .delete_cron("missing-cron")
+            .await
+            .expect_err("delete should fail for missing cron");
+        assert!(
+            err.to_string()
+                .contains("cron job 'missing-cron' not found when deleting")
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
     async fn cron_task_lifecycle_transitions() {
         let store = create_store().await;
         store

--- a/klaw-tool/CHANGELOG.md
+++ b/klaw-tool/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-03-31
+
+### Fixed
+- `cron_manager` test coverage now asserts that `delete` and `set_enabled` surface errors for missing cron ids, protecting the tool layer from regressing back to false-success responses
+
 ## 2026-03-30
 
 ### Removed

--- a/klaw-tool/src/cron_manager.rs
+++ b/klaw-tool/src/cron_manager.rs
@@ -1020,7 +1020,10 @@ mod tests {
         }
 
         async fn delete_cron(&self, cron_id: &str) -> Result<(), StorageError> {
-            self.jobs.lock().await.remove(cron_id);
+            let removed = self.jobs.lock().await.remove(cron_id);
+            if removed.is_none() {
+                return Err(StorageError::backend("cron not found"));
+            }
             Ok(())
         }
 
@@ -1230,6 +1233,33 @@ mod tests {
             .await
             .expect("delete");
         assert!(out.content_for_model.contains("\"deleted\": true"));
+    }
+
+    #[tokio::test]
+    async fn set_enabled_returns_error_for_missing_cron_job() {
+        let tool = CronManagerTool::from_storage(Arc::new(MockCronStorage::default()));
+
+        let err = tool
+            .execute(
+                json!({"action":"set_enabled","id":"missing-job","enabled":false}),
+                &ctx(),
+            )
+            .await
+            .expect_err("missing cron should fail");
+
+        assert!(err.to_string().contains("cron not found"));
+    }
+
+    #[tokio::test]
+    async fn delete_returns_error_for_missing_cron_job() {
+        let tool = CronManagerTool::from_storage(Arc::new(MockCronStorage::default()));
+
+        let err = tool
+            .execute(json!({"action":"delete","id":"missing-job"}), &ctx())
+            .await
+            .expect_err("missing cron should fail");
+
+        assert!(err.to_string().contains("cron not found"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- make cron `set_enabled` and `delete` return explicit not-found errors when the target id does not exist in both SQLx and Turso backends
- add storage regression coverage for missing-id cron mutations and tool-layer tests that prevent `cron_manager` from regressing back to false-success responses
- update crate changelogs for the storage and tool behavior hardening

## Test plan
- [x] `cargo test -p klaw-storage`
- [x] `cargo test -p klaw-tool`
- [x] `cargo fmt --all`

Fixes #140

Made with [Cursor](https://cursor.com)