### PR TITLE
fix(runtime): accept cron and webhook shell approvals

### DIFF
--- a/klaw-cron/CHANGELOG.md
+++ b/klaw-cron/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 2026-04-09
+
+### Fixed
+
+- `CronWorker` 现在会把 execution session 的 `channel.base_session_key` / `channel.delivery_session_key` 连同回复所需的 channel metadata 一起持久化到 session 索引，允许后续 `/approve` 之类的交互命令安全识别并认领 cron 触发的隔离执行 session
+
 ## 2026-03-31
 
 ### Fixed

--- a/klaw-cron/src/worker.rs
+++ b/klaw-cron/src/worker.rs
@@ -137,6 +137,18 @@ where
             "channel.delivery_session_key".to_string(),
             serde_json::Value::String(delivery_session_key),
         );
+        if let Some(delivery_metadata_json) =
+            persistable_session_delivery_metadata_json(&payload.metadata)
+        {
+            self.storage
+                .set_delivery_metadata(
+                    &execution_session_key,
+                    &payload.chat_id,
+                    &payload.channel,
+                    Some(&delivery_metadata_json),
+                )
+                .await?;
+        }
 
         let envelope = Envelope {
             header: EnvelopeHeader::new(execution_session_key),
@@ -234,6 +246,25 @@ where
 
 fn build_execution_session_key(job_id: &str, run_id: &str) -> String {
     format!("cron:{job_id}:{run_id}")
+}
+
+fn persistable_session_delivery_metadata_json(
+    metadata: &BTreeMap<String, serde_json::Value>,
+) -> Option<String> {
+    let delivery_metadata = metadata
+        .iter()
+        .filter_map(|(key, value)| match key.as_str() {
+            "channel.base_session_key"
+            | "channel.delivery_session_key"
+            | "channel.dingtalk.session_webhook"
+            | "channel.dingtalk.bot_title" => Some((key.clone(), value.clone())),
+            _ => None,
+        })
+        .collect::<serde_json::Map<String, serde_json::Value>>();
+    if delivery_metadata.is_empty() {
+        return None;
+    }
+    serde_json::to_string(&delivery_metadata).ok()
 }
 
 fn infer_base_session_key(payload: &InboundMessage) -> Option<String> {
@@ -1344,6 +1375,29 @@ mod tests {
             messages[0]
                 .payload
                 .metadata
+                .get("channel.delivery_session_key")
+                .and_then(|value| value.as_str()),
+            Some("dingtalk:acc:chat1:child")
+        );
+        let execution_session = storage
+            .get_session(&messages[0].header.session_key)
+            .await
+            .expect("execution session should be persisted");
+        let execution_metadata = execution_session
+            .delivery_metadata_json
+            .as_deref()
+            .map(serde_json::from_str::<serde_json::Map<String, serde_json::Value>>)
+            .transpose()
+            .expect("execution delivery metadata should parse")
+            .expect("execution delivery metadata should exist");
+        assert_eq!(
+            execution_metadata
+                .get("channel.base_session_key")
+                .and_then(|value| value.as_str()),
+            Some("dingtalk:acc:chat1")
+        );
+        assert_eq!(
+            execution_metadata
                 .get("channel.delivery_session_key")
                 .and_then(|value| value.as_str()),
             Some("dingtalk:acc:chat1:child")

--- a/klaw-runtime/CHANGELOG.md
+++ b/klaw-runtime/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 2026-04-09
+
+### Fixed
+
+- `/approve` 现在会识别挂接到当前会话链路上的 `cron` / `webhook` execution session 审批；当 approval 绑定的是隔离执行 session 时，runtime 会依据持久化的 `channel.base_session_key` / `channel.delivery_session_key` 允许当前 IM 会话认领并继续执行批准后的 shell 命令
+
 ## 2026-04-08
 
 ### Added

--- a/klaw-runtime/src/im_commands/mod.rs
+++ b/klaw-runtime/src/im_commands/mod.rs
@@ -20,6 +20,77 @@ pub(super) fn second_arg_token(arg: Option<&str>) -> Option<&str> {
     parser::second_arg_token(arg)
 }
 
+fn approval_link_metadata_matches_route(
+    metadata: &BTreeMap<String, Value>,
+    route: &SessionRoute,
+    base_session_key: &str,
+) -> bool {
+    let linked_base = metadata
+        .get("channel.base_session_key")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let linked_delivery = metadata
+        .get("channel.delivery_session_key")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    if linked_base.is_none() && linked_delivery.is_none() {
+        return false;
+    }
+    let base_matches = linked_base.is_some_and(|value| value == base_session_key);
+    let delivery_matches =
+        linked_delivery.is_some_and(|value| value == route.active_session_key.as_str());
+    let base_conflict = linked_base.is_some_and(|value| value != base_session_key);
+    let delivery_conflict =
+        linked_delivery.is_some_and(|value| value != route.active_session_key.as_str());
+    (base_matches || delivery_matches) && !base_conflict && !delivery_conflict
+}
+
+async fn approval_belongs_to_route(
+    runtime: &RuntimeBundle,
+    approval_session_key: &str,
+    route: &SessionRoute,
+    base_session_key: &str,
+) -> bool {
+    if approval_session_key == route.active_session_key || approval_session_key == base_session_key
+    {
+        return true;
+    }
+    let sessions = session_manager(runtime);
+    let Ok(session) = sessions.get_session(approval_session_key).await else {
+        return false;
+    };
+    let metadata = session
+        .delivery_metadata_json
+        .as_deref()
+        .and_then(parse_delivery_metadata_json)
+        .unwrap_or_default();
+    approval_link_metadata_matches_route(&metadata, route, base_session_key)
+}
+
+async fn approval_followup_context(
+    runtime: &RuntimeBundle,
+    approval_session_key: &str,
+    fallback_channel: &str,
+    fallback_chat_id: &str,
+) -> (String, String, BTreeMap<String, Value>) {
+    let sessions = session_manager(runtime);
+    let Ok(session) = sessions.get_session(approval_session_key).await else {
+        return (
+            fallback_channel.to_string(),
+            fallback_chat_id.to_string(),
+            BTreeMap::new(),
+        );
+    };
+    let metadata = session
+        .delivery_metadata_json
+        .as_deref()
+        .and_then(parse_delivery_metadata_json)
+        .unwrap_or_default();
+    (session.channel, session.chat_id, metadata)
+}
+
 pub(super) async fn try_handle(
     runtime: &RuntimeBundle,
     channel: String,
@@ -273,8 +344,8 @@ pub(super) async fn handle_im_command(
                     )));
                 }
             };
-            if approval.session_key != route.active_session_key
-                && approval.session_key != base_session_key
+            if !approval_belongs_to_route(runtime, &approval.session_key, &route, &base_session_key)
+                .await
             {
                 return Ok(Some(channel_response(
                     format!("❌ Approval `{approval_id}` does not belong to current session."),
@@ -337,17 +408,32 @@ pub(super) async fn handle_im_command(
                         shell_result:\n{}",
                         approved.id, approved.command_preview, execution_result
                     );
+                    let (followup_channel, followup_chat_id, stored_delivery_metadata) =
+                        approval_followup_context(
+                            runtime,
+                            &approved.session_key,
+                            &channel,
+                            &chat_id,
+                        )
+                        .await;
+                    let mut followup_request_metadata =
+                        build_approved_shell_followup_request_metadata(&request_metadata);
+                    for (key, value) in stored_delivery_metadata {
+                        if key.starts_with("channel.") || key.starts_with("webhook.") {
+                            followup_request_metadata.entry(key).or_insert(value);
+                        }
+                    }
                     let maybe_output = submit_and_get_output(
                         runtime,
-                        channel.clone(),
+                        followup_channel,
                         model_followup_input,
                         approved.session_key.clone(),
-                        chat_id.clone(),
+                        followup_chat_id,
                         "local-user".to_string(),
                         route.model_provider.clone(),
                         route.model.clone(),
                         Vec::new(),
-                        build_approved_shell_followup_request_metadata(&request_metadata),
+                        followup_request_metadata,
                     )
                     .await?;
                     match maybe_output {
@@ -390,8 +476,8 @@ pub(super) async fn handle_im_command(
                     )));
                 }
             };
-            if approval.session_key != route.active_session_key
-                && approval.session_key != base_session_key
+            if !approval_belongs_to_route(runtime, &approval.session_key, &route, &base_session_key)
+                .await
             {
                 return Ok(Some(channel_response(
                     format!("❌ Approval `{approval_id}` does not belong to current session."),

--- a/klaw-runtime/src/lib.rs
+++ b/klaw-runtime/src/lib.rs
@@ -1385,9 +1385,13 @@ fn persistable_session_delivery_metadata_json(
     let delivery_metadata = metadata
         .iter()
         .filter_map(|(key, value)| match key.as_str() {
-            "channel.dingtalk.session_webhook" | "channel.dingtalk.bot_title" => {
-                Some((key.clone(), value.clone()))
-            }
+            "channel.base_session_key"
+            | "channel.delivery_session_key"
+            | "channel.dingtalk.session_webhook"
+            | "channel.dingtalk.bot_title"
+            | "webhook.delivery_session_key"
+            | "webhook.delivery_channel"
+            | "webhook.delivery_chat_id" => Some((key.clone(), value.clone())),
             _ => None,
         })
         .collect::<serde_json::Map<String, serde_json::Value>>();
@@ -2458,6 +2462,18 @@ async fn submit_webhook_isolated_turn(
             "webhook.delivery_chat_id".to_string(),
             Value::String(route.chat_id.clone()),
         );
+    }
+    if let Some(delivery_metadata_json) =
+        persistable_session_delivery_metadata_json(&inbound_metadata)
+    {
+        sessions
+            .set_delivery_metadata(
+                &execution.session_key,
+                &execution.chat_id,
+                "webhook",
+                Some(&delivery_metadata_json),
+            )
+            .await?;
     }
 
     let envelope = Envelope {
@@ -4824,6 +4840,101 @@ A .docx file is a ZIP archive containing XML files.
     }
 
     #[tokio::test(flavor = "current_thread")]
+    async fn approve_command_accepts_linked_execution_session_approval() {
+        let provider = Arc::new(BootstrapCaptureProvider::default());
+        let runtime = build_test_runtime(provider.clone()).await;
+        let channel = "telegram".to_string();
+        let base_session_key = "telegram:tg7:chat-linked".to_string();
+        let active_session_key = "telegram:tg7:chat-linked:active".to_string();
+        let execution_session_key = "webhook:github:req-linked".to_string();
+        let chat_id = "chat-linked".to_string();
+        let sessions = test_session_manager(&runtime);
+        sessions
+            .get_or_create_session_state(
+                &base_session_key,
+                &chat_id,
+                &channel,
+                "test-provider",
+                "test-model",
+            )
+            .await
+            .expect("base session should exist");
+        sessions
+            .get_or_create_session_state(
+                &active_session_key,
+                &chat_id,
+                &channel,
+                "test-provider",
+                "test-model",
+            )
+            .await
+            .expect("active session should exist");
+        sessions
+            .set_active_session(&base_session_key, &chat_id, &channel, &active_session_key)
+            .await
+            .expect("active session should switch");
+        sessions
+            .get_or_create_session_state(
+                &execution_session_key,
+                &execution_session_key,
+                "webhook",
+                "test-provider",
+                "test-model",
+            )
+            .await
+            .expect("execution session should exist");
+        sessions
+            .set_delivery_metadata(
+                &execution_session_key,
+                &execution_session_key,
+                "webhook",
+                Some(
+                    "{\"channel.base_session_key\":\"telegram:tg7:chat-linked\",\"channel.delivery_session_key\":\"telegram:tg7:chat-linked:active\",\"webhook.delivery_session_key\":\"telegram:tg7:chat-linked:active\"}",
+                ),
+            )
+            .await
+            .expect("execution delivery metadata should persist");
+
+        let manager = approval_manager(&runtime);
+        let approval = manager
+            .create_approval(ApprovalCreateInput {
+                session_key: execution_session_key,
+                tool_name: "shell".to_string(),
+                command_text: "printf linked-approval".to_string(),
+                command_preview: Some("printf linked-approval".to_string()),
+                command_hash: Some("linked-command-hash-1".to_string()),
+                risk_level: Some("unsafe".to_string()),
+                requested_by: Some("agent".to_string()),
+                justification: None,
+                expires_in_minutes: Some(10),
+            })
+            .await
+            .expect("approval should be created");
+
+        let response = im_commands::handle_im_command(
+            &runtime,
+            channel,
+            base_session_key,
+            chat_id,
+            format!("/approve {}", approval.id),
+            BTreeMap::new(),
+        )
+        .await
+        .expect("approve command should succeed")
+        .expect("approve command should return a response");
+
+        assert_eq!(response.content, "bootstrap reply");
+        let captured = provider
+            .last_user_message
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
+            .clone()
+            .expect("follow-up user message should be captured");
+        assert!(captured.contains("shell_result:"));
+        assert!(captured.contains("linked-approval"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
     async fn submit_and_get_output_persists_dingtalk_delivery_metadata_on_active_session() {
         let provider = Arc::new(BootstrapCaptureProvider::default());
         let runtime = build_test_runtime(provider).await;
@@ -5042,6 +5153,25 @@ A .docx file is a ZIP archive containing XML files.
                 .payload
                 .metadata
                 .get("channel.delivery_session_key"),
+            Some(&json!("dingtalk:acc:chat-1:active"))
+        );
+        let execution_session = sessions
+            .get_session("webhook:github:req-1")
+            .await
+            .expect("execution session should exist");
+        let execution_metadata: serde_json::Map<String, Value> = execution_session
+            .delivery_metadata_json
+            .as_deref()
+            .map(serde_json::from_str)
+            .transpose()
+            .expect("execution delivery metadata should parse")
+            .expect("execution delivery metadata should exist");
+        assert_eq!(
+            execution_metadata.get("channel.base_session_key"),
+            Some(&json!("dingtalk:acc:chat-1"))
+        );
+        assert_eq!(
+            execution_metadata.get("channel.delivery_session_key"),
             Some(&json!("dingtalk:acc:chat-1:active"))
         );
     }


### PR DESCRIPTION
Fixes #189

## Summary
- persist `channel.base_session_key` and delivery routing metadata on isolated cron and webhook execution sessions
- allow `/approve` and `/reject` to recognize approvals linked to the current IM session route, not just the active/base session itself
- keep approved shell follow-up turns on the execution session context and add regression coverage for cron and webhook approval flows

## Test plan
- `cargo test -p klaw-runtime`
- `cargo test -p klaw-cron`

Made with [Cursor](https://cursor.com)