### PR TITLE
fix(storage): guard cron update affected rows

### DIFF
--- a/klaw-storage/CHANGELOG.md
+++ b/klaw-storage/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 2026-03-31
 
 ### Fixed
-- cron `set_enabled` and `delete` mutations in both SQLx and Turso backends now fail with explicit not-found errors when the target cron id does not exist, instead of silently reporting success after a zero-row write
+- cron `update`, `set_enabled`, and `delete` mutations in both SQLx and Turso backends now fail with explicit not-found errors when the target cron id does not exist, instead of silently reporting success after a zero-row write
 
 ## 2026-03-30
 

--- a/klaw-storage/src/backend/sqlx.rs
+++ b/klaw-storage/src/backend/sqlx.rs
@@ -2440,7 +2440,7 @@ impl CronStorage for SqlxSessionStore {
     ) -> Result<CronJob, StorageError> {
         let current = self.get_cron(cron_id).await?;
         let now = now_ms();
-        sqlx::query(
+        let updated = sqlx::query(
             "UPDATE cron
              SET name = ?1,
                  schedule_kind = ?2,
@@ -2472,6 +2472,11 @@ impl CronStorage for SqlxSessionStore {
         .execute(&self.pool)
         .await
         .map_err(StorageError::backend)?;
+        if updated.rows_affected() == 0 {
+            return Err(StorageError::backend(format!(
+                "cron job '{cron_id}' not found when updating"
+            )));
+        }
         self.get_cron(cron_id).await
     }
 

--- a/klaw-storage/src/backend/turso.rs
+++ b/klaw-storage/src/backend/turso.rs
@@ -2027,9 +2027,15 @@ impl CronStorage for TursoSessionStore {
         );
         {
             let conn = self.connection().await?;
-            conn.execute(&sql, ())
+            let affected = conn
+                .execute(&sql, ())
                 .await
                 .map_err(StorageError::backend)?;
+            if affected == 0 {
+                return Err(StorageError::backend(format!(
+                    "cron job '{cron_id}' not found when updating"
+                )));
+            }
         }
         self.get_cron(cron_id).await
     }

--- a/klaw-storage/src/lib.rs
+++ b/klaw-storage/src/lib.rs
@@ -788,6 +788,18 @@ mod tests {
         let store = create_store().await;
 
         let err = store
+            .update_cron(
+                "missing-cron",
+                &UpdateCronJobPatch {
+                    name: Some("renamed".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect_err("update should fail for missing cron");
+        assert!(err.to_string().contains("cron job not found"));
+
+        let err = store
             .set_enabled("missing-cron", false)
             .await
             .expect_err("set_enabled should fail for missing cron");

--- a/klaw-tool/CHANGELOG.md
+++ b/klaw-tool/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 2026-03-31
 
 ### Fixed
-- `cron_manager` test coverage now asserts that `delete` and `set_enabled` surface errors for missing cron ids, protecting the tool layer from regressing back to false-success responses
+- `cron_manager` test coverage now asserts that `update`, `delete`, and `set_enabled` surface errors for missing cron ids, protecting the tool layer from regressing back to false-success responses
 
 ## 2026-03-30
 

--- a/klaw-tool/src/cron_manager.rs
+++ b/klaw-tool/src/cron_manager.rs
@@ -1236,6 +1236,21 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn update_returns_error_for_missing_cron_job() {
+        let tool = CronManagerTool::from_storage(Arc::new(MockCronStorage::default()));
+
+        let err = tool
+            .execute(
+                json!({"action":"update","id":"missing-job","name":"renamed"}),
+                &ctx(),
+            )
+            .await
+            .expect_err("missing cron should fail");
+
+        assert!(err.to_string().contains("cron not found"));
+    }
+
+    #[tokio::test]
     async fn set_enabled_returns_error_for_missing_cron_job() {
         let tool = CronManagerTool::from_storage(Arc::new(MockCronStorage::default()));
 


### PR DESCRIPTION
## Summary
- add explicit zero-row guards to cron `update` in both SQLx and Turso storage backends
- extend storage regression coverage for missing-id cron mutations to include `update`
- extend `cron_manager` tests so missing-id `update` cannot regress into a false-success path

## Test plan
- [x] `cargo test -p klaw-storage`
- [x] `cargo test -p klaw-tool`
- [x] `cargo fmt --all`

Fixes #144

Made with [Cursor](https://cursor.com)