### PR TITLE
refactor(core): remove ErrorClass and standardize docs

### DIFF
--- a/klaw-core/CHANGELOG.md
+++ b/klaw-core/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 ## 2026-04-03
 
+### Removed
+- removed the unused `ErrorClass` enum from `reliability.rs` because runtime error handling already flows through `ErrorCode` and normalized retry buckets
+
 ### Changed
 - strengthened the runtime system prompt with an explicit truthfulness rule that forbids claiming files were read, commands were run, searches were performed, or other tool-backed actions were completed unless they were actually verified by a tool result in the current turn or directly provided by the user
+- translated remaining `klaw-core` Rust doc comments to English and added clarifying comments around runtime error normalization
 
 ## 2026-04-02
 

--- a/klaw-core/src/agent_loop.rs
+++ b/klaw-core/src/agent_loop.rs
@@ -1517,6 +1517,8 @@ impl AgentLoop {
     }
 }
 
+// Retry policies operate on a small set of stable buckets, so the runtime
+// normalizes concrete protocol error codes before delegating to the policy.
 fn classify_error_kind(code: Option<ErrorCode>) -> &'static str {
     match code {
         Some(ErrorCode::ValidationFailed | ErrorCode::InvalidSchema) => "validation",
@@ -1528,6 +1530,8 @@ fn classify_error_kind(code: Option<ErrorCode>) -> &'static str {
     }
 }
 
+// Provider-layer failures are converted into protocol-level error codes so the
+// rest of the runtime can make retry, telemetry, and DLQ decisions uniformly.
 fn map_llm_error_to_code(err: &LlmError) -> ErrorCode {
     match err {
         LlmError::ProviderUnavailable { .. }

--- a/klaw-core/src/media.rs
+++ b/klaw-core/src/media.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
-/// 媒体来源类型，供 channel/tool/archive 之间共享。
+/// Shared media source categories used across channels, tools, and archives.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum MediaSourceKind {
@@ -10,7 +10,7 @@ pub enum MediaSourceKind {
     ModelGenerated,
 }
 
-/// 标准化的媒体引用，占位表示可归档或可下载的媒体对象。
+/// Standardized media reference that can point to archival or downloadable media.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MediaReference {
     pub source_kind: MediaSourceKind,

--- a/klaw-core/src/mock.rs
+++ b/klaw-core/src/mock.rs
@@ -11,7 +11,7 @@ use async_trait::async_trait;
 use std::{collections::HashSet, collections::VecDeque, sync::Arc, time::Duration};
 use tokio::sync::Mutex;
 
-/// 内存传输实现，用于本地与测试。
+/// In-memory transport implementation for local runs and tests.
 #[derive(Debug, Clone)]
 pub struct InMemoryTransport<T> {
     queue: Arc<Mutex<VecDeque<Envelope<T>>>>,
@@ -28,19 +28,19 @@ impl<T> Default for InMemoryTransport<T> {
 }
 
 impl<T> InMemoryTransport<T> {
-    /// 创建空队列传输实例。
+    /// Creates an empty transport instance.
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// 注入一条待消费消息。
+    /// Enqueues a message so it can be consumed later.
     pub async fn enqueue(&self, msg: Envelope<T>) {
         self.queue.lock().await.push_back(msg);
     }
 }
 
 impl<T: Clone> InMemoryTransport<T> {
-    /// 获取已发布消息快照。
+    /// Returns a snapshot of all messages published so far.
     pub async fn published_messages(&self) -> Vec<Envelope<T>> {
         self.published.lock().await.clone()
     }
@@ -51,7 +51,7 @@ impl<T> MessageTransport<T> for InMemoryTransport<T>
 where
     T: Send + Sync + Clone + 'static,
 {
-    /// 内存实现默认采用 at-least-once 语义。
+    /// The in-memory transport models at-least-once delivery semantics.
     fn mode(&self) -> DeliveryMode {
         DeliveryMode::AtLeastOnce
     }
@@ -94,7 +94,7 @@ where
     }
 }
 
-/// 内存会话调度器，提供最小可用调度行为。
+/// In-memory session scheduler with the smallest useful behavior surface.
 #[derive(Debug, Clone)]
 pub struct InMemorySessionScheduler {
     max_depth: usize,
@@ -102,7 +102,7 @@ pub struct InMemorySessionScheduler {
 }
 
 impl InMemorySessionScheduler {
-    /// 创建调度器。
+    /// Creates a new scheduler instance.
     pub fn new(max_depth: usize, lock_ttl: Duration) -> Self {
         Self {
             max_depth,
@@ -146,7 +146,7 @@ where
     }
 }
 
-/// 内存幂等存储实现。
+/// In-memory idempotency store implementation.
 #[derive(Debug, Default, Clone)]
 pub struct InMemoryIdempotencyStore {
     keys: Arc<Mutex<HashSet<String>>>,

--- a/klaw-core/src/observability.rs
+++ b/klaw-core/src/observability.rs
@@ -3,20 +3,20 @@ use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use uuid::Uuid;
 
-/// 健康状态枚举。
+/// Health status values reported by runtime components.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HealthStatus {
-    /// 依赖就绪，可接流量。
+    /// Dependencies are ready and the component can serve traffic.
     Ready,
-    /// 进程存活。
+    /// The process is alive.
     Live,
-    /// 可用但功能受限。
+    /// The component is available but running in a degraded mode.
     Degraded,
-    /// 不可用。
+    /// The component is unavailable.
     Unavailable,
 }
 
-/// 统一指标名称。
+/// Canonical metric names emitted by the runtime.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MetricName {
     InboundConsumedTotal,
@@ -30,7 +30,7 @@ pub enum MetricName {
 }
 
 impl MetricName {
-    /// 返回指标的标准字符串名称。
+    /// Returns the stable metric name string.
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::InboundConsumedTotal => "agent_inbound_consumed_total",
@@ -113,25 +113,25 @@ pub struct TurnOutcomeRecord {
     pub tool_loop_exhausted: bool,
 }
 
-/// 审计事件负载。
+/// Structured payload recorded for audit events.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AuditEvent {
-    /// 事件名称。
+    /// Event name.
     pub event_name: String,
-    /// 追踪 ID。
+    /// Trace identifier.
     pub trace_id: Uuid,
-    /// 会话键（可选）。
+    /// Session key, when available.
     pub session_key: Option<String>,
-    /// 错误码（可选）。
+    /// Error code, when available.
     pub error_code: Option<String>,
-    /// 扩展负载。
+    /// Additional event payload.
     pub payload: serde_json::Value,
 }
 
-/// 可观测性上报抽象。
+/// Observability reporting abstraction used by the runtime.
 #[async_trait]
 pub trait AgentTelemetry: Send + Sync {
-    /// 记录工具调用结果。
+    /// Records the outcome of a tool invocation.
     async fn record_tool_outcome(
         &self,
         session_key: &str,
@@ -140,28 +140,28 @@ pub trait AgentTelemetry: Send + Sync {
         error_code: Option<&str>,
         duration: Duration,
     );
-    /// 记录模型请求结果。
+    /// Records an LLM request result.
     async fn record_model_request(&self, record: ModelRequestRecord);
-    /// 记录按模型归因的工具调用结果。
+    /// Records a tool result attributed to a specific provider/model pair.
     async fn record_model_tool_outcome(&self, record: ModelToolOutcomeRecord);
-    /// 记录单轮 agent 执行结果。
+    /// Records the outcome of a single agent turn.
     async fn record_turn_outcome(&self, record: TurnOutcomeRecord);
-    /// 增加计数器。
+    /// Increments a counter metric.
     async fn incr_counter(&self, name: &'static str, labels: &[(&str, &str)], value: u64);
-    /// 上报直方图时延。
+    /// Observes a duration in a histogram metric.
     async fn observe_histogram(
         &self,
         name: &'static str,
         labels: &[(&str, &str)],
         duration: Duration,
     );
-    /// 记录审计事件。
+    /// Emits an audit event.
     async fn emit_audit_event(
         &self,
         event_name: &'static str,
         trace_id: Uuid,
         payload: serde_json::Value,
     );
-    /// 设置组件健康状态。
+    /// Updates component health state.
     async fn set_health(&self, component: &'static str, status: HealthStatus);
 }

--- a/klaw-core/src/reliability.rs
+++ b/klaw-core/src/reliability.rs
@@ -30,32 +30,11 @@ pub trait RetryPolicy: Send + Sync {
     /// Defines the upper bound for retry attempts.
     fn max_attempts(&self) -> u32;
     /// Classifies the error and returns the appropriate retry decision.
-    /// @param error_kind - String identifier for the error category (e.g., "timeout", "validation")
-    /// @param attempt - Current attempt number (starting from 1)
+    /// `error_kind` is the normalized retry bucket selected by the runtime for
+    /// the current failure (for example, `validation` or
+    /// `provider_unavailable`).
+    /// `attempt` starts at 1 for the first failure.
     fn classify(&self, error_kind: &str, attempt: u32) -> RetryDecision;
-}
-
-/// Error classification categories for systematic error handling.
-/// Provides a structured way to categorize errors based on their nature and recoverability.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ErrorClass {
-    /// Validation errors - payload or input doesn't meet requirements.
-    /// These are typically permanent and should not be retried.
-    Validation,
-    /// Temporary dependency failures - external service temporarily unavailable.
-    /// These are typically recoverable after a short delay.
-    DependencyTemporary,
-    /// Permanent dependency failures - external service returning persistent errors.
-    /// These may require intervention and should not be blindly retried.
-    DependencyPermanent,
-    /// Temporary infrastructure failures - network or resource issues.
-    /// These are typically recoverable after infrastructure recovers.
-    InfrastructureTemporary,
-    /// Permanent infrastructure failures - persistent system-level issues.
-    InfrastructurePermanent,
-    /// Budget or quota limit exceeded errors.
-    /// These require quota increase or throttling adjustments to resolve.
-    BudgetExceeded,
 }
 
 /// Dead letter policy configuration for handling permanently failed messages.
@@ -140,6 +119,8 @@ impl RetryPolicy for ExponentialBackoffRetryPolicy {
             return RetryDecision::SendToDeadLetter;
         }
 
+        // Keep retry buckets coarse so runtime code can map multiple concrete
+        // error codes onto one retry decision path.
         match error_kind {
             "validation" | "schema" | "duplicate" => RetryDecision::Abort,
             "provider_unavailable" | "transport_unavailable" | "tool_timeout" => {

--- a/klaw-core/src/scheduler.rs
+++ b/klaw-core/src/scheduler.rs
@@ -1,55 +1,55 @@
 use async_trait::async_trait;
 use std::time::Duration;
 
-/// 可被会话调度器调度的任务。
+/// A task that can be scheduled by the session scheduler.
 pub trait SessionTask: Send + Sync {
-    /// 返回该任务的会话键。
+    /// Returns the session key that serializes this task.
     fn session_key(&self) -> &str;
-    /// 返回该任务唯一 ID。
+    /// Returns the unique identifier for this task.
     fn task_id(&self) -> &str;
 }
 
-/// 会话队列溢出策略。
+/// Overflow policy applied when a session queue is already saturated.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum QueueOverflowPolicy {
-    /// 聚合并继续排队。
+    /// Collect the work and keep it in the same queue.
     Collect,
-    /// 转化为 follow-up 任务。
+    /// Convert the work into a follow-up task.
     FollowUp,
-    /// 直接拒绝。
+    /// Reject the work immediately.
     Drop,
 }
 
-/// 调度决策结果。
+/// Scheduling decision returned by a session scheduler.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TaskScheduleDecision {
-    /// 立即执行。
+    /// Execute the task immediately.
     ExecuteNow,
-    /// 已入队，返回当前队列深度。
+    /// The task was enqueued and the current queue depth is returned.
     Enqueued { queue_depth: usize },
-    /// 被拒绝并附带原因。
+    /// The task was rejected with a stable reason string.
     Rejected { reason: &'static str },
 }
 
-/// 会话串行调度抽象。
+/// Serial scheduling abstraction for session-scoped work.
 #[async_trait]
 pub trait SessionScheduler<T>: Send + Sync
 where
     T: SessionTask,
 {
-    /// 调度任务并返回决策。
+    /// Schedules a task and returns the resulting decision.
     async fn schedule(&self, task: T, overflow_policy: QueueOverflowPolicy)
     -> TaskScheduleDecision;
 
-    /// 标记任务执行完成，释放会话占用。
+    /// Marks a task as complete and releases any session lock.
     async fn complete(&self, session_key: &str, task_id: &str);
 
-    /// 查询会话队列深度。
+    /// Returns the current queue depth for the session.
     async fn queue_depth(&self, session_key: &str) -> usize;
 
-    /// 返回允许的最大队列深度。
+    /// Returns the maximum queue depth allowed by this scheduler.
     fn max_queue_depth(&self) -> usize;
 
-    /// 返回会话锁 TTL。
+    /// Returns the lock TTL used for session serialization.
     fn session_lock_ttl(&self) -> Duration;
 }


### PR DESCRIPTION
## Summary
- remove the unused `ErrorClass` enum from `klaw-core` now that runtime retry behavior is already driven by normalized `ErrorCode` buckets
- translate remaining Rust doc comments in `klaw-core` source files from Chinese to English for a consistent crate surface
- add brief clarifying comments around runtime error normalization and update the crate changelog

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo test -p klaw-core`

Closes #161

Made with [Cursor](https://cursor.com)