### PR TITLE
fix(webui,storage,runtime): prevent history reload on new agent and filter websocket sessions at query level

### DIFF
--- a/klaw-cli/src/commands/session.rs
+++ b/klaw-cli/src/commands/session.rs
@@ -47,11 +47,12 @@ impl SessionListCommand {
     async fn run(self, manager: &impl SessionManager) -> Result<(), Box<dyn std::error::Error>> {
         let sessions = manager
             .list_sessions(SessionListQuery {
-                limit: self.limit,
+                limit: Some(self.limit),
                 offset: self.offset,
                 updated_from_ms: None,
                 updated_to_ms: None,
                 channel: None,
+                session_key_prefix: None,
                 sort_order: Default::default(),
             })
             .await?;

--- a/klaw-gui/src/panels/heartbeat.rs
+++ b/klaw-gui/src/panels/heartbeat.rs
@@ -830,8 +830,9 @@ fn run_session_query(limit: i64, offset: i64) -> Result<Vec<SessionIndex>, Strin
                 .map_err(|err| format!("failed to open session store: {err}"))?;
             store
                 .list_sessions(
-                    limit,
+                    Some(limit),
                     offset,
+                    None,
                     None,
                     None,
                     None,

--- a/klaw-gui/src/panels/memory.rs
+++ b/klaw-gui/src/panels/memory.rs
@@ -287,8 +287,9 @@ impl MemoryPanel {
                 let session_store = open_default_store().await.map_err(MemoryError::Storage)?;
                 let sessions = session_store
                     .list_sessions(
-                        1000,
+                        Some(1000),
                         0,
+                        None,
                         None,
                         None,
                         None,

--- a/klaw-gui/src/panels/session.rs
+++ b/klaw-gui/src/panels/session.rs
@@ -69,11 +69,12 @@ impl SessionPanel {
         let page = self.page.max(1);
         let offset = (page - 1) * size;
         let query = SessionListQuery {
-            limit: size,
+            limit: Some(size),
             offset,
             updated_from_ms: self.start_date.and_then(date_start_ms),
             updated_to_ms: self.end_date.and_then(date_end_ms),
             channel: self.channel_filter.clone(),
+            session_key_prefix: None,
             sort_order: self.sort_order,
         };
 
@@ -126,7 +127,9 @@ impl SessionPanel {
     fn toggle_sort_order(&mut self) {
         self.sort_order = match self.sort_order {
             SessionSortOrder::UpdatedAtAsc => SessionSortOrder::UpdatedAtDesc,
-            SessionSortOrder::UpdatedAtDesc => SessionSortOrder::UpdatedAtAsc,
+            SessionSortOrder::UpdatedAtDesc | SessionSortOrder::CreatedAtDesc => {
+                SessionSortOrder::UpdatedAtAsc
+            }
         };
     }
 
@@ -134,6 +137,7 @@ impl SessionPanel {
         match self.sort_order {
             SessionSortOrder::UpdatedAtAsc => "Updated At ↑",
             SessionSortOrder::UpdatedAtDesc => "Updated At ↓",
+            SessionSortOrder::CreatedAtDesc => "Created At ↓",
         }
     }
 }

--- a/klaw-runtime/src/gateway_websocket.rs
+++ b/klaw-runtime/src/gateway_websocket.rs
@@ -410,13 +410,12 @@ fn build_web_workspace_bootstrap(
 ) -> GatewayWorkspaceBootstrap {
     let sessions = sessions
         .into_iter()
-        .enumerate()
-        .map(|(index, session)| GatewayWorkspaceSession {
-            session_key: session.session_key,
+        .map(|session| GatewayWorkspaceSession {
+            session_key: session.session_key.clone(),
             title: session
                 .title
                 .filter(|title| !title.trim().is_empty())
-                .unwrap_or_else(|| format!("Agent {}", index + 1)),
+                .unwrap_or_else(|| format!("Agent {}", &session.session_key.trim_start_matches("websocket:")[..8])),
             created_at_ms: session.created_at_ms,
             model_provider: session.model_provider,
             model: session.model,
@@ -546,7 +545,7 @@ mod tests {
     fn web_workspace_bootstrap_keeps_web_sessions_after_channel_changes() {
         let workspace = build_web_workspace_bootstrap(vec![
             SessionIndex {
-                session_key: "websocket:new".to_string(),
+                session_key: "websocket:a1b2c3d4-5678-9012-abcd-ef0123456789".to_string(),
                 chat_id: "chat-new".to_string(),
                 channel: "websocket".to_string(),
                 title: None,
@@ -583,11 +582,11 @@ mod tests {
 
         assert_eq!(
             workspace.active_session_key.as_deref(),
-            Some("websocket:new")
+            Some("websocket:a1b2c3d4-5678-9012-abcd-ef0123456789")
         );
         assert_eq!(workspace.sessions.len(), 2);
-        assert_eq!(workspace.sessions[0].session_key, "websocket:new");
-        assert_eq!(workspace.sessions[0].title, "Agent 1");
+        assert_eq!(workspace.sessions[0].session_key, "websocket:a1b2c3d4-5678-9012-abcd-ef0123456789");
+        assert_eq!(workspace.sessions[0].title, "Agent a1b2c3d4");
         assert_eq!(workspace.sessions[1].session_key, "websocket:old");
         assert_eq!(workspace.sessions[1].title, "Saved old");
     }

--- a/klaw-runtime/src/gateway_websocket.rs
+++ b/klaw-runtime/src/gateway_websocket.rs
@@ -60,7 +60,13 @@ impl RuntimeWebsocketHandler {
     ) -> Result<GatewayWorkspaceBootstrap, GatewayWebsocketHandlerError> {
         let sessions =
             klaw_session::SqliteSessionManager::from_store(self.runtime.session_store.clone())
-                .list_sessions(SessionListQuery::default())
+                .list_sessions(SessionListQuery {
+                    limit: None,
+                    channel: Some("websocket".to_string()),
+                    session_key_prefix: Some("websocket:".to_string()),
+                    sort_order: klaw_storage::SessionSortOrder::CreatedAtDesc,
+                    ..SessionListQuery::default()
+                })
                 .await
                 .map_err(|err| GatewayWebsocketHandlerError::internal(err.to_string()))?;
         Ok(build_web_workspace_bootstrap(sessions))
@@ -400,15 +406,9 @@ fn serialize_response(response: &ChannelResponse, show_reasoning: bool) -> Value
 }
 
 fn build_web_workspace_bootstrap(
-    mut sessions: Vec<klaw_storage::SessionIndex>,
+    sessions: Vec<klaw_storage::SessionIndex>,
 ) -> GatewayWorkspaceBootstrap {
-    sessions.retain(|session| session.session_key.starts_with("websocket:"));
-    sessions.sort_by(|left, right| {
-        left.created_at_ms
-            .cmp(&right.created_at_ms)
-            .then_with(|| left.session_key.cmp(&right.session_key))
-    });
-    let mut sessions = sessions
+    let sessions = sessions
         .into_iter()
         .enumerate()
         .map(|(index, session)| GatewayWorkspaceSession {
@@ -422,12 +422,6 @@ fn build_web_workspace_bootstrap(
             model: session.model,
         })
         .collect::<Vec<_>>();
-    sessions.sort_by(|left, right| {
-        right
-            .created_at_ms
-            .cmp(&left.created_at_ms)
-            .then_with(|| right.session_key.cmp(&left.session_key))
-    });
     let active_session_key = sessions.first().map(|session| session.session_key.clone());
     GatewayWorkspaceBootstrap {
         sessions,
@@ -552,40 +546,6 @@ mod tests {
     fn web_workspace_bootstrap_keeps_web_sessions_after_channel_changes() {
         let workspace = build_web_workspace_bootstrap(vec![
             SessionIndex {
-                session_key: "websocket:old".to_string(),
-                chat_id: "chat-old".to_string(),
-                channel: "websocket".to_string(),
-                title: Some("Saved old".to_string()),
-                active_session_key: None,
-                model_provider: None,
-                model_provider_explicit: false,
-                model: None,
-                model_explicit: false,
-                delivery_metadata_json: None,
-                created_at_ms: 10,
-                updated_at_ms: 20,
-                last_message_at_ms: 20,
-                turn_count: 1,
-                jsonl_path: "old.jsonl".to_string(),
-            },
-            SessionIndex {
-                session_key: "terminal:ignore".to_string(),
-                chat_id: "chat-ignore".to_string(),
-                channel: "terminal".to_string(),
-                title: Some("Terminal".to_string()),
-                active_session_key: None,
-                model_provider: None,
-                model_provider_explicit: false,
-                model: None,
-                model_explicit: false,
-                delivery_metadata_json: None,
-                created_at_ms: 30,
-                updated_at_ms: 40,
-                last_message_at_ms: 40,
-                turn_count: 1,
-                jsonl_path: "ignore.jsonl".to_string(),
-            },
-            SessionIndex {
                 session_key: "websocket:new".to_string(),
                 chat_id: "chat-new".to_string(),
                 channel: "websocket".to_string(),
@@ -602,6 +562,23 @@ mod tests {
                 turn_count: 1,
                 jsonl_path: "new.jsonl".to_string(),
             },
+            SessionIndex {
+                session_key: "websocket:old".to_string(),
+                chat_id: "chat-old".to_string(),
+                channel: "websocket".to_string(),
+                title: Some("Saved old".to_string()),
+                active_session_key: None,
+                model_provider: None,
+                model_provider_explicit: false,
+                model: None,
+                model_explicit: false,
+                delivery_metadata_json: None,
+                created_at_ms: 10,
+                updated_at_ms: 20,
+                last_message_at_ms: 20,
+                turn_count: 1,
+                jsonl_path: "old.jsonl".to_string(),
+            },
         ]);
 
         assert_eq!(
@@ -610,7 +587,7 @@ mod tests {
         );
         assert_eq!(workspace.sessions.len(), 2);
         assert_eq!(workspace.sessions[0].session_key, "websocket:new");
-        assert_eq!(workspace.sessions[0].title, "Agent 2");
+        assert_eq!(workspace.sessions[0].title, "Agent 1");
         assert_eq!(workspace.sessions[1].session_key, "websocket:old");
         assert_eq!(workspace.sessions[1].title, "Saved old");
     }

--- a/klaw-runtime/src/im_commands/usage.rs
+++ b/klaw-runtime/src/im_commands/usage.rs
@@ -10,7 +10,7 @@ pub(super) async fn usage_response(
         .list_llm_usage(
             session_key,
             klaw_session::SessionListQuery {
-                limit: 1,
+                limit: Some(1),
                 ..Default::default()
             },
         )

--- a/klaw-session/src/manager.rs
+++ b/klaw-session/src/manager.rs
@@ -12,22 +12,24 @@ use klaw_storage::{
 
 #[derive(Debug, Clone)]
 pub struct SessionListQuery {
-    pub limit: i64,
+    pub limit: Option<i64>,
     pub offset: i64,
     pub updated_from_ms: Option<i64>,
     pub updated_to_ms: Option<i64>,
     pub channel: Option<String>,
+    pub session_key_prefix: Option<String>,
     pub sort_order: SessionSortOrder,
 }
 
 impl Default for SessionListQuery {
     fn default() -> Self {
         Self {
-            limit: 100,
+            limit: Some(100),
             offset: 0,
             updated_from_ms: None,
             updated_to_ms: None,
             channel: None,
+            session_key_prefix: None,
             sort_order: SessionSortOrder::UpdatedAtDesc,
         }
     }
@@ -405,7 +407,7 @@ impl SessionManager for SqliteSessionManager {
         &self,
         query: SessionListQuery,
     ) -> Result<Vec<SessionIndex>, SessionError> {
-        let limit = query.limit.max(1);
+        let limit = query.limit.map(|l| l.max(1));
         let offset = query.offset.max(0);
         Ok(self
             .store
@@ -415,6 +417,7 @@ impl SessionManager for SqliteSessionManager {
                 query.updated_from_ms,
                 query.updated_to_ms,
                 query.channel.as_deref(),
+                query.session_key_prefix.as_deref(),
                 query.sort_order,
             )
             .await?)
@@ -436,7 +439,7 @@ impl SessionManager for SqliteSessionManager {
         session_key: &str,
         query: SessionListQuery,
     ) -> Result<Vec<LlmUsageRecord>, SessionError> {
-        let limit = query.limit.max(1);
+        let limit = query.limit.unwrap_or(100).max(1);
         let offset = query.offset.max(0);
         Ok(self
             .store
@@ -603,11 +606,12 @@ mod tests {
         let manager = SqliteSessionManager::from_store(store);
         let sessions = manager
             .list_sessions(SessionListQuery {
-                limit: 10,
+                limit: Some(10),
                 offset: 0,
                 updated_from_ms: None,
                 updated_to_ms: None,
                 channel: None,
+                session_key_prefix: None,
                 sort_order: SessionSortOrder::UpdatedAtDesc,
             })
             .await
@@ -629,11 +633,12 @@ mod tests {
         let manager = SqliteSessionManager::from_store(store);
         let sessions = manager
             .list_sessions(SessionListQuery {
-                limit: 0,
+                limit: None,
                 offset: -5,
                 updated_from_ms: None,
                 updated_to_ms: None,
                 channel: None,
+                session_key_prefix: None,
                 sort_order: SessionSortOrder::UpdatedAtDesc,
             })
             .await
@@ -658,11 +663,12 @@ mod tests {
         let manager = SqliteSessionManager::from_store(store);
         let sessions = manager
             .list_sessions(SessionListQuery {
-                limit: 10,
+                limit: Some(10),
                 offset: 0,
                 updated_from_ms: None,
                 updated_to_ms: None,
                 channel: Some("terminal".to_string()),
+                session_key_prefix: None,
                 sort_order: SessionSortOrder::UpdatedAtAsc,
             })
             .await

--- a/klaw-storage/src/backend/sqlx.rs
+++ b/klaw-storage/src/backend/sqlx.rs
@@ -1852,11 +1852,12 @@ impl SessionStorage for SqlxSessionStore {
 
     async fn list_sessions(
         &self,
-        limit: i64,
+        limit: Option<i64>,
         offset: i64,
         updated_from_ms: Option<i64>,
         updated_to_ms: Option<i64>,
         channel: Option<&str>,
+        session_key_prefix: Option<&str>,
         sort_order: SessionSortOrder,
     ) -> Result<Vec<SessionIndex>, StorageError> {
         let mut query = String::from(
@@ -1872,10 +1873,13 @@ impl SessionStorage for SqlxSessionStore {
         if channel.is_some() {
             query.push_str(" AND channel = ?");
         }
-        query.push_str(&format!(
-            " ORDER BY {} LIMIT ? OFFSET ?",
-            sort_order.sql_order_by()
-        ));
+        if session_key_prefix.is_some() {
+            query.push_str(" AND session_key LIKE ?");
+        }
+        query.push_str(&format!(" ORDER BY {}", sort_order.sql_order_by()));
+        if let Some(limit) = limit {
+            query.push_str(" LIMIT ? OFFSET ?");
+        }
 
         let mut q = sqlx::query_as::<_, SessionIndexRow>(&query);
         if let Some(from) = updated_from_ms {
@@ -1887,7 +1891,12 @@ impl SessionStorage for SqlxSessionStore {
         if let Some(channel) = channel {
             q = q.bind(channel);
         }
-        q = q.bind(limit.max(1)).bind(offset.max(0));
+        if let Some(prefix) = session_key_prefix {
+            q = q.bind(format!("{}%", prefix));
+        }
+        if let Some(limit) = limit {
+            q = q.bind(limit.max(1)).bind(offset.max(0));
+        }
 
         let rows = q
             .fetch_all(&self.pool)

--- a/klaw-storage/src/backend/turso.rs
+++ b/klaw-storage/src/backend/turso.rs
@@ -1093,11 +1093,12 @@ impl SessionStorage for TursoSessionStore {
 
     async fn list_sessions(
         &self,
-        limit: i64,
+        limit: Option<i64>,
         offset: i64,
         updated_from_ms: Option<i64>,
         updated_to_ms: Option<i64>,
         channel: Option<&str>,
+        session_key_prefix: Option<&str>,
         sort_order: SessionSortOrder,
     ) -> Result<Vec<SessionIndex>, StorageError> {
         let mut sql = String::from(
@@ -1113,12 +1114,16 @@ impl SessionStorage for TursoSessionStore {
         if let Some(channel) = channel {
             sql.push_str(&format!(" AND channel = '{}'", escape_sql_text(channel)));
         }
-        sql.push_str(&format!(
-            " ORDER BY {} LIMIT {} OFFSET {}",
-            sort_order.sql_order_by(),
-            limit.max(1),
-            offset.max(0)
-        ));
+        if let Some(prefix) = session_key_prefix {
+            sql.push_str(&format!(
+                " AND session_key LIKE '{}%'",
+                escape_sql_text(prefix)
+            ));
+        }
+        sql.push_str(&format!(" ORDER BY {}", sort_order.sql_order_by()));
+        if let Some(limit) = limit {
+            sql.push_str(&format!(" LIMIT {} OFFSET {}", limit.max(1), offset.max(0)));
+        }
         let conn = self.connection().await?;
         let mut rows = conn.query(&sql, ()).await.map_err(StorageError::backend)?;
         let mut out = Vec::new();

--- a/klaw-storage/src/lib.rs
+++ b/klaw-storage/src/lib.rs
@@ -248,11 +248,12 @@ mod tests {
 
         let filtered = store
             .list_sessions(
-                10,
+                Some(10),
                 0,
                 None,
                 None,
                 Some("terminal"),
+                None,
                 SessionSortOrder::UpdatedAtAsc,
             )
             .await

--- a/klaw-storage/src/traits.rs
+++ b/klaw-storage/src/traits.rs
@@ -114,11 +114,12 @@ pub trait SessionStorage: Send + Sync {
 
     async fn list_sessions(
         &self,
-        limit: i64,
+        limit: Option<i64>,
         offset: i64,
         updated_from_ms: Option<i64>,
         updated_to_ms: Option<i64>,
         channel: Option<&str>,
+        session_key_prefix: Option<&str>,
         sort_order: SessionSortOrder,
     ) -> Result<Vec<SessionIndex>, StorageError>;
 

--- a/klaw-storage/src/types.rs
+++ b/klaw-storage/src/types.rs
@@ -65,6 +65,7 @@ pub enum SessionSortOrder {
     UpdatedAtAsc,
     #[default]
     UpdatedAtDesc,
+    CreatedAtDesc,
 }
 
 impl SessionSortOrder {
@@ -73,6 +74,7 @@ impl SessionSortOrder {
         match self {
             Self::UpdatedAtAsc => "updated_at_ms ASC, session_key ASC",
             Self::UpdatedAtDesc => "updated_at_ms DESC, session_key DESC",
+            Self::CreatedAtDesc => "created_at_ms DESC, session_key DESC",
         }
     }
 }

--- a/klaw-webui/src/web_chat/transport.rs
+++ b/klaw-webui/src/web_chat/transport.rs
@@ -14,7 +14,9 @@ use super::{
     app::ChatApp,
     protocol::{ServerFrame, send_method},
     session::ChatMessage,
+    session::SessionWindow,
     session::current_timestamp_ms,
+    session::window_anchor_for_slot,
     ui::sync_card_state_overrides,
 };
 
@@ -322,8 +324,7 @@ impl ChatApp {
             result.get("title").and_then(Value::as_str),
             result.get("created_at_ms").and_then(Value::as_i64),
         ) {
-            let mut entries = self.workspace_entries();
-            entries.push(WorkspaceSessionEntry {
+            let entry = WorkspaceSessionEntry {
                 session_key: session_key.to_string(),
                 title: title.to_string(),
                 created_at_ms,
@@ -335,13 +336,16 @@ impl ChatApp {
                     .get("model")
                     .and_then(Value::as_str)
                     .map(ToString::to_string),
-            });
-            self.sync_sessions_from_workspace(entries, Some(session_key.to_string()));
-            if let Some(index) = self.session_index(session_key) {
-                self.sessions[index].open = true;
+            };
+            let session = SessionWindow::new(entry, true, &self.provider_catalog);
+            self.sessions.push(session);
+            self.sessions
+                .sort_by(|a, b| b.created_at_ms.cmp(&a.created_at_ms));
+            for (index, s) in self.sessions.iter_mut().enumerate() {
+                s.window_anchor = window_anchor_for_slot(index as u32);
             }
+            self.active_session_key = Some(session_key.to_string());
             self.persist_workspace_state();
-            self.subscribe_sessions_needing_history();
             return;
         }
 


### PR DESCRIPTION
Fixes #193

## Summary

Two related bugs in the webUI session management:

### Bug 1 — New agent creation triggers history reload for all open agents
`session.create` response handler called `sync_sessions_from_workspace`, which rebuilt all `SessionWindow` objects from scratch — discarding `history_loaded`/`history_loading` state. This caused `subscribe_sessions_needing_history` to fire subscribe requests for every already-open agent.

**Fix**: Append the new `SessionWindow` directly and sort by `created_at_ms` DESC, instead of rebuilding the full list.

### Bug 2 — Agent list incomplete and inconsistent
`load_web_workspace` used `SessionListQuery::default()` (limit=100, channel=None), fetching all session types then filtering in memory. Other channels (terminal, cron, webhook) consumed the 100-row quota, causing websocket sessions to be truncated unpredictably.

**Fix**:
- `SessionListQuery.limit` changed from `i64` to `Option<i64>` (None = unlimited)
- Added `SessionListQuery.session_key_prefix` for SQL `LIKE 'prefix%'` filtering
- Added `SessionSortOrder::CreatedAtDesc` for server-side ordering
- `load_web_workspace` now queries with `channel: "websocket"`, `session_key_prefix: "websocket:"`, `limit: None`, `CreatedAtDesc`
- `build_web_workspace_bootstrap` no longer sorts/filters in memory

## Changed crates
- `klaw-webui` — session.create response handler
- `klaw-runtime` — gateway websocket handler and workspace bootstrap
- `klaw-session` — SessionListQuery definition
- `klaw-storage` — Storage trait, sqlx/turso backends, SessionSortOrder
- `klaw-gui`, `klaw-cli` — adapted to new signatures

## Validation
- `cargo test -p klaw-session -p klaw-storage -p klaw-runtime` — all pass
- `cargo check --workspace` — clean
- `cargo build -p klaw-webui --target wasm32-unknown-unknown --release` — clean

## Risks
- Storage schema unchanged, no migration needed
- `SessionListQuery` is a public API change; all internal callers updated
- Existing `limit: 100` default preserved via `Some(100)`