### PR TITLE
fix(channel): render dingtalk approval commands as code blocks

### DIFF
--- a/klaw-channel/CHANGELOG.md
+++ b/klaw-channel/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 2026-04-09
+
+### Fixed
+
+- `dingtalk` 审批 ActionCard 里的“待执行命令”预览改为 fenced code block 输出，不再使用单行反引号，长命令在卡片里会以代码框样式展示
+
 ## 2026-04-08
 
 ### Changed

--- a/klaw-channel/src/dingtalk/parsing.rs
+++ b/klaw-channel/src/dingtalk/parsing.rs
@@ -1113,7 +1113,7 @@ fn base_card_sections(card: &ImCard, fallback_title: &str) -> Vec<String> {
     )];
     if let Some(command_preview) = card.command_preview() {
         sections.push(format!(
-            "**待执行命令**\n\n`{}`",
+            "**待执行命令**\n\n```\n{}\n```",
             escape_markdown_for_action_card(command_preview)
         ));
     }

--- a/klaw-channel/src/dingtalk/tests.rs
+++ b/klaw-channel/src/dingtalk/tests.rs
@@ -706,7 +706,7 @@ fn build_approval_action_card_body_includes_command_preview() {
     let card = resolve_approval_card(&output).expect("approval card");
     let body = build_approval_action_card_body(&card);
     assert!(body.contains("待执行命令"));
-    assert!(body.contains("python3 -c \"print(1)\""));
+    assert!(body.contains("```\npython3 -c \"print(1)\"\n```"));
     assert!(body.contains("审批单: `approval-1`"));
 }
 


### PR DESCRIPTION
Fixes #187

## Summary
- render DingTalk approval command previews as fenced code blocks
- keep long shell commands readable inside approval action cards
- strengthen the regression test to lock in the block-formatted output

## Test plan
- [x] cargo fmt --all
- [x] cargo test -p klaw-channel dingtalk


Made with [Cursor](https://cursor.com)