### PR TITLE
feat(acp): complete structured ACP client workflow

### DIFF
--- a/klaw-acp/CHANGELOG.md
+++ b/klaw-acp/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2026-04-02
+
+### Added
+
+- ACP `session/update` 现在会保留结构化事件快照，覆盖消息、thought、tool、plan、mode、config、available commands 与 session info 等标准更新类型
+- ACP client 现在支持结构化权限请求模型和外部异步 permission handler，为 GUI 往返审批链路提供协议层基础
+
+### Changed
+
+- `ContentBlock` 渲染已从仅支持 `Text` 扩展为可读摘要输出，`ResourceLink` 与嵌入式 `Resource` 不再静默丢失
+- ACP prompt 流式 update 现在统一透传结构化 session 事件，而不是只产出回答/thought/tool 的字符串片段
+
 ## 2026-03-30
 
 ### Added

--- a/klaw-acp/src/client.rs
+++ b/klaw-acp/src/client.rs
@@ -2,7 +2,9 @@ use agent_client_protocol as acp;
 use async_trait::async_trait;
 use std::{
     collections::BTreeMap,
+    future::Future,
     path::{Path, PathBuf},
+    pin::Pin,
     sync::Arc,
 };
 use tokio::{
@@ -19,16 +21,178 @@ pub struct AcpSessionUpdateLog {
     pub reasoning: String,
     pub tool_updates: Vec<String>,
     pub raw_updates: Vec<String>,
+    pub events: Vec<AcpSessionEvent>,
+    pub available_commands: Vec<AcpAvailableCommand>,
+    pub current_mode_id: Option<String>,
+    pub config_options: Vec<AcpConfigOption>,
+    pub session_title: Option<String>,
+    pub session_updated_at: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AcpPromptUpdate {
-    AnswerChunk(String),
-    ThoughtChunk(String),
-    ToolUpdate(String),
+    SessionEvent(AcpSessionEvent),
+    PermissionRequest(AcpPermissionRequest),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AcpSessionEvent {
+    pub session_id: String,
+    pub summary: String,
+    pub update: AcpSessionEventKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AcpSessionEventKind {
+    UserMessageChunk {
+        content: AcpContentBlockEvent,
+    },
+    AgentMessageChunk {
+        content: AcpContentBlockEvent,
+    },
+    AgentThoughtChunk {
+        content: AcpContentBlockEvent,
+    },
+    ToolCall(AcpToolCallEvent),
+    ToolCallUpdate(AcpToolCallUpdateEvent),
+    Plan(AcpPlanEvent),
+    AvailableCommandsUpdate {
+        commands: Vec<AcpAvailableCommand>,
+    },
+    CurrentModeUpdate {
+        current_mode_id: String,
+    },
+    ConfigOptionUpdate {
+        config_options: Vec<AcpConfigOption>,
+    },
+    SessionInfoUpdate {
+        title: Option<Option<String>>,
+        updated_at: Option<Option<String>>,
+    },
+    Other {
+        description: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AcpContentBlockEvent {
+    Text {
+        text: String,
+    },
+    Image {
+        mime_type: String,
+        uri: Option<String>,
+        data_len: usize,
+    },
+    Audio {
+        mime_type: String,
+        data_len: usize,
+    },
+    ResourceLink {
+        name: String,
+        uri: String,
+        title: Option<String>,
+        description: Option<String>,
+        mime_type: Option<String>,
+    },
+    EmbeddedTextResource {
+        uri: String,
+        mime_type: Option<String>,
+        text: String,
+    },
+    EmbeddedBlobResource {
+        uri: String,
+        mime_type: Option<String>,
+        byte_len: usize,
+    },
+    Unsupported {
+        description: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AcpToolCallEvent {
+    pub tool_call_id: String,
+    pub title: String,
+    pub kind: String,
+    pub status: String,
+    pub content: Vec<String>,
+    pub locations: Vec<String>,
+    pub raw_input: Option<String>,
+    pub raw_output: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AcpToolCallUpdateEvent {
+    pub tool_call_id: String,
+    pub title: Option<String>,
+    pub kind: Option<String>,
+    pub status: Option<String>,
+    pub content: Option<Vec<String>>,
+    pub locations: Option<Vec<String>>,
+    pub raw_input: Option<String>,
+    pub raw_output: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AcpPlanEvent {
+    pub entries: Vec<AcpPlanEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AcpPlanEntry {
+    pub content: String,
+    pub priority: String,
+    pub status: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AcpAvailableCommand {
+    pub name: String,
+    pub description: String,
+    pub input_hint: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AcpConfigOption {
+    pub id: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub category: Option<String>,
+    pub current_value: String,
+    pub values: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AcpPermissionRequest {
+    pub session_id: String,
+    pub tool_call_id: String,
+    pub title: Option<String>,
+    pub kind: Option<String>,
+    pub status: Option<String>,
+    pub raw_input: Option<String>,
+    pub raw_output: Option<String>,
+    pub options: Vec<AcpPermissionOption>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AcpPermissionOption {
+    pub option_id: String,
+    pub label: String,
+    pub kind: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AcpPermissionDecision {
+    SelectOption { option_id: String },
+    Cancelled,
 }
 
 type PromptUpdateSink = Arc<dyn Fn(AcpPromptUpdate) + Send + Sync>;
+pub type AcpPermissionRequestFuture =
+    Pin<Box<dyn Future<Output = AcpPermissionDecision> + Send + 'static>>;
+pub type AcpPermissionRequestHandler =
+    Arc<dyn Fn(AcpPermissionRequest) -> AcpPermissionRequestFuture + Send + Sync>;
 
 impl AcpSessionUpdateLog {
     #[must_use]
@@ -86,12 +250,13 @@ pub struct KlawAcpClient {
     updates: Arc<Mutex<BTreeMap<String, AcpSessionUpdateLog>>>,
     terminals: Arc<Mutex<BTreeMap<String, Arc<Mutex<TrackedTerminal>>>>>,
     prompt_update_sink: Option<PromptUpdateSink>,
+    permission_request_handler: Option<AcpPermissionRequestHandler>,
 }
 
 impl KlawAcpClient {
     #[must_use]
     pub fn new(session_root: PathBuf) -> Self {
-        Self::with_prompt_update_sink(session_root, None)
+        Self::with_event_handlers(session_root, None, None)
     }
 
     #[must_use]
@@ -99,11 +264,21 @@ impl KlawAcpClient {
         session_root: PathBuf,
         prompt_update_sink: Option<PromptUpdateSink>,
     ) -> Self {
+        Self::with_event_handlers(session_root, prompt_update_sink, None)
+    }
+
+    #[must_use]
+    pub fn with_event_handlers(
+        session_root: PathBuf,
+        prompt_update_sink: Option<PromptUpdateSink>,
+        permission_request_handler: Option<AcpPermissionRequestHandler>,
+    ) -> Self {
         Self {
             session_root,
             updates: Arc::new(Mutex::new(BTreeMap::new())),
             terminals: Arc::new(Mutex::new(BTreeMap::new())),
             prompt_update_sink,
+            permission_request_handler,
         }
     }
 
@@ -119,6 +294,18 @@ impl KlawAcpClient {
         let mut guard = self.updates.lock().await;
         let entry = guard.entry(session_id).or_default();
         mutate(entry);
+    }
+
+    async fn tracked_terminal(
+        &self,
+        terminal_id: &str,
+    ) -> acp::Result<Arc<Mutex<TrackedTerminal>>> {
+        self.terminals
+            .lock()
+            .await
+            .get(terminal_id)
+            .cloned()
+            .ok_or_else(|| acp::Error::resource_not_found(Some(terminal_id.to_string())))
     }
 
     fn resolve_scoped_path(&self, requested: &Path) -> acp::Result<PathBuf> {
@@ -160,76 +347,33 @@ impl acp::Client for KlawAcpClient {
         &self,
         args: acp::RequestPermissionRequest,
     ) -> acp::Result<acp::RequestPermissionResponse> {
-        let outcome = args
-            .options
-            .first()
-            .map(|option| {
+        let request = map_permission_request(&args);
+        let decision = if let Some(handler) = self.permission_request_handler.as_ref() {
+            handler(request).await
+        } else {
+            default_permission_decision(&args)
+        };
+        let outcome = match decision {
+            AcpPermissionDecision::SelectOption { option_id } => {
                 acp::RequestPermissionOutcome::Selected(acp::SelectedPermissionOutcome::new(
-                    option.option_id.clone(),
+                    option_id,
                 ))
-            })
-            .unwrap_or(acp::RequestPermissionOutcome::Cancelled);
+            }
+            AcpPermissionDecision::Cancelled => acp::RequestPermissionOutcome::Cancelled,
+        };
         Ok(acp::RequestPermissionResponse::new(outcome))
     }
 
     async fn session_notification(&self, args: acp::SessionNotification) -> acp::Result<()> {
         let session_id = args.session_id.to_string();
-        let stream_update = match &args.update {
-            acp::SessionUpdate::AgentMessageChunk(chunk) => Some(AcpPromptUpdate::AnswerChunk(
-                render_content_block(&chunk.content).to_string(),
-            )),
-            acp::SessionUpdate::AgentThoughtChunk(chunk) => Some(AcpPromptUpdate::ThoughtChunk(
-                render_content_block(&chunk.content).to_string(),
-            )),
-            acp::SessionUpdate::ToolCall(tool_call) => Some(AcpPromptUpdate::ToolUpdate(format!(
-                "tool call: {:?} {}",
-                tool_call.kind, tool_call.title
-            ))),
-            acp::SessionUpdate::ToolCallUpdate(update) => Some(AcpPromptUpdate::ToolUpdate(
-                format!("tool update: {:?}", update),
-            )),
-            acp::SessionUpdate::Plan(plan) => {
-                Some(AcpPromptUpdate::ToolUpdate(format!("plan: {:?}", plan)))
-            }
-            _ => None,
-        };
-        if let Some(update) = stream_update
-            && let Some(sink) = self.prompt_update_sink.as_ref()
-        {
-            sink(update);
+        let event = map_session_event(&session_id, &args.update);
+        if let Some(sink) = self.prompt_update_sink.as_ref() {
+            sink(AcpPromptUpdate::SessionEvent(event.clone()));
         }
         self.mutate_session_log(session_id, |entry| {
-            entry.raw_updates.push(format!("{:?}", args.update));
-            match args.update {
-                acp::SessionUpdate::AgentMessageChunk(chunk) => {
-                    entry.answer.push_str(&render_content_block(&chunk.content));
-                }
-                acp::SessionUpdate::AgentThoughtChunk(chunk) => {
-                    entry
-                        .reasoning
-                        .push_str(&render_content_block(&chunk.content));
-                }
-                acp::SessionUpdate::ToolCall(tool_call) => {
-                    entry.tool_updates.push(format!(
-                        "tool call: {:?} {}",
-                        tool_call.kind, tool_call.title
-                    ));
-                }
-                acp::SessionUpdate::ToolCallUpdate(update) => {
-                    entry
-                        .tool_updates
-                        .push(format!("tool update: {:?}", update));
-                }
-                acp::SessionUpdate::Plan(plan) => {
-                    entry.tool_updates.push(format!("plan: {:?}", plan));
-                }
-                acp::SessionUpdate::UserMessageChunk(_)
-                | acp::SessionUpdate::AvailableCommandsUpdate(_)
-                | acp::SessionUpdate::CurrentModeUpdate(_)
-                | acp::SessionUpdate::ConfigOptionUpdate(_)
-                | acp::SessionUpdate::SessionInfoUpdate(_)
-                | _ => {}
-            }
+            entry.raw_updates.push(format!("{:?}", &args.update));
+            entry.events.push(event.clone());
+            merge_session_update_into_log(entry, &args.update);
         })
         .await;
         Ok(())
@@ -315,13 +459,8 @@ impl acp::Client for KlawAcpClient {
         &self,
         args: acp::TerminalOutputRequest,
     ) -> acp::Result<acp::TerminalOutputResponse> {
-        let terminal = self
-            .terminals
-            .lock()
-            .await
-            .get(args.terminal_id.to_string().as_str())
-            .cloned()
-            .ok_or_else(|| acp::Error::resource_not_found(Some(args.terminal_id.to_string())))?;
+        let terminal_id = args.terminal_id.to_string();
+        let terminal = self.tracked_terminal(&terminal_id).await?;
         let mut guard = terminal.lock().await;
         let exit_status = refresh_exit_status(&mut guard)
             .await
@@ -337,12 +476,8 @@ impl acp::Client for KlawAcpClient {
         &self,
         args: acp::ReleaseTerminalRequest,
     ) -> acp::Result<acp::ReleaseTerminalResponse> {
-        let Some(terminal) = self
-            .terminals
-            .lock()
-            .await
-            .remove(args.terminal_id.to_string().as_str())
-        else {
+        let terminal_id = args.terminal_id.to_string();
+        let Some(terminal) = self.terminals.lock().await.remove(terminal_id.as_str()) else {
             return Ok(acp::ReleaseTerminalResponse::default());
         };
         let mut guard = terminal.lock().await;
@@ -361,13 +496,8 @@ impl acp::Client for KlawAcpClient {
         &self,
         args: acp::WaitForTerminalExitRequest,
     ) -> acp::Result<acp::WaitForTerminalExitResponse> {
-        let terminal = self
-            .terminals
-            .lock()
-            .await
-            .get(args.terminal_id.to_string().as_str())
-            .cloned()
-            .ok_or_else(|| acp::Error::resource_not_found(Some(args.terminal_id.to_string())))?;
+        let terminal_id = args.terminal_id.to_string();
+        let terminal = self.tracked_terminal(&terminal_id).await?;
         let mut guard = terminal.lock().await;
         if let Some(exit_status) = guard.exit_status.clone() {
             return Ok(acp::WaitForTerminalExitResponse::new(exit_status));
@@ -386,13 +516,8 @@ impl acp::Client for KlawAcpClient {
         &self,
         args: acp::KillTerminalRequest,
     ) -> acp::Result<acp::KillTerminalResponse> {
-        let terminal = self
-            .terminals
-            .lock()
-            .await
-            .get(args.terminal_id.to_string().as_str())
-            .cloned()
-            .ok_or_else(|| acp::Error::resource_not_found(Some(args.terminal_id.to_string())))?;
+        let terminal_id = args.terminal_id.to_string();
+        let terminal = self.tracked_terminal(&terminal_id).await?;
         let mut guard = terminal.lock().await;
         if guard.exit_status.is_none() {
             guard
@@ -408,11 +533,575 @@ impl acp::Client for KlawAcpClient {
     }
 }
 
-fn render_content_block(content: &acp::ContentBlock) -> &str {
+fn render_content_block(content: &acp::ContentBlock) -> AcpContentBlockEvent {
     match content {
-        acp::ContentBlock::Text(text) => text.text.as_str(),
-        _ => "",
+        acp::ContentBlock::Text(text) => AcpContentBlockEvent::Text {
+            text: text.text.clone(),
+        },
+        acp::ContentBlock::Image(image) => AcpContentBlockEvent::Image {
+            mime_type: image.mime_type.clone(),
+            uri: image.uri.clone(),
+            data_len: image.data.len(),
+        },
+        acp::ContentBlock::Audio(audio) => AcpContentBlockEvent::Audio {
+            mime_type: audio.mime_type.clone(),
+            data_len: audio.data.len(),
+        },
+        acp::ContentBlock::ResourceLink(resource) => AcpContentBlockEvent::ResourceLink {
+            name: resource.name.clone(),
+            uri: resource.uri.clone(),
+            title: resource.title.clone(),
+            description: resource.description.clone(),
+            mime_type: resource.mime_type.clone(),
+        },
+        acp::ContentBlock::Resource(resource) => match &resource.resource {
+            acp::EmbeddedResourceResource::TextResourceContents(text) => {
+                AcpContentBlockEvent::EmbeddedTextResource {
+                    uri: text.uri.clone(),
+                    mime_type: text.mime_type.clone(),
+                    text: text.text.clone(),
+                }
+            }
+            acp::EmbeddedResourceResource::BlobResourceContents(blob) => {
+                AcpContentBlockEvent::EmbeddedBlobResource {
+                    uri: blob.uri.clone(),
+                    mime_type: blob.mime_type.clone(),
+                    byte_len: blob.blob.len(),
+                }
+            }
+            _ => AcpContentBlockEvent::Unsupported {
+                description: format!("{resource:?}"),
+            },
+        },
+        _ => AcpContentBlockEvent::Unsupported {
+            description: format!("{content:?}"),
+        },
     }
+}
+
+impl AcpContentBlockEvent {
+    fn rendered_text(&self) -> String {
+        match self {
+            Self::Text { text } => text.clone(),
+            Self::Image {
+                mime_type,
+                uri,
+                data_len,
+            } => match uri {
+                Some(uri) => format!("[image {mime_type} {data_len} bytes {uri}]"),
+                None => format!("[image {mime_type} {data_len} bytes]"),
+            },
+            Self::Audio {
+                mime_type,
+                data_len,
+            } => format!("[audio {mime_type} {data_len} bytes]"),
+            Self::ResourceLink {
+                name,
+                uri,
+                title,
+                description,
+                mime_type,
+            } => {
+                let mut parts = vec![format!("name={name}"), format!("uri={uri}")];
+                if let Some(title) = title {
+                    parts.push(format!("title={title}"));
+                }
+                if let Some(description) = description {
+                    parts.push(format!("description={description}"));
+                }
+                if let Some(mime_type) = mime_type {
+                    parts.push(format!("mime={mime_type}"));
+                }
+                format!("[resource_link {}]", parts.join(" "))
+            }
+            Self::EmbeddedTextResource {
+                uri,
+                mime_type,
+                text,
+            } => match mime_type {
+                Some(mime_type) => {
+                    format!("[embedded_text_resource uri={uri} mime={mime_type}] {text}")
+                }
+                None => format!("[embedded_text_resource uri={uri}] {text}"),
+            },
+            Self::EmbeddedBlobResource {
+                uri,
+                mime_type,
+                byte_len,
+            } => match mime_type {
+                Some(mime_type) => {
+                    format!("[embedded_blob_resource uri={uri} mime={mime_type} bytes={byte_len}]")
+                }
+                None => format!("[embedded_blob_resource uri={uri} bytes={byte_len}]"),
+            },
+            Self::Unsupported { description } => format!("[unsupported_content {description}]"),
+        }
+    }
+}
+
+fn merge_session_update_into_log(entry: &mut AcpSessionUpdateLog, update: &acp::SessionUpdate) {
+    match update {
+        acp::SessionUpdate::UserMessageChunk(_) => {}
+        acp::SessionUpdate::AgentMessageChunk(chunk) => {
+            entry
+                .answer
+                .push_str(&render_content_block(&chunk.content).rendered_text());
+        }
+        acp::SessionUpdate::AgentThoughtChunk(chunk) => {
+            entry
+                .reasoning
+                .push_str(&render_content_block(&chunk.content).rendered_text());
+        }
+        acp::SessionUpdate::ToolCall(tool_call) => {
+            entry.tool_updates.push(format_tool_call_summary(tool_call));
+        }
+        acp::SessionUpdate::ToolCallUpdate(update) => {
+            entry
+                .tool_updates
+                .push(format_tool_call_update_summary(update));
+        }
+        acp::SessionUpdate::Plan(plan) => {
+            entry.tool_updates.push(format_plan_summary(plan));
+        }
+        acp::SessionUpdate::AvailableCommandsUpdate(update) => {
+            entry.available_commands = update
+                .available_commands
+                .iter()
+                .map(map_available_command)
+                .collect();
+        }
+        acp::SessionUpdate::CurrentModeUpdate(update) => {
+            entry.current_mode_id = Some(update.current_mode_id.to_string());
+        }
+        acp::SessionUpdate::ConfigOptionUpdate(update) => {
+            entry.config_options = update
+                .config_options
+                .iter()
+                .map(map_config_option)
+                .collect();
+        }
+        acp::SessionUpdate::SessionInfoUpdate(update) => {
+            if let Some(title) = maybe_undefined_to_option(&update.title) {
+                entry.session_title = title;
+            }
+            if let Some(updated_at) = maybe_undefined_to_option(&update.updated_at) {
+                entry.session_updated_at = updated_at;
+            }
+        }
+        _ => {}
+    }
+}
+
+fn map_session_event(session_id: &str, update: &acp::SessionUpdate) -> AcpSessionEvent {
+    let (summary, mapped_update) = match update {
+        acp::SessionUpdate::UserMessageChunk(chunk) => {
+            let content = render_content_block(&chunk.content);
+            let summary = format!("user: {}", content.rendered_text());
+            (summary, AcpSessionEventKind::UserMessageChunk { content })
+        }
+        acp::SessionUpdate::AgentMessageChunk(chunk) => {
+            let content = render_content_block(&chunk.content);
+            let summary = format!("assistant: {}", content.rendered_text());
+            (summary, AcpSessionEventKind::AgentMessageChunk { content })
+        }
+        acp::SessionUpdate::AgentThoughtChunk(chunk) => {
+            let content = render_content_block(&chunk.content);
+            let summary = format!("thought: {}", content.rendered_text());
+            (summary, AcpSessionEventKind::AgentThoughtChunk { content })
+        }
+        acp::SessionUpdate::ToolCall(tool_call) => {
+            let event = map_tool_call(tool_call);
+            let summary = format_tool_call_summary(tool_call);
+            (summary, AcpSessionEventKind::ToolCall(event))
+        }
+        acp::SessionUpdate::ToolCallUpdate(update) => {
+            let event = map_tool_call_update(update);
+            let summary = format_tool_call_update_summary(update);
+            (summary, AcpSessionEventKind::ToolCallUpdate(event))
+        }
+        acp::SessionUpdate::Plan(plan) => {
+            let event = map_plan(plan);
+            let summary = format_plan_summary(plan);
+            (summary, AcpSessionEventKind::Plan(event))
+        }
+        acp::SessionUpdate::AvailableCommandsUpdate(update) => {
+            let commands = update
+                .available_commands
+                .iter()
+                .map(map_available_command)
+                .collect::<Vec<_>>();
+            let summary = if commands.is_empty() {
+                "available commands updated (none)".to_string()
+            } else {
+                format!(
+                    "available commands updated: {}",
+                    commands
+                        .iter()
+                        .map(|command| command.name.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            };
+            (
+                summary,
+                AcpSessionEventKind::AvailableCommandsUpdate { commands },
+            )
+        }
+        acp::SessionUpdate::CurrentModeUpdate(update) => {
+            let current_mode_id = update.current_mode_id.to_string();
+            (
+                format!("current mode updated: {current_mode_id}"),
+                AcpSessionEventKind::CurrentModeUpdate { current_mode_id },
+            )
+        }
+        acp::SessionUpdate::ConfigOptionUpdate(update) => {
+            let config_options = update
+                .config_options
+                .iter()
+                .map(map_config_option)
+                .collect::<Vec<_>>();
+            let summary = if config_options.is_empty() {
+                "config options updated (none)".to_string()
+            } else {
+                format!(
+                    "config options updated: {}",
+                    config_options
+                        .iter()
+                        .map(|option| format!("{}={}", option.id, option.current_value))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            };
+            (
+                summary,
+                AcpSessionEventKind::ConfigOptionUpdate { config_options },
+            )
+        }
+        acp::SessionUpdate::SessionInfoUpdate(update) => {
+            let title = maybe_undefined_to_option(&update.title);
+            let updated_at = maybe_undefined_to_option(&update.updated_at);
+            let mut parts = Vec::new();
+            if let Some(title) = &title {
+                parts.push(match title {
+                    Some(value) => format!("title={value}"),
+                    None => "title=<cleared>".to_string(),
+                });
+            }
+            if let Some(updated_at) = &updated_at {
+                parts.push(match updated_at {
+                    Some(value) => format!("updated_at={value}"),
+                    None => "updated_at=<cleared>".to_string(),
+                });
+            }
+            let summary = if parts.is_empty() {
+                "session info updated".to_string()
+            } else {
+                format!("session info updated: {}", parts.join(", "))
+            };
+            (
+                summary,
+                AcpSessionEventKind::SessionInfoUpdate { title, updated_at },
+            )
+        }
+        _ => (
+            format!("other session update: {update:?}"),
+            AcpSessionEventKind::Other {
+                description: format!("{update:?}"),
+            },
+        ),
+    };
+    AcpSessionEvent {
+        session_id: session_id.to_string(),
+        summary,
+        update: mapped_update,
+    }
+}
+
+fn map_tool_call(tool_call: &acp::ToolCall) -> AcpToolCallEvent {
+    AcpToolCallEvent {
+        tool_call_id: tool_call.tool_call_id.to_string(),
+        title: tool_call.title.clone(),
+        kind: format_tool_kind(tool_call.kind),
+        status: format_tool_call_status(tool_call.status),
+        content: tool_call
+            .content
+            .iter()
+            .map(format_tool_call_content)
+            .collect(),
+        locations: tool_call
+            .locations
+            .iter()
+            .map(format_tool_call_location)
+            .collect(),
+        raw_input: tool_call.raw_input.as_ref().map(format_json_value),
+        raw_output: tool_call.raw_output.as_ref().map(format_json_value),
+    }
+}
+
+fn map_tool_call_update(update: &acp::ToolCallUpdate) -> AcpToolCallUpdateEvent {
+    AcpToolCallUpdateEvent {
+        tool_call_id: update.tool_call_id.to_string(),
+        title: update.fields.title.clone(),
+        kind: update.fields.kind.map(format_tool_kind),
+        status: update.fields.status.map(format_tool_call_status),
+        content: update
+            .fields
+            .content
+            .as_ref()
+            .map(|content| content.iter().map(format_tool_call_content).collect()),
+        locations: update
+            .fields
+            .locations
+            .as_ref()
+            .map(|locations| locations.iter().map(format_tool_call_location).collect()),
+        raw_input: update.fields.raw_input.as_ref().map(format_json_value),
+        raw_output: update.fields.raw_output.as_ref().map(format_json_value),
+    }
+}
+
+fn map_plan(plan: &acp::Plan) -> AcpPlanEvent {
+    AcpPlanEvent {
+        entries: plan
+            .entries
+            .iter()
+            .map(|entry| AcpPlanEntry {
+                content: entry.content.clone(),
+                priority: format!("{:?}", entry.priority),
+                status: format!("{:?}", entry.status),
+            })
+            .collect(),
+    }
+}
+
+fn map_available_command(command: &acp::AvailableCommand) -> AcpAvailableCommand {
+    AcpAvailableCommand {
+        name: command.name.clone(),
+        description: command.description.clone(),
+        input_hint: command.input.as_ref().map(|input| match input {
+            acp::AvailableCommandInput::Unstructured(input) => input.hint.clone(),
+            _ => format!("{input:?}"),
+        }),
+    }
+}
+
+fn map_config_option(option: &acp::SessionConfigOption) -> AcpConfigOption {
+    let (current_value, values) = match &option.kind {
+        acp::SessionConfigKind::Select(select) => (
+            select.current_value.to_string(),
+            format_select_options(&select.options),
+        ),
+        _ => (format!("{:?}", option.kind), Vec::new()),
+    };
+    AcpConfigOption {
+        id: option.id.to_string(),
+        name: option.name.clone(),
+        description: option.description.clone(),
+        category: option.category.as_ref().map(format_config_option_category),
+        current_value,
+        values,
+    }
+}
+
+fn map_permission_request(args: &acp::RequestPermissionRequest) -> AcpPermissionRequest {
+    AcpPermissionRequest {
+        session_id: args.session_id.to_string(),
+        tool_call_id: args.tool_call.tool_call_id.to_string(),
+        title: args.tool_call.fields.title.clone(),
+        kind: args.tool_call.fields.kind.map(format_tool_kind),
+        status: args.tool_call.fields.status.map(format_tool_call_status),
+        raw_input: args
+            .tool_call
+            .fields
+            .raw_input
+            .as_ref()
+            .map(format_json_value),
+        raw_output: args
+            .tool_call
+            .fields
+            .raw_output
+            .as_ref()
+            .map(format_json_value),
+        options: args
+            .options
+            .iter()
+            .map(|option| AcpPermissionOption {
+                option_id: option.option_id.to_string(),
+                label: option.name.clone(),
+                kind: format_permission_option_kind(option.kind),
+            })
+            .collect(),
+    }
+}
+
+fn default_permission_decision(args: &acp::RequestPermissionRequest) -> AcpPermissionDecision {
+    args.options
+        .first()
+        .map(|option| AcpPermissionDecision::SelectOption {
+            option_id: option.option_id.to_string(),
+        })
+        .unwrap_or(AcpPermissionDecision::Cancelled)
+}
+
+fn format_tool_call_summary(tool_call: &acp::ToolCall) -> String {
+    format!(
+        "tool call [{}] {} ({}, {})",
+        tool_call.tool_call_id,
+        tool_call.title,
+        format_tool_kind(tool_call.kind),
+        format_tool_call_status(tool_call.status)
+    )
+}
+
+fn format_tool_call_update_summary(update: &acp::ToolCallUpdate) -> String {
+    let mut changes = Vec::new();
+    if let Some(title) = &update.fields.title {
+        changes.push(format!("title={title}"));
+    }
+    if let Some(kind) = update.fields.kind {
+        changes.push(format!("kind={}", format_tool_kind(kind)));
+    }
+    if let Some(status) = update.fields.status {
+        changes.push(format!("status={}", format_tool_call_status(status)));
+    }
+    if update.fields.content.is_some() {
+        changes.push("content=updated".to_string());
+    }
+    if update.fields.locations.is_some() {
+        changes.push("locations=updated".to_string());
+    }
+    if update.fields.raw_input.is_some() {
+        changes.push("raw_input=updated".to_string());
+    }
+    if update.fields.raw_output.is_some() {
+        changes.push("raw_output=updated".to_string());
+    }
+    if changes.is_empty() {
+        format!("tool update [{}]", update.tool_call_id)
+    } else {
+        format!(
+            "tool update [{}]: {}",
+            update.tool_call_id,
+            changes.join(", ")
+        )
+    }
+}
+
+fn format_plan_summary(plan: &acp::Plan) -> String {
+    if plan.entries.is_empty() {
+        return "plan updated (empty)".to_string();
+    }
+    format!(
+        "plan updated: {}",
+        plan.entries
+            .iter()
+            .map(|entry| format!(
+                "{} [{:?}/{:?}]",
+                entry.content, entry.priority, entry.status
+            ))
+            .collect::<Vec<_>>()
+            .join(" | ")
+    )
+}
+
+fn format_tool_kind(kind: acp::ToolKind) -> String {
+    match kind {
+        acp::ToolKind::Read => "read".to_string(),
+        acp::ToolKind::Edit => "edit".to_string(),
+        acp::ToolKind::Delete => "delete".to_string(),
+        acp::ToolKind::Move => "move".to_string(),
+        acp::ToolKind::Search => "search".to_string(),
+        acp::ToolKind::Execute => "execute".to_string(),
+        acp::ToolKind::Think => "think".to_string(),
+        acp::ToolKind::Fetch => "fetch".to_string(),
+        acp::ToolKind::SwitchMode => "switch_mode".to_string(),
+        acp::ToolKind::Other => "other".to_string(),
+        _ => format!("{kind:?}"),
+    }
+}
+
+fn format_tool_call_status(status: acp::ToolCallStatus) -> String {
+    match status {
+        acp::ToolCallStatus::Pending => "pending".to_string(),
+        acp::ToolCallStatus::InProgress => "in_progress".to_string(),
+        acp::ToolCallStatus::Completed => "completed".to_string(),
+        acp::ToolCallStatus::Failed => "failed".to_string(),
+        _ => format!("{status:?}"),
+    }
+}
+
+fn format_tool_call_content(content: &acp::ToolCallContent) -> String {
+    match content {
+        acp::ToolCallContent::Content(content) => {
+            render_content_block(&content.content).rendered_text()
+        }
+        acp::ToolCallContent::Diff(diff) => format!(
+            "[diff path={} old_len={} new_len={}]",
+            diff.path.display(),
+            diff.old_text.as_ref().map_or(0, String::len),
+            diff.new_text.len()
+        ),
+        acp::ToolCallContent::Terminal(terminal) => {
+            format!("[terminal id={}]", terminal.terminal_id)
+        }
+        _ => format!("{content:?}"),
+    }
+}
+
+fn format_tool_call_location(location: &acp::ToolCallLocation) -> String {
+    match location.line {
+        Some(line) => format!("{}:{}", location.path.display(), line),
+        None => location.path.display().to_string(),
+    }
+}
+
+fn format_select_options(options: &acp::SessionConfigSelectOptions) -> Vec<String> {
+    match options {
+        acp::SessionConfigSelectOptions::Ungrouped(options) => options
+            .iter()
+            .map(|option| format!("{} ({})", option.name, option.value))
+            .collect(),
+        acp::SessionConfigSelectOptions::Grouped(groups) => groups
+            .iter()
+            .flat_map(|group| {
+                group.options.iter().map(move |option| {
+                    format!("{} / {} ({})", group.name, option.name, option.value)
+                })
+            })
+            .collect(),
+        _ => vec![format!("{options:?}")],
+    }
+}
+
+fn format_config_option_category(category: &acp::SessionConfigOptionCategory) -> String {
+    match category {
+        acp::SessionConfigOptionCategory::Mode => "mode".to_string(),
+        acp::SessionConfigOptionCategory::Model => "model".to_string(),
+        acp::SessionConfigOptionCategory::ThoughtLevel => "thought_level".to_string(),
+        acp::SessionConfigOptionCategory::Other(value) => value.clone(),
+        _ => format!("{category:?}"),
+    }
+}
+
+fn maybe_undefined_to_option(value: &acp::MaybeUndefined<String>) -> Option<Option<String>> {
+    match value {
+        acp::MaybeUndefined::Undefined => None,
+        acp::MaybeUndefined::Null => Some(None),
+        acp::MaybeUndefined::Value(value) => Some(Some(value.clone())),
+    }
+}
+
+fn format_permission_option_kind(kind: acp::PermissionOptionKind) -> String {
+    match kind {
+        acp::PermissionOptionKind::AllowOnce => "allow_once".to_string(),
+        acp::PermissionOptionKind::AllowAlways => "allow_always".to_string(),
+        acp::PermissionOptionKind::RejectOnce => "reject_once".to_string(),
+        acp::PermissionOptionKind::RejectAlways => "reject_always".to_string(),
+        _ => format!("{kind:?}"),
+    }
+}
+
+fn format_json_value(value: &serde_json::Value) -> String {
+    serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string())
 }
 
 fn slice_lines(content: &str, line: Option<u32>, limit: Option<u32>) -> String {
@@ -475,6 +1164,7 @@ fn convert_exit_status(status: std::process::ExitStatus) -> acp::TerminalExitSta
 #[cfg(test)]
 mod tests {
     use super::*;
+    use agent_client_protocol::Client as _;
 
     fn temp_dir() -> PathBuf {
         let dir = std::env::temp_dir().join(format!("klaw-acp-client-{}", Uuid::new_v4()));
@@ -489,6 +1179,12 @@ mod tests {
             reasoning: "thinking".to_string(),
             tool_updates: vec!["tool".to_string()],
             raw_updates: vec!["raw".to_string()],
+            events: Vec::new(),
+            available_commands: Vec::new(),
+            current_mode_id: None,
+            config_options: Vec::new(),
+            session_title: None,
+            session_updated_at: None,
         };
         assert_eq!(log.final_output(), "done");
     }
@@ -520,6 +1216,141 @@ mod tests {
         let outside = root.join("..").join("outside.txt");
         let result = client.resolve_scoped_path(&outside);
         assert!(result.is_err());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn render_content_block_summarizes_resources() {
+        let link = render_content_block(&acp::ContentBlock::ResourceLink(acp::ResourceLink::new(
+            "README",
+            "file:///workspace/README.md",
+        )));
+        assert_eq!(
+            link.rendered_text(),
+            "[resource_link name=README uri=file:///workspace/README.md]"
+        );
+
+        let resource = render_content_block(&acp::ContentBlock::Resource(
+            acp::EmbeddedResource::new(acp::EmbeddedResourceResource::TextResourceContents(
+                acp::TextResourceContents::new("# Heading", "file:///workspace/notes.md")
+                    .mime_type("text/markdown"),
+            )),
+        ));
+        assert_eq!(
+            resource.rendered_text(),
+            "[embedded_text_resource uri=file:///workspace/notes.md mime=text/markdown] # Heading"
+        );
+    }
+
+    #[test]
+    fn permission_request_mapping_preserves_tool_context() {
+        let request = acp::RequestPermissionRequest::new(
+            "session-1",
+            acp::ToolCallUpdate::new(
+                "tool-1",
+                acp::ToolCallUpdateFields::new()
+                    .title("Write output.txt")
+                    .kind(acp::ToolKind::Edit)
+                    .status(acp::ToolCallStatus::Pending),
+            ),
+            vec![acp::PermissionOption::new(
+                "allow",
+                "Allow once",
+                acp::PermissionOptionKind::AllowOnce,
+            )],
+        );
+
+        let mapped = map_permission_request(&request);
+        assert_eq!(mapped.session_id, "session-1");
+        assert_eq!(mapped.tool_call_id, "tool-1");
+        assert_eq!(mapped.title.as_deref(), Some("Write output.txt"));
+        assert_eq!(mapped.kind.as_deref(), Some("edit"));
+        assert_eq!(mapped.status.as_deref(), Some("pending"));
+        assert_eq!(mapped.options.len(), 1);
+        assert!(matches!(
+            default_permission_decision(&request),
+            AcpPermissionDecision::SelectOption { ref option_id } if option_id == "allow"
+        ));
+    }
+
+    #[tokio::test]
+    async fn session_notification_tracks_structured_session_state() {
+        let root = temp_dir();
+        let client = KlawAcpClient::new(root.clone());
+        let session_id = "session-1";
+
+        client
+            .session_notification(acp::SessionNotification::new(
+                session_id,
+                acp::SessionUpdate::CurrentModeUpdate(acp::CurrentModeUpdate::new("build")),
+            ))
+            .await
+            .expect("current mode update should succeed");
+        client
+            .session_notification(acp::SessionNotification::new(
+                session_id,
+                acp::SessionUpdate::AvailableCommandsUpdate(acp::AvailableCommandsUpdate::new(
+                    vec![acp::AvailableCommand::new("create_plan", "Create a plan")],
+                )),
+            ))
+            .await
+            .expect("available commands update should succeed");
+        client
+            .session_notification(acp::SessionNotification::new(
+                session_id,
+                acp::SessionUpdate::ConfigOptionUpdate(acp::ConfigOptionUpdate::new(vec![
+                    acp::SessionConfigOption::select(
+                        "mode",
+                        "Mode",
+                        "build",
+                        vec![acp::SessionConfigSelectOption::new("build", "Build")],
+                    ),
+                ])),
+            ))
+            .await
+            .expect("config option update should succeed");
+        client
+            .session_notification(acp::SessionNotification::new(
+                session_id,
+                acp::SessionUpdate::SessionInfoUpdate(
+                    acp::SessionInfoUpdate::new()
+                        .title("ACP session".to_string())
+                        .updated_at("2026-04-02T00:00:00Z".to_string()),
+                ),
+            ))
+            .await
+            .expect("session info update should succeed");
+        client
+            .session_notification(acp::SessionNotification::new(
+                session_id,
+                acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(
+                    acp::ContentBlock::ResourceLink(acp::ResourceLink::new(
+                        "README",
+                        "file:///workspace/README.md",
+                    )),
+                )),
+            ))
+            .await
+            .expect("message chunk should succeed");
+
+        let log = client
+            .session_log(session_id)
+            .await
+            .expect("session log should exist");
+        assert_eq!(log.current_mode_id.as_deref(), Some("build"));
+        assert_eq!(log.available_commands.len(), 1);
+        assert_eq!(log.config_options.len(), 1);
+        assert_eq!(log.session_title.as_deref(), Some("ACP session"));
+        assert_eq!(
+            log.session_updated_at.as_deref(),
+            Some("2026-04-02T00:00:00Z")
+        );
+        assert!(
+            log.answer
+                .contains("[resource_link name=README uri=file:///workspace/README.md]")
+        );
+        assert!(log.events.len() >= 5);
+
         let _ = std::fs::remove_dir_all(root);
     }
 }

--- a/klaw-acp/src/lib.rs
+++ b/klaw-acp/src/lib.rs
@@ -3,6 +3,12 @@ mod hub;
 mod manager;
 mod runtime;
 
+pub use client::{
+    AcpAvailableCommand, AcpConfigOption, AcpContentBlockEvent, AcpPermissionDecision,
+    AcpPermissionOption, AcpPermissionRequest, AcpPermissionRequestFuture,
+    AcpPermissionRequestHandler, AcpPlanEntry, AcpPlanEvent, AcpSessionEvent, AcpSessionEventKind,
+    AcpToolCallEvent, AcpToolCallUpdateEvent,
+};
 pub use client::{AcpPromptUpdate, AcpSessionUpdateLog, KlawAcpClient};
 pub use hub::AcpAgentHub;
 pub use manager::{

--- a/klaw-acp/src/manager.rs
+++ b/klaw-acp/src/manager.rs
@@ -1,5 +1,5 @@
 use crate::{
-    client::{AcpPromptUpdate, KlawAcpClient},
+    client::{AcpPermissionRequestHandler, AcpPromptUpdate, KlawAcpClient},
     hub::AcpAgentHub,
     runtime::{AcpExecutionError, AcpProxyTool, AcpToolDescriptor},
 };
@@ -312,6 +312,7 @@ impl AcpManager {
             timeout,
             None,
             None,
+            None,
         )
         .await
     }
@@ -323,11 +324,13 @@ impl AcpManager {
         working_directory: Option<&str>,
         timeout: Option<Duration>,
         prompt_update_sink: Option<Arc<dyn Fn(AcpPromptUpdate) + Send + Sync>>,
+        permission_request_handler: Option<AcpPermissionRequestHandler>,
         cancel_receiver: Option<watch::Receiver<bool>>,
     ) -> Result<String, AcpExecutionError> {
         let prompt = prompt.to_string();
         let working_directory = working_directory.map(ToString::to_string);
         let prompt_update_sink = prompt_update_sink.clone();
+        let permission_request_handler = permission_request_handler.clone();
         let cancel_receiver = cancel_receiver.clone();
         tokio::task::spawn_blocking(move || {
             run_prompt_blocking(
@@ -337,6 +340,7 @@ impl AcpManager {
                 working_directory,
                 timeout,
                 prompt_update_sink,
+                permission_request_handler,
                 cancel_receiver,
             )
         })
@@ -498,6 +502,7 @@ fn run_prompt_blocking(
     working_directory: Option<String>,
     timeout: Option<Duration>,
     prompt_update_sink: Option<Arc<dyn Fn(AcpPromptUpdate) + Send + Sync>>,
+    permission_request_handler: Option<AcpPermissionRequestHandler>,
     cancel_receiver: Option<watch::Receiver<bool>>,
 ) -> Result<String, AcpExecutionError> {
     let runtime = tokio::runtime::Builder::new_current_thread()
@@ -513,6 +518,7 @@ fn run_prompt_blocking(
             working_directory,
             timeout,
             prompt_update_sink,
+            permission_request_handler,
             cancel_receiver,
         )
         .await
@@ -526,6 +532,7 @@ async fn run_prompt_async(
     working_directory: Option<String>,
     timeout: Option<Duration>,
     prompt_update_sink: Option<Arc<dyn Fn(AcpPromptUpdate) + Send + Sync>>,
+    permission_request_handler: Option<AcpPermissionRequestHandler>,
     mut cancel_receiver: Option<watch::Receiver<bool>>,
 ) -> Result<String, AcpExecutionError> {
     use acp::Agent as _;
@@ -539,7 +546,11 @@ async fn run_prompt_async(
     );
     let session_root = resolve_session_root(working_directory.as_deref())?;
     debug!(agent = %config.id, session_root = %session_root.display(), "resolved acp session root");
-    let client = KlawAcpClient::with_prompt_update_sink(session_root.clone(), prompt_update_sink);
+    let client = KlawAcpClient::with_event_handlers(
+        session_root.clone(),
+        prompt_update_sink,
+        permission_request_handler,
+    );
 
     let mut command = tokio::process::Command::new(config.command.trim());
     command
@@ -625,22 +636,12 @@ async fn run_prompt_async(
             ));
         }
         Err(_) => {
-            let stderr = stderr_tail.lock().await.clone();
-            let message = if stderr.trim().is_empty() {
-                format!(
-                    "timed out after {:?} waiting for new_session response from `{}`",
-                    startup_timeout,
-                    config.command.trim()
-                )
-            } else {
-                format!(
-                    "timed out after {:?} waiting for new_session response from `{}`; stderr: {}",
-                    startup_timeout,
-                    config.command.trim(),
-                    stderr.trim()
-                )
-            };
-            return Err(AcpExecutionError::NewSession(message));
+            let stderr = stderr_tail.lock().await;
+            return Err(AcpExecutionError::NewSession(new_session_timeout_message(
+                startup_timeout,
+                config.command.trim(),
+                stderr.as_str(),
+            )));
         }
     };
     debug!(
@@ -774,6 +775,21 @@ fn resolve_session_root(
     std::fs::canonicalize(&candidate).map_err(|err| {
         AcpExecutionError::InvalidWorkingDirectory(format!("{} ({err})", candidate.display()))
     })
+}
+
+fn new_session_timeout_message(startup_timeout: Duration, command: &str, stderr: &str) -> String {
+    if stderr.trim().is_empty() {
+        format!(
+            "timed out after {:?} waiting for new_session response from `{command}`",
+            startup_timeout
+        )
+    } else {
+        format!(
+            "timed out after {:?} waiting for new_session response from `{command}`; stderr: {}",
+            startup_timeout,
+            stderr.trim()
+        )
+    }
 }
 
 async fn with_stderr(err: acp::Error, stderr_tail: &Arc<Mutex<String>>) -> String {
@@ -1211,6 +1227,7 @@ for raw_line in sys.stdin:
             Duration::from_secs(5),
             "please keep running",
             Some(working_directory.as_str()),
+            None,
             None,
             None,
             Some(cancel_rx),

--- a/klaw-cli/CHANGELOG.md
+++ b/klaw-cli/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+## 2026-04-02
+
+### Changed
+
+- GUI runtime 的 ACP prompt 执行链路现在会透传结构化 session 事件，而不是在 CLI 层提前压扁成字符串 chunk
+- GUI runtime 现在维护 pending ACP permission waiter，并在停止 prompt 或 prompt 结束时统一向未完成的权限请求返回 `Cancelled`
+
+### Added
+
+- GUI runtime 新增 ACP permission resolve command，允许面板把用户选择的 permission option 回写到正在运行的 ACP 会话
+
 ## 2026-03-31
 
 ### Fixed

--- a/klaw-cli/src/commands/gui.rs
+++ b/klaw-cli/src/commands/gui.rs
@@ -4,8 +4,16 @@ use klaw_channel::{ChannelConfigSnapshot, ChannelManager};
 use klaw_config::AppConfig;
 use klaw_llm::ToolDefinition;
 use klaw_mcp::McpConfigSnapshot;
-use std::{io, sync::Arc, time::Duration};
-use tokio::sync::{Mutex as AsyncMutex, watch};
+use std::{
+    collections::BTreeMap,
+    io,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::Duration,
+};
+use tokio::sync::{Mutex as AsyncMutex, oneshot, watch};
 
 use super::startup_display::print_startup_banner;
 use crate::commands::signal::shutdown_signal;
@@ -18,6 +26,18 @@ use crate::runtime::{
 };
 use klaw_config::ConfigStore;
 use tracing::{info, warn};
+
+async fn cancel_pending_acp_permissions(
+    pending: &AsyncMutex<BTreeMap<u64, oneshot::Sender<klaw_acp::AcpPermissionDecision>>>,
+) {
+    let waiters = {
+        let mut guard = pending.lock().await;
+        std::mem::take(&mut *guard)
+    };
+    for (_, waiter) in waiters {
+        let _ = waiter.send(klaw_acp::AcpPermissionDecision::Cancelled);
+    }
+}
 
 fn wait_for_worker_shutdown<T>(
     worker: std::thread::JoinHandle<T>,
@@ -88,6 +108,100 @@ fn tool_definitions(runtime: &crate::runtime::RuntimeBundle) -> Vec<ToolDefiniti
     definitions
 }
 
+async fn run_execute_acp_prompt_stream_command(
+    agent_id: String,
+    prompt: String,
+    working_directory: Option<String>,
+    timeout_seconds: Option<u64>,
+    events: std::sync::mpsc::Sender<klaw_gui::AcpPromptEvent>,
+    acp_manager: Arc<AsyncMutex<klaw_acp::AcpManager>>,
+    pending_permissions: Arc<
+        AsyncMutex<BTreeMap<u64, oneshot::Sender<klaw_acp::AcpPermissionDecision>>>,
+    >,
+    permission_counter: Arc<AtomicU64>,
+    cancel_rx: watch::Receiver<bool>,
+) {
+    tracing::debug!(
+        agent = %agent_id,
+        working_directory = ?working_directory,
+        timeout_seconds,
+        prompt_len = prompt.len(),
+        "gui requested acp test prompt"
+    );
+    let timeout = timeout_seconds.map(Duration::from_secs);
+    let execution_config = {
+        let guard = acp_manager.lock().await;
+        guard.agent_execution_config(&agent_id)
+    };
+    let result = match execution_config {
+        Ok((config, startup_timeout)) => {
+            let chunk_events = events.clone();
+            let session_permission_counter = Arc::clone(&permission_counter);
+            let sink = Arc::new(move |update: klaw_acp::AcpPromptUpdate| match update {
+                klaw_acp::AcpPromptUpdate::SessionEvent(event) => {
+                    let _ = chunk_events.send(klaw_gui::AcpPromptEvent::SessionEvent(event));
+                }
+                klaw_acp::AcpPromptUpdate::PermissionRequest(request) => {
+                    let request_id = session_permission_counter.fetch_add(1, Ordering::Relaxed);
+                    let _ = chunk_events.send(klaw_gui::AcpPromptEvent::PermissionRequested {
+                        request_id,
+                        request,
+                    });
+                }
+            });
+            let permission_events = events.clone();
+            let interactive_permission_counter = Arc::clone(&permission_counter);
+            let permission_waiters_for_handler = Arc::clone(&pending_permissions);
+            let permission_handler: klaw_acp::AcpPermissionRequestHandler = Arc::new(
+                move |request: klaw_acp::AcpPermissionRequest| -> klaw_acp::AcpPermissionRequestFuture {
+                    let pending_permissions = Arc::clone(&permission_waiters_for_handler);
+                    let permission_events = permission_events.clone();
+                    let request_id = interactive_permission_counter.fetch_add(1, Ordering::Relaxed);
+                    Box::pin(async move {
+                        let (decision_tx, decision_rx) = oneshot::channel();
+                        pending_permissions
+                            .lock()
+                            .await
+                            .insert(request_id, decision_tx);
+                        let _ = permission_events.send(klaw_gui::AcpPromptEvent::PermissionRequested {
+                            request_id,
+                            request,
+                        });
+                        match decision_rx.await {
+                            Ok(decision) => decision,
+                            Err(_) => klaw_acp::AcpPermissionDecision::Cancelled,
+                        }
+                    })
+                },
+            );
+            klaw_acp::AcpManager::execute_prompt_with_config_stream(
+                config,
+                startup_timeout,
+                &prompt,
+                working_directory.as_deref(),
+                timeout,
+                Some(sink),
+                Some(permission_handler),
+                Some(cancel_rx),
+            )
+            .await
+        }
+        Err(err) => Err(err),
+    };
+    cancel_pending_acp_permissions(pending_permissions.as_ref()).await;
+    match result {
+        Ok(final_output) => {
+            let _ = events.send(klaw_gui::AcpPromptEvent::Completed { final_output });
+        }
+        Err(klaw_acp::AcpExecutionError::Cancelled { .. }) => {
+            let _ = events.send(klaw_gui::AcpPromptEvent::Stopped);
+        }
+        Err(err) => {
+            let _ = events.send(klaw_gui::AcpPromptEvent::Failed(err.to_string()));
+        }
+    }
+}
+
 #[derive(Debug, Args)]
 pub struct GuiCommand {}
 
@@ -156,6 +270,13 @@ impl GuiCommand {
                             let mut runtime_cmd_rx = runtime_cmd_rx;
                             let mut runtime_cmd_open = true;
                             let mut active_acp_prompt_cancel: Option<watch::Sender<bool>> = None;
+                            let active_acp_permission_waiters = Arc::new(AsyncMutex::new(
+                                BTreeMap::<
+                                    u64,
+                                    oneshot::Sender<klaw_acp::AcpPermissionDecision>,
+                                >::new(),
+                            ));
+                            let next_acp_permission_id = Arc::new(AtomicU64::new(1));
                             let channel_factory = build_channel_driver_factory(&config_for_thread)
                                 .map_err(|err| err.to_string())?;
                             let channel_manager = Arc::new(AsyncMutex::new(
@@ -354,69 +475,60 @@ impl GuiCommand {
                                             }) => {
                                                 let (cancel_tx, cancel_rx) = watch::channel(false);
                                                 active_acp_prompt_cancel = Some(cancel_tx);
+                                                cancel_pending_acp_permissions(
+                                                    active_acp_permission_waiters.as_ref(),
+                                                )
+                                                .await;
                                                 let manager = Arc::clone(&acp_manager);
-                                                tokio::task::spawn_local(async move {
-                                                    tracing::debug!(
-                                                        agent = %agent_id,
-                                                        working_directory = ?working_directory,
-                                                        timeout_seconds,
-                                                        prompt_len = prompt.len(),
-                                                        "gui requested acp test prompt"
-                                                    );
-                                                    let timeout = timeout_seconds.map(std::time::Duration::from_secs);
-                                                    let execution_config = {
-                                                        let guard = manager.lock().await;
-                                                        guard.agent_execution_config(&agent_id)
-                                                    };
-                                                    let result = match execution_config {
-                                                        Ok((config, startup_timeout)) => {
-                                                            let chunk_events = events.clone();
-                                                            let sink = Arc::new(move |update: klaw_acp::AcpPromptUpdate| {
-                                                                let chunk = match update {
-                                                                    klaw_acp::AcpPromptUpdate::AnswerChunk(text) => text,
-                                                                    klaw_acp::AcpPromptUpdate::ThoughtChunk(text) => {
-                                                                        format!("\n[thought] {text}\n")
-                                                                    }
-                                                                    klaw_acp::AcpPromptUpdate::ToolUpdate(text) => {
-                                                                        format!("\n[{text}]\n")
-                                                                    }
-                                                                };
-                                                                let _ = chunk_events.send(klaw_gui::AcpPromptEvent::Chunk(chunk));
-                                                            });
-                                                            klaw_acp::AcpManager::execute_prompt_with_config_stream(
-                                                                config,
-                                                                startup_timeout,
-                                                                &prompt,
-                                                                working_directory.as_deref(),
-                                                                timeout,
-                                                                Some(sink),
-                                                                Some(cancel_rx),
-                                                            )
-                                                            .await
-                                                        }
-                                                        Err(err) => Err(err),
-                                                    };
-                                                    match result {
-                                                        Ok(final_output) => {
-                                                            let _ = events.send(klaw_gui::AcpPromptEvent::Completed {
-                                                                final_output,
-                                                            });
-                                                        }
-                                                        Err(klaw_acp::AcpExecutionError::Cancelled { .. }) => {
-                                                            let _ = events.send(klaw_gui::AcpPromptEvent::Stopped);
-                                                        }
-                                                        Err(err) => {
-                                                            let _ = events.send(klaw_gui::AcpPromptEvent::Failed(err.to_string()));
-                                                        }
-                                                    }
-                                                });
+                                                let pending_permissions = Arc::clone(
+                                                    &active_acp_permission_waiters,
+                                                );
+                                                let permission_counter =
+                                                    Arc::clone(&next_acp_permission_id);
+                                                tokio::task::spawn_local(run_execute_acp_prompt_stream_command(
+                                                    agent_id,
+                                                    prompt,
+                                                    working_directory,
+                                                    timeout_seconds,
+                                                    events,
+                                                    manager,
+                                                    pending_permissions,
+                                                    permission_counter,
+                                                    cancel_rx,
+                                                ));
                                             }
                                             Some(klaw_gui::RuntimeCommand::StopAcpPrompt { response }) => {
+                                                cancel_pending_acp_permissions(
+                                                    active_acp_permission_waiters.as_ref(),
+                                                )
+                                                .await;
                                                 let result = match active_acp_prompt_cancel.take() {
                                                     Some(cancel) => cancel
                                                         .send(true)
                                                         .map_err(|_| "acp prompt is no longer running".to_string()),
                                                     None => Err("no ACP test prompt is currently running".to_string()),
+                                                };
+                                                let _ = response.send(result.map(|_| ()));
+                                            }
+                                            Some(klaw_gui::RuntimeCommand::ResolveAcpPermission {
+                                                request_id,
+                                                decision,
+                                                response,
+                                            }) => {
+                                                let waiter = active_acp_permission_waiters
+                                                    .lock()
+                                                    .await
+                                                    .remove(&request_id);
+                                                let result = match waiter {
+                                                    Some(waiter) => waiter
+                                                        .send(decision)
+                                                        .map_err(|_| {
+                                                            "acp permission request is no longer waiting"
+                                                                .to_string()
+                                                        }),
+                                                    None => Err(format!(
+                                                        "unknown acp permission request `{request_id}`"
+                                                    )),
                                                 };
                                                 let _ = response.send(result.map(|_| ()));
                                             }

--- a/klaw-gui/CHANGELOG.md
+++ b/klaw-gui/CHANGELOG.md
@@ -1,5 +1,17 @@
 # CHANGELOG
 
+## 2026-04-02
+
+### Changed
+
+- `ACP` 面板的 `Test Prompt` 弹窗现在会展示结构化 session 快照，包括当前 mode、available commands、config options、session info 与最近事件时间线
+- `ACP` 面板的 detail 窗口现在会附带最近一次测试 prompt 的结构化状态摘要，便于排查外部 ACP agent 的模式切换和配置更新
+
+### Added
+
+- `ACP` 面板现在支持直接响应外部 agent 的权限请求，可在弹窗内查看 pending permission、选择返回的 option 或主动 cancel
+- `ACP` prompt 流现在同时保留原始文本视图和结构化事件视图，方便区分调试信息与最终回答内容
+
 ## 2026-04-01
 
 ### Added

--- a/klaw-gui/src/panels/acp.rs
+++ b/klaw-gui/src/panels/acp.rs
@@ -1,14 +1,17 @@
 use crate::notifications::NotificationCenter;
 use crate::panels::{PanelRenderer, RenderCtx};
 use crate::runtime_bridge::{
-    AcpPromptEvent, request_acp_status, request_execute_acp_prompt_stream, request_stop_acp_prompt,
-    request_sync_acp,
+    AcpPromptEvent, request_acp_status, request_execute_acp_prompt_stream,
+    request_resolve_acp_permission, request_stop_acp_prompt, request_sync_acp,
 };
 use crate::widgets::{ArrayEditor, KeyValueEditor};
 use egui::{Color32, RichText};
 use egui_extras::{Column, TableBuilder};
 use egui_phosphor::regular;
-use klaw_acp::{AcpRuntimeSnapshot, AcpSyncResult};
+use klaw_acp::{
+    AcpAvailableCommand, AcpConfigOption, AcpContentBlockEvent, AcpPermissionDecision,
+    AcpPermissionRequest, AcpRuntimeSnapshot, AcpSessionEvent, AcpSessionEventKind, AcpSyncResult,
+};
 use klaw_config::{AcpAgentConfig, AppConfig, ConfigError, ConfigSnapshot, ConfigStore};
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::mpsc::{self, Receiver};
@@ -95,10 +98,25 @@ struct PromptTestState {
     working_directory: String,
     timeout_seconds: String,
     output: String,
+    session_events: Vec<AcpSessionEvent>,
+    available_commands: Vec<AcpAvailableCommand>,
+    current_mode_id: Option<String>,
+    config_options: Vec<AcpConfigOption>,
+    session_title: Option<String>,
+    session_updated_at: Option<String>,
+    permission_history: Vec<String>,
+    pending_permissions: Vec<PendingPermissionState>,
     last_error: Option<String>,
     running: bool,
     stopped: bool,
     window_open: bool,
+}
+
+#[derive(Debug, Clone)]
+struct PendingPermissionState {
+    request_id: u64,
+    request: AcpPermissionRequest,
+    resolving: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -119,6 +137,7 @@ pub struct AcpPanel {
     status_fetch_rx: Option<Receiver<Result<AcpRuntimeSnapshot, String>>>,
     sync_fetch_rx: Option<Receiver<Result<AcpSyncResult, String>>>,
     prompt_fetch_rx: Option<Receiver<AcpPromptEvent>>,
+    permission_action_rx: Option<Receiver<(u64, Result<(), String>)>>,
     prompt_test: PromptTestState,
     last_status_refresh_at: Option<Instant>,
     status_refresh_announce: bool,
@@ -290,15 +309,136 @@ impl AcpPanel {
         }
     }
 
-    fn poll_prompt_test(&mut self, notifications: &mut NotificationCenter) {
-        let Some(rx) = self.prompt_fetch_rx.as_ref() else {
+    fn apply_session_event(&mut self, event: AcpSessionEvent) {
+        self.append_output_for_event(&event);
+        match &event.update {
+            AcpSessionEventKind::AvailableCommandsUpdate { commands } => {
+                self.prompt_test.available_commands = commands.clone();
+            }
+            AcpSessionEventKind::CurrentModeUpdate { current_mode_id } => {
+                self.prompt_test.current_mode_id = Some(current_mode_id.clone());
+            }
+            AcpSessionEventKind::ConfigOptionUpdate { config_options } => {
+                self.prompt_test.config_options = config_options.clone();
+            }
+            AcpSessionEventKind::SessionInfoUpdate { title, updated_at } => {
+                if let Some(title) = title {
+                    self.prompt_test.session_title = title.clone();
+                }
+                if let Some(updated_at) = updated_at {
+                    self.prompt_test.session_updated_at = updated_at.clone();
+                }
+            }
+            _ => {}
+        }
+        self.prompt_test.session_events.push(event);
+    }
+
+    fn append_output_for_event(&mut self, event: &AcpSessionEvent) {
+        match &event.update {
+            AcpSessionEventKind::AgentMessageChunk { content } => {
+                self.prompt_test
+                    .output
+                    .push_str(&render_content_block(content));
+            }
+            AcpSessionEventKind::AgentThoughtChunk { content } => {
+                self.push_output_line(&format!("[thought] {}", render_content_block(content)));
+            }
+            AcpSessionEventKind::UserMessageChunk { content } => {
+                self.push_output_line(&format!("[user] {}", render_content_block(content)));
+            }
+            _ => self.push_output_line(&format!("[{}]", event.summary)),
+        }
+    }
+
+    fn push_output_line(&mut self, line: &str) {
+        if !self.prompt_test.output.is_empty() && !self.prompt_test.output.ends_with('\n') {
+            self.prompt_test.output.push('\n');
+        }
+        self.prompt_test.output.push_str(line);
+        if !self.prompt_test.output.ends_with('\n') {
+            self.prompt_test.output.push('\n');
+        }
+    }
+
+    fn poll_permission_action(&mut self, notifications: &mut NotificationCenter) {
+        let Some(rx) = self.permission_action_rx.as_ref() else {
             return;
         };
         let mut clear_receiver = false;
-        for _ in 0..64 {
+        loop {
             match rx.try_recv() {
-                Ok(AcpPromptEvent::Chunk(chunk)) => {
-                    self.prompt_test.output.push_str(&chunk);
+                Ok((request_id, Ok(()))) => {
+                    if let Some(permission) = pending_permission_mut(
+                        &mut self.prompt_test.pending_permissions,
+                        request_id,
+                    ) {
+                        permission.resolving = false;
+                    }
+                    self.prompt_test
+                        .permission_history
+                        .push(format!("permission resolved: request #{request_id}"));
+                    self.prompt_test
+                        .pending_permissions
+                        .retain(|permission| permission.request_id != request_id);
+                    notifications.success("ACP permission response sent");
+                    clear_receiver = true;
+                }
+                Ok((request_id, Err(err))) => {
+                    if let Some(permission) = pending_permission_mut(
+                        &mut self.prompt_test.pending_permissions,
+                        request_id,
+                    ) {
+                        permission.resolving = false;
+                    }
+                    notifications.error(format!("Failed to resolve ACP permission: {err}"));
+                    clear_receiver = true;
+                }
+                Err(mpsc::TryRecvError::Empty) => break,
+                Err(mpsc::TryRecvError::Disconnected) => {
+                    for permission in &mut self.prompt_test.pending_permissions {
+                        permission.resolving = false;
+                    }
+                    notifications.error("ACP permission response task disconnected unexpectedly");
+                    clear_receiver = true;
+                    break;
+                }
+            }
+        }
+        if clear_receiver {
+            self.permission_action_rx = None;
+        }
+    }
+
+    fn poll_prompt_test(&mut self, notifications: &mut NotificationCenter) {
+        let mut clear_receiver = false;
+        for _ in 0..64 {
+            let next_event = {
+                let Some(rx) = self.prompt_fetch_rx.as_ref() else {
+                    return;
+                };
+                rx.try_recv()
+            };
+            match next_event {
+                Ok(AcpPromptEvent::SessionEvent(event)) => {
+                    self.apply_session_event(event);
+                    self.prompt_test.window_open = true;
+                }
+                Ok(AcpPromptEvent::PermissionRequested {
+                    request_id,
+                    request,
+                }) => {
+                    self.prompt_test
+                        .pending_permissions
+                        .push(PendingPermissionState {
+                            request_id,
+                            request: request.clone(),
+                            resolving: false,
+                        });
+                    self.prompt_test.permission_history.push(format!(
+                        "permission requested: {}",
+                        permission_title(&request)
+                    ));
                     self.prompt_test.window_open = true;
                 }
                 Ok(AcpPromptEvent::Completed { final_output }) => {
@@ -317,6 +457,7 @@ impl AcpPanel {
                     self.prompt_test.running = false;
                     self.prompt_test.stopped = true;
                     self.prompt_test.last_error = None;
+                    self.prompt_test.pending_permissions.clear();
                     if !self.prompt_test.output.ends_with("\n[prompt stopped]\n") {
                         if !self.prompt_test.output.ends_with('\n')
                             && !self.prompt_test.output.is_empty()
@@ -333,6 +474,7 @@ impl AcpPanel {
                 Ok(AcpPromptEvent::Failed(err)) => {
                     self.prompt_test.running = false;
                     self.prompt_test.stopped = false;
+                    self.prompt_test.pending_permissions.clear();
                     self.prompt_test.last_error = Some(err.clone());
                     self.prompt_test.window_open = true;
                     clear_receiver = true;
@@ -342,6 +484,7 @@ impl AcpPanel {
                 Err(mpsc::TryRecvError::Empty) => break,
                 Err(mpsc::TryRecvError::Disconnected) => {
                     self.prompt_test.running = false;
+                    self.prompt_test.pending_permissions.clear();
                     self.prompt_test.last_error =
                         Some("ACP test prompt task disconnected unexpectedly".to_string());
                     self.prompt_test.window_open = true;
@@ -585,6 +728,15 @@ impl AcpPanel {
                 self.prompt_test.stopped = false;
                 self.prompt_test.last_error = None;
                 self.prompt_test.output.clear();
+                self.prompt_test.session_events.clear();
+                self.prompt_test.available_commands.clear();
+                self.prompt_test.current_mode_id = None;
+                self.prompt_test.config_options.clear();
+                self.prompt_test.session_title = None;
+                self.prompt_test.session_updated_at = None;
+                self.prompt_test.permission_history.clear();
+                self.prompt_test.pending_permissions.clear();
+                self.permission_action_rx = None;
                 self.prompt_test.window_open = true;
             }
             Err(err) => {
@@ -606,6 +758,34 @@ impl AcpPanel {
                 notifications.error(format!("Failed to stop ACP test prompt: {err}"));
             }
         }
+    }
+
+    fn resolve_permission(
+        &mut self,
+        request_id: u64,
+        decision: AcpPermissionDecision,
+        notifications: &mut NotificationCenter,
+    ) {
+        if self.permission_action_rx.is_some() {
+            notifications.info("An ACP permission response is already in progress");
+            return;
+        }
+        let Some(permission) = self
+            .prompt_test
+            .pending_permissions
+            .iter_mut()
+            .find(|permission| permission.request_id == request_id)
+        else {
+            notifications.error("ACP permission request is no longer pending");
+            return;
+        };
+        permission.resolving = true;
+        let (tx, rx) = mpsc::channel();
+        self.permission_action_rx = Some(rx);
+        thread::spawn(move || {
+            let result = request_resolve_acp_permission(request_id, decision);
+            let _ = tx.send((request_id, result));
+        });
     }
 
     fn render_stats(&self, ui: &mut egui::Ui) {
@@ -943,7 +1123,167 @@ impl AcpPanel {
                 }
 
                 ui.add_space(8.0);
-                ui.label(RichText::new("Stream").strong());
+                ui.label(RichText::new("Session Snapshot").strong());
+                egui::Grid::new("acp-test-prompt-snapshot-grid")
+                    .num_columns(2)
+                    .spacing([12.0, 6.0])
+                    .show(ui, |ui| {
+                        ui.label("Title");
+                        ui.label(
+                            self.prompt_test
+                                .session_title
+                                .as_deref()
+                                .unwrap_or("(not set)"),
+                        );
+                        ui.end_row();
+
+                        ui.label("Mode");
+                        ui.label(
+                            self.prompt_test
+                                .current_mode_id
+                                .as_deref()
+                                .unwrap_or("(unknown)"),
+                        );
+                        ui.end_row();
+
+                        ui.label("Updated At");
+                        ui.label(
+                            self.prompt_test
+                                .session_updated_at
+                                .as_deref()
+                                .unwrap_or("(not set)"),
+                        );
+                        ui.end_row();
+
+                        ui.label("Commands");
+                        if self.prompt_test.available_commands.is_empty() {
+                            ui.weak("(none)");
+                        } else {
+                            ui.label(
+                                self.prompt_test
+                                    .available_commands
+                                    .iter()
+                                    .map(|command| command.name.as_str())
+                                    .collect::<Vec<_>>()
+                                    .join(", "),
+                            );
+                        }
+                        ui.end_row();
+                    });
+
+                if !self.prompt_test.config_options.is_empty() {
+                    ui.add_space(8.0);
+                    ui.label(RichText::new("Config Options").strong());
+                    egui::Grid::new("acp-test-prompt-config-options-grid")
+                        .num_columns(2)
+                        .spacing([12.0, 6.0])
+                        .show(ui, |ui| {
+                            for option in &self.prompt_test.config_options {
+                                ui.label(option.name.as_str());
+                                let mut value = option.current_value.clone();
+                                if !option.values.is_empty() {
+                                    value.push_str("  [");
+                                    value.push_str(&option.values.join(", "));
+                                    value.push(']');
+                                }
+                                ui.label(value);
+                                ui.end_row();
+                            }
+                        });
+                }
+
+                if !self.prompt_test.pending_permissions.is_empty() {
+                    ui.add_space(8.0);
+                    ui.label(RichText::new("Pending Permissions").strong());
+                    let pending_permissions = self.prompt_test.pending_permissions.clone();
+                    for permission in pending_permissions {
+                        ui.group(|ui| {
+                            ui.horizontal_wrapped(|ui| {
+                                ui.label(RichText::new(format!(
+                                    "#{} {}",
+                                    permission.request_id,
+                                    permission_title(&permission.request)
+                                ))
+                                .strong());
+                                if permission.resolving {
+                                    ui.spinner();
+                                    ui.weak("sending response...");
+                                }
+                            });
+                            if let Some(kind) = permission.request.kind.as_deref() {
+                                ui.small(format!("tool kind: {kind}"));
+                            }
+                            if let Some(status) = permission.request.status.as_deref() {
+                                ui.small(format!("tool status: {status}"));
+                            }
+                            if let Some(raw_input) = permission.request.raw_input.as_deref() {
+                                ui.small(format!("raw input: {raw_input}"));
+                            }
+                            ui.add_space(4.0);
+                            ui.horizontal_wrapped(|ui| {
+                                for option in &permission.request.options {
+                                    let button = egui::Button::new(format!(
+                                        "{} ({})",
+                                        option.label, option.kind
+                                    ));
+                                    if ui
+                                        .add_enabled(!permission.resolving, button)
+                                        .clicked()
+                                    {
+                                        self.resolve_permission(
+                                            permission.request_id,
+                                            AcpPermissionDecision::SelectOption {
+                                                option_id: option.option_id.clone(),
+                                            },
+                                            notifications,
+                                        );
+                                    }
+                                }
+                                if ui
+                                    .add_enabled(
+                                        !permission.resolving,
+                                        egui::Button::new("Cancel").fill(Color32::DARK_RED),
+                                    )
+                                    .clicked()
+                                {
+                                    self.resolve_permission(
+                                        permission.request_id,
+                                        AcpPermissionDecision::Cancelled,
+                                        notifications,
+                                    );
+                                }
+                            });
+                        });
+                    }
+                }
+
+                if !self.prompt_test.permission_history.is_empty() {
+                    ui.add_space(8.0);
+                    ui.label(RichText::new("Permission Timeline").strong());
+                    for item in self.prompt_test.permission_history.iter().rev().take(8) {
+                        ui.small(item);
+                    }
+                }
+
+                ui.add_space(8.0);
+                ui.label(RichText::new("Structured Events").strong());
+                egui::ScrollArea::vertical()
+                    .id_salt("acp-test-prompt-events-window")
+                    .max_height(180.0)
+                    .auto_shrink([false, false])
+                    .stick_to_bottom(true)
+                    .show(ui, |ui| {
+                        if self.prompt_test.session_events.is_empty() {
+                            ui.weak("Waiting for ACP session updates...");
+                        } else {
+                            for event in self.prompt_test.session_events.iter().rev().take(32).rev() {
+                                ui.small(event.summary.as_str());
+                            }
+                        }
+                    });
+
+                ui.add_space(8.0);
+                ui.label(RichText::new("Raw Stream").strong());
                 egui::ScrollArea::vertical()
                     .id_salt("acp-test-prompt-stream-window")
                     .auto_shrink([false, false])
@@ -1214,6 +1554,47 @@ impl AcpPanel {
                         );
                         ui.colored_label(Color32::LIGHT_RED, last_error);
                     }
+                    if self.prompt_test.agent_id == detail_window.agent_id
+                        && !self.prompt_test.session_events.is_empty()
+                    {
+                        ui.add_space(8.0);
+                        ui.label(RichText::new("Latest Prompt Snapshot").strong());
+                        if let Some(mode) = self.prompt_test.current_mode_id.as_deref() {
+                            ui.small(format!("mode: {mode}"));
+                        }
+                        if let Some(title) = self.prompt_test.session_title.as_deref() {
+                            ui.small(format!("title: {title}"));
+                        }
+                        if let Some(updated_at) = self.prompt_test.session_updated_at.as_deref() {
+                            ui.small(format!("updated_at: {updated_at}"));
+                        }
+                        if !self.prompt_test.available_commands.is_empty() {
+                            ui.small(format!(
+                                "available commands: {}",
+                                self.prompt_test
+                                    .available_commands
+                                    .iter()
+                                    .map(|command| command.name.as_str())
+                                    .collect::<Vec<_>>()
+                                    .join(", ")
+                            ));
+                        }
+                        if !self.prompt_test.config_options.is_empty() {
+                            ui.small(format!(
+                                "config options: {}",
+                                self.prompt_test
+                                    .config_options
+                                    .iter()
+                                    .map(|option| format!("{}={}", option.id, option.current_value))
+                                    .collect::<Vec<_>>()
+                                    .join(", ")
+                            ));
+                        }
+                        ui.add_space(6.0);
+                        for event in self.prompt_test.session_events.iter().rev().take(12).rev() {
+                            ui.small(event.summary.as_str());
+                        }
+                    }
                 });
             });
 
@@ -1234,6 +1615,7 @@ impl PanelRenderer for AcpPanel {
         self.poll_manager_sync(notifications);
         self.poll_status_refresh(notifications);
         self.poll_prompt_test(notifications);
+        self.poll_permission_action(notifications);
         self.refresh_status_if_due();
         ui.ctx().request_repaint_after(ACP_STATUS_POLL_INTERVAL);
         ui.heading(ctx.tab_title);
@@ -1288,6 +1670,65 @@ impl PanelRenderer for AcpPanel {
     }
 }
 
+fn pending_permission_mut(
+    pending_permissions: &mut Vec<PendingPermissionState>,
+    request_id: u64,
+) -> Option<&mut PendingPermissionState> {
+    pending_permissions
+        .iter_mut()
+        .find(|permission| permission.request_id == request_id)
+}
+
+fn render_content_block(content: &AcpContentBlockEvent) -> String {
+    match content {
+        AcpContentBlockEvent::Text { text } => text.clone(),
+        AcpContentBlockEvent::Image {
+            mime_type,
+            uri,
+            data_len,
+        } => match uri {
+            Some(uri) => format!("[image {mime_type} {data_len} bytes {uri}]"),
+            None => format!("[image {mime_type} {data_len} bytes]"),
+        },
+        AcpContentBlockEvent::Audio {
+            mime_type,
+            data_len,
+        } => format!("[audio {mime_type} {data_len} bytes]"),
+        AcpContentBlockEvent::ResourceLink {
+            name, uri, title, ..
+        } => match title {
+            Some(title) => format!("[resource {name} {title} {uri}]"),
+            None => format!("[resource {name} {uri}]"),
+        },
+        AcpContentBlockEvent::EmbeddedTextResource {
+            uri,
+            mime_type,
+            text,
+        } => match mime_type {
+            Some(mime_type) => format!("[embedded text {uri} {mime_type}] {text}"),
+            None => format!("[embedded text {uri}] {text}"),
+        },
+        AcpContentBlockEvent::EmbeddedBlobResource {
+            uri,
+            mime_type,
+            byte_len,
+        } => match mime_type {
+            Some(mime_type) => format!("[embedded blob {uri} {mime_type} {byte_len} bytes]"),
+            None => format!("[embedded blob {uri} {byte_len} bytes]"),
+        },
+        AcpContentBlockEvent::Unsupported { description } => {
+            format!("[unsupported content {description}]")
+        }
+    }
+}
+
+fn permission_title(request: &AcpPermissionRequest) -> String {
+    request
+        .title
+        .clone()
+        .unwrap_or_else(|| request.tool_call_id.clone())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1325,5 +1766,37 @@ mod tests {
         };
 
         assert_eq!(AcpPanel::command_display(&agent), "-");
+    }
+
+    #[test]
+    fn render_content_block_formats_resource_link() {
+        let rendered = super::render_content_block(&AcpContentBlockEvent::ResourceLink {
+            name: "README".to_string(),
+            uri: "file:///workspace/README.md".to_string(),
+            title: Some("Workspace README".to_string()),
+            description: None,
+            mime_type: Some("text/markdown".to_string()),
+        });
+
+        assert_eq!(
+            rendered,
+            "[resource README Workspace README file:///workspace/README.md]"
+        );
+    }
+
+    #[test]
+    fn permission_title_prefers_explicit_title() {
+        let request = AcpPermissionRequest {
+            session_id: "session-1".to_string(),
+            tool_call_id: "tool-1".to_string(),
+            title: Some("Write output.txt".to_string()),
+            kind: Some("edit".to_string()),
+            status: Some("pending".to_string()),
+            raw_input: None,
+            raw_output: None,
+            options: Vec::new(),
+        };
+
+        assert_eq!(super::permission_title(&request), "Write output.txt");
     }
 }

--- a/klaw-gui/src/runtime_bridge.rs
+++ b/klaw-gui/src/runtime_bridge.rs
@@ -1,4 +1,6 @@
-use klaw_acp::{AcpRuntimeSnapshot, AcpSyncResult};
+use klaw_acp::{
+    AcpPermissionDecision, AcpPermissionRequest, AcpRuntimeSnapshot, AcpSessionEvent, AcpSyncResult,
+};
 use klaw_channel::{ChannelInstanceKey, ChannelInstanceStatus, ChannelSyncResult};
 use klaw_config::TailscaleMode;
 use klaw_gateway::{GatewayRuntimeInfo, TailscaleHostInfo};
@@ -34,8 +36,14 @@ pub struct ProviderRuntimeSnapshot {
 
 #[derive(Debug, Clone)]
 pub enum AcpPromptEvent {
-    Chunk(String),
-    Completed { final_output: String },
+    SessionEvent(AcpSessionEvent),
+    PermissionRequested {
+        request_id: u64,
+        request: AcpPermissionRequest,
+    },
+    Completed {
+        final_output: String,
+    },
     Stopped,
     Failed(String),
 }
@@ -89,6 +97,11 @@ pub enum RuntimeCommand {
         events: mpsc::Sender<AcpPromptEvent>,
     },
     StopAcpPrompt {
+        response: mpsc::Sender<Result<(), String>>,
+    },
+    ResolveAcpPermission {
+        request_id: u64,
+        decision: AcpPermissionDecision,
         response: mpsc::Sender<Result<(), String>>,
     },
     RunCronNow {
@@ -691,23 +704,17 @@ pub fn request_mcp_status() -> Result<McpRuntimeSnapshot, String> {
 }
 
 pub fn request_acp_status() -> Result<AcpRuntimeSnapshot, String> {
-    let sender = match sender_slot()
+    let sender = sender_slot()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
         .clone()
-    {
-        Some(s) => s,
-        None => return Err("runtime command channel is not available".to_string()),
-    };
+        .ok_or_else(|| "runtime command channel is not available".to_string())?;
     let (response_tx, response_rx) = mpsc::channel();
-    if sender
+    sender
         .send(RuntimeCommand::GetAcpStatus {
             response: response_tx,
         })
-        .is_err()
-    {
-        return Err("failed to send runtime command".to_string());
-    }
+        .map_err(|_| "failed to send runtime command".to_string())?;
 
     match recv_response(response_rx, RUNTIME_STATUS_TIMEOUT, "acp status") {
         Ok(result) => result,
@@ -754,12 +761,38 @@ pub fn request_stop_acp_prompt() -> Result<(), String> {
     recv_response(response_rx, RUNTIME_ACTION_TIMEOUT, "stop acp prompt")?
 }
 
+pub fn request_resolve_acp_permission(
+    request_id: u64,
+    decision: AcpPermissionDecision,
+) -> Result<(), String> {
+    let sender = sender_slot()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone()
+        .ok_or_else(|| "runtime command channel is not available".to_string())?;
+    let (response_tx, response_rx) = mpsc::channel();
+    sender
+        .send(RuntimeCommand::ResolveAcpPermission {
+            request_id,
+            decision,
+            response: response_tx,
+        })
+        .map_err(|_| "failed to send runtime command".to_string())?;
+    recv_response(
+        response_rx,
+        RUNTIME_ACTION_TIMEOUT,
+        "resolve acp permission",
+    )?
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        AcpPromptEvent, RuntimeRequestHandle, drain_log_chunks, install_log_receiver,
-        log_stats_snapshot, record_dropped_log_chunk,
+        AcpPromptEvent, RuntimeCommand, RuntimeRequestHandle, clear_runtime_command_sender,
+        drain_log_chunks, install_log_receiver, install_runtime_command_sender, log_stats_snapshot,
+        record_dropped_log_chunk, request_resolve_acp_permission,
     };
+    use klaw_acp::AcpPermissionDecision;
     use std::sync::mpsc;
     use std::time::Duration;
 
@@ -777,6 +810,39 @@ mod tests {
     #[test]
     fn acp_prompt_event_stopped_is_distinct() {
         assert!(matches!(AcpPromptEvent::Stopped, AcpPromptEvent::Stopped));
+    }
+
+    #[test]
+    fn request_resolve_acp_permission_sends_runtime_command() {
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+        install_runtime_command_sender(sender);
+
+        let worker = std::thread::spawn(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("runtime");
+            runtime.block_on(async move {
+                match receiver.recv().await {
+                    Some(RuntimeCommand::ResolveAcpPermission {
+                        request_id,
+                        decision,
+                        response,
+                    }) => {
+                        assert_eq!(request_id, 42);
+                        assert!(matches!(decision, AcpPermissionDecision::Cancelled));
+                        response.send(Ok(())).expect("send response");
+                    }
+                    other => panic!("unexpected runtime command: {other:?}"),
+                }
+            });
+        });
+
+        let result = request_resolve_acp_permission(42, AcpPermissionDecision::Cancelled);
+        clear_runtime_command_sender();
+        worker.join().expect("worker thread joins");
+
+        assert_eq!(result, Ok(()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- preserve standard ACP `SessionUpdate` traffic as structured events from `klaw-acp` through the GUI runtime bridge instead of flattening updates into plain text chunks
- add a real ACP permission roundtrip so the ACP panel can surface pending permission requests, send user decisions back to the running session, and cancel unresolved requests when prompts stop
- upgrade the ACP panel and detail window to expose mode, config options, available commands, session metadata, event timelines, and raw stream output for debugging external ACP agents

## Test plan
- [x] `cargo check -p klaw-acp -p klaw-gui -p klaw-cli`
- [x] `cargo test -p klaw-acp -p klaw-gui -p klaw-cli`

Closes #154

Made with [Cursor](https://cursor.com)