### PR TITLE
feat(agent): improve tool loop exhaustion handling

### DIFF
--- a/klaw-agent/CHANGELOG.md
+++ b/klaw-agent/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-04-11
+
+### Changed
+- When approaching the `max_tool_iterations` limit (≥3 iterations allowed), the agent now injects a final-iteration system prompt asking the model to summarize progress and respond directly instead of calling more tools
+
 ## 2026-03-26
 
 ### Added

--- a/klaw-agent/src/lib.rs
+++ b/klaw-agent/src/lib.rs
@@ -32,6 +32,7 @@ const META_CURRENT_ATTACHMENTS_KEY: &str = "agent.current_attachments";
 const APPROVAL_REQUIRED_SIGNAL: &str = "approval_required";
 const STOP_SIGNAL: &str = "stop";
 const STOPPED_TURN_MESSAGE: &str = "Current turn stopped. No further tool calls were made.";
+const FINAL_ITERATION_PROMPT: &str = "You are about to reach the maximum tool call limit. This is your final iteration. Please respond directly to the user with a summary of what you have accomplished so far, and explain that you have reached the tool call limit. Do NOT call any more tools in this response.";
 
 #[derive(Debug, Clone, Copy)]
 pub struct AgentExecutionLimits {
@@ -376,6 +377,32 @@ pub async fn run_agent_execution(
             break;
         }
         iteration = iteration.saturating_add(1);
+        let is_final_allowed_iteration =
+            max_tool_iterations > 0 && iteration == max_tool_iterations;
+        let should_warn_final_iteration = is_final_allowed_iteration
+            && max_tool_iterations >= 3
+            && !llm_messages.iter().any(|m| {
+                m.role == "system"
+                    && m
+                        .content
+                        .contains("You are about to reach the maximum tool call limit")
+            });
+        let final_iteration_messages: Option<Vec<LlmMessage>> =
+            if should_warn_final_iteration {
+                let mut msgs = llm_messages.clone();
+                msgs.push(LlmMessage {
+                    role: "system".to_string(),
+                    content: FINAL_ITERATION_PROMPT.to_string(),
+                    media: Vec::new(),
+                    tool_calls: None,
+                    tool_call_id: None,
+                });
+                Some(msgs)
+            } else {
+                None
+            };
+        let messages_for_request: &Vec<LlmMessage> =
+            final_iteration_messages.as_ref().unwrap_or(&llm_messages);
         let chat_options = ChatOptions {
             temperature: 0.2,
             max_tokens: None,
@@ -425,7 +452,7 @@ pub async fn run_agent_execution(
         });
         let llm_response = provider
             .chat_stream(
-                llm_messages.clone(),
+                messages_for_request.clone(),
                 tool_defs.clone(),
                 input.execution_context.resolved_model.as_deref(),
                 chat_options,

--- a/klaw-core/CHANGELOG.md
+++ b/klaw-core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-04-11
+
+### Changed
+- `ToolLoopExhausted` errors now return an informative response to the user instead of `final_response: None`, explaining that the tool call limit was reached and suggesting alternatives
+
 ## 2026-04-07
 
 ### Added

--- a/klaw-core/src/agent_loop.rs
+++ b/klaw-core/src/agent_loop.rs
@@ -1209,8 +1209,33 @@ impl AgentLoop {
                         )
                         .await;
                 }
+                let mut response_metadata =
+                    heartbeat_response_metadata(&msg.payload.metadata);
+                response_metadata.insert(
+                    META_AGENT_DISPOSITION_KEY.to_string(),
+                    serde_json::Value::String("exhausted".to_string()),
+                );
+                let exhausted_content = format!(
+                    "I've reached the maximum number of tool call iterations ({}). \
+                     This usually happens when a task requires more steps than the configured limit. \
+                     You may try:\n\
+                     - Breaking down the task into smaller parts\n\
+                     - Asking me to continue from where I left off\n\
+                     - Adjusting the iteration limit if you have administrative access",
+                    self.limits.max_tool_iterations
+                );
                 ProcessOutcome {
-                    final_response: None,
+                    final_response: Some(Envelope {
+                        header: msg.header.clone(),
+                        metadata: BTreeMap::new(),
+                        payload: OutboundMessage {
+                            channel: msg.payload.channel.clone(),
+                            chat_id: msg.payload.chat_id.clone(),
+                            content: exhausted_content,
+                            reply_to: None,
+                            metadata: response_metadata,
+                        },
+                    }),
                     error_code: Some(ErrorCode::RetryExhausted),
                     final_state: AgentRunState::Failed,
                     llm_audits: Vec::new(),


### PR DESCRIPTION
## Summary

- 当 `max_tool_iterations >= 3` 且到达最后一轮时，向模型发送系统提示请求直接回复用户并总结已完成工作
- 循环耗尽时返回明确消息告知用户限制已达到，而非静默无响应

Closes #191

## 改动

- `klaw-agent/src/lib.rs`: 新增 `FINAL_ITERATION_PROMPT`，循环末轮注入提示
- `klaw-core/src/agent_loop.rs`: `ToolLoopExhausted` 返回包含解释性内容的响应

## 测试

- `cargo test -p klaw-agent --lib` ✅
- `cargo test -p klaw-core --lib` ✅  
- `cargo test --workspace` ✅