### PR TITLE
fix(core): tighten runtime prompt truthfulness rules

### DIFF
--- a/klaw-core/CHANGELOG.md
+++ b/klaw-core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-04-03
+
+### Changed
+- strengthened the runtime system prompt with an explicit truthfulness rule that forbids claiming files were read, commands were run, searches were performed, or other tool-backed actions were completed unless they were actually verified by a tool result in the current turn or directly provided by the user
+
 ## 2026-04-02
 
 ### Changed

--- a/klaw-core/src/prompt.rs
+++ b/klaw-core/src/prompt.rs
@@ -12,7 +12,30 @@ const INLINED_WORKSPACE_PROMPT_DOC_FILES: [&str; 4] =
     ["AGENTS.md", "SOUL.md", "IDENTITY.md", "TOOLS.md"];
 const ON_DEMAND_WORKSPACE_PROMPT_DOC_FILES: [&str; 2] = ["USER.md", "BOOTSTRAP.md"];
 const RUNTIME_PROMPT_RULES: &str = "Treat the inlined workspace docs below as baseline instructions. Lazy-load only the remaining workspace docs and skills when they are relevant to the current user request.";
-const RUNTIME_PROMPT_EXTRA_INSTRUCTIONS: &str = "Do not re-read `AGENTS.md`, `SOUL.md`, `IDENTITY.md`, or `TOOLS.md` just to recover instructions already inlined into this system prompt.\nWhen additional workspace context is needed, read only the remaining on-demand docs from disk before acting.\nWhen a task requires remembering or recalling prior context, use the memory tool. Do not rely on ad-hoc markdown memory files.\nFiles under archives/ are read-only source material. Never edit, move, or delete them in place. If you need to transform or modify an archived file, use the archive tool to copy it into workspace first, then operate on the copied file.\nWhen the user wants a file or image sent back into chat, use the `channel_attachment` tool instead of only describing the file in plain text. Use `archive_id` when you already have a valid archived file id. Use `path` only for an absolute local file path that is inside the workspace or a configured channel allowlist. Prefer `kind=image` for screenshots or images that should render inline, and `kind=file` for generic documents or downloads. Never pass a list index like `1` as `archive_id`, and never use a relative path.";
+const RUNTIME_PROMPT_EXTRA_INSTRUCTIONS: &str = concat!(
+    "General:\n",
+    "- Do not re-read `AGENTS.md`, `SOUL.md`, `IDENTITY.md`, or `TOOLS.md` just to recover instructions already inlined into this system prompt.\n",
+    "- When additional workspace context is needed, read only the remaining on-demand docs from disk before acting.\n",
+    "\n",
+    "Truthfulness:\n",
+    "- Never claim to have read, checked, searched, run, verified, confirmed, sent, or changed something unless that action actually happened through a tool result in this turn or the evidence was explicitly provided by the user in the conversation.\n",
+    "- Do not present intended actions, assumptions, remembered context, or likely outcomes as completed work.\n",
+    "- If something has not been verified yet, say that it is unverified and describe the next tool you would use to verify it.\n",
+    "\n",
+    "Memory:\n",
+    "- When a task requires remembering or recalling prior context, use the memory tool. Do not rely on ad-hoc markdown memory files.\n",
+    "\n",
+    "Archives:\n",
+    "- Files under archives/ are read-only source material. Never edit, move, or delete them in place.\n",
+    "- If you need to transform or modify an archived file, use the archive tool to copy it into workspace first, then operate on the copied file.\n",
+    "\n",
+    "Channel Attachments:\n",
+    "- When the user wants a file or image sent back into chat, use the `channel_attachment` tool instead of only describing the file in plain text.\n",
+    "- Use `archive_id` when you already have a valid archived file id.\n",
+    "- Use `path` only for an absolute local file path that is inside the workspace or a configured channel allowlist.\n",
+    "- Prefer `kind=image` for screenshots or images that should render inline, and `kind=file` for generic documents or downloads.\n",
+    "- Never pass a list index like `1` as `archive_id`, and never use a relative path.\n",
+);
 
 const PROMPT_TEMPLATE_FILES: [(&str, &str); 6] = [
     ("AGENTS.md", include_str!("../templates/prompt/AGENTS.md")),
@@ -559,6 +582,9 @@ mod tests {
         assert!(
             prompt.contains("Do not re-read `AGENTS.md`, `SOUL.md`, `IDENTITY.md`, or `TOOLS.md`")
         );
+        assert!(prompt.contains(
+            "Never claim to have read, checked, searched, run, verified, confirmed, sent, or changed something unless that action actually happened through a tool result in this turn"
+        ));
     }
 
     #[tokio::test(flavor = "current_thread")]


### PR DESCRIPTION
## Summary
- add an explicit runtime system-prompt truthfulness rule so the agent does not claim tool-backed work that was never actually verified
- restructure `RUNTIME_PROMPT_EXTRA_INSTRUCTIONS` into clearer sections for maintenance and future prompt updates
- record the prompt change in `klaw-core/CHANGELOG.md`

## Test plan
- [x] `cargo test -p klaw-core prompt`


Made with [Cursor](https://cursor.com)