### PR TITLE
fix(tool): route apply_patch denials through approvals

### DIFF
--- a/klaw-approval/CHANGELOG.md
+++ b/klaw-approval/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 2026-04-14
+
+### Changed
+
+- `ApprovalManager` 的消费接口已从 shell 专用流程扩展为按 `tool_name + session_key + command_hash` 的通用审批消费模型，`consume_approval` 也不再限制为只处理 shell 记录
+
 ## 2026-03-16
 
 ### Added

--- a/klaw-approval/src/error.rs
+++ b/klaw-approval/src/error.rs
@@ -7,8 +7,6 @@ pub enum ApprovalError {
     InvalidArgs(String),
     #[error("invalid approval row: {0}")]
     InvalidApprovalRow(String),
-    #[error("approval `{0}` is not a shell approval")]
-    NotShellApproval(String),
     #[error("storage error: {0}")]
     Storage(#[from] StorageError),
 }

--- a/klaw-approval/src/manager.rs
+++ b/klaw-approval/src/manager.rs
@@ -81,20 +81,43 @@ pub trait ApprovalManager: Send + Sync {
         now_ms: i64,
     ) -> Result<ApprovalResolveOutcome, ApprovalError>;
 
+    async fn consume_tool_approval(
+        &self,
+        approval_id: &str,
+        tool_name: &str,
+        session_key: &str,
+        command_hash: &str,
+        now_ms: i64,
+    ) -> Result<bool, ApprovalError>;
+
+    async fn consume_latest_tool_approval(
+        &self,
+        tool_name: &str,
+        session_key: &str,
+        command_hash: &str,
+        now_ms: i64,
+    ) -> Result<bool, ApprovalError>;
+
     async fn consume_shell_approval(
         &self,
         approval_id: &str,
         session_key: &str,
         command_hash: &str,
         now_ms: i64,
-    ) -> Result<bool, ApprovalError>;
+    ) -> Result<bool, ApprovalError> {
+        self.consume_tool_approval(approval_id, "shell", session_key, command_hash, now_ms)
+            .await
+    }
 
     async fn consume_latest_shell_approval(
         &self,
         session_key: &str,
         command_hash: &str,
         now_ms: i64,
-    ) -> Result<bool, ApprovalError>;
+    ) -> Result<bool, ApprovalError> {
+        self.consume_latest_tool_approval("shell", session_key, command_hash, now_ms)
+            .await
+    }
 
     async fn consume_approval(
         &self,
@@ -292,33 +315,43 @@ impl ApprovalManager for SqliteApprovalManager {
         })
     }
 
-    async fn consume_shell_approval(
+    async fn consume_tool_approval(
         &self,
         approval_id: &str,
+        tool_name: &str,
         session_key: &str,
         command_hash: &str,
         now_ms: i64,
     ) -> Result<bool, ApprovalError> {
         let approval_id = normalize_non_empty(approval_id, "approval_id")?;
+        let tool_name = normalize_non_empty(tool_name, "tool_name")?;
         let session_key = normalize_non_empty(session_key, "session_key")?;
         let command_hash = normalize_non_empty(command_hash, "command_hash")?;
         Ok(self
             .store
-            .consume_approved_shell_command(&approval_id, &session_key, &command_hash, now_ms)
+            .consume_approved_tool_command(
+                &approval_id,
+                &tool_name,
+                &session_key,
+                &command_hash,
+                now_ms,
+            )
             .await?)
     }
 
-    async fn consume_latest_shell_approval(
+    async fn consume_latest_tool_approval(
         &self,
+        tool_name: &str,
         session_key: &str,
         command_hash: &str,
         now_ms: i64,
     ) -> Result<bool, ApprovalError> {
+        let tool_name = normalize_non_empty(tool_name, "tool_name")?;
         let session_key = normalize_non_empty(session_key, "session_key")?;
         let command_hash = normalize_non_empty(command_hash, "command_hash")?;
         Ok(self
             .store
-            .consume_latest_approved_shell_command(&session_key, &command_hash, now_ms)
+            .consume_latest_approved_tool_command(&tool_name, &session_key, &command_hash, now_ms)
             .await?)
     }
 
@@ -328,13 +361,11 @@ impl ApprovalManager for SqliteApprovalManager {
         now_ms: i64,
     ) -> Result<ApprovalResolveOutcome, ApprovalError> {
         let approval = self.get_approval(approval_id).await?;
-        if approval.tool_name != "shell" {
-            return Err(ApprovalError::NotShellApproval(approval.id));
-        }
         let updated = self
             .store
-            .consume_approved_shell_command(
+            .consume_approved_tool_command(
                 &approval.id,
+                &approval.tool_name,
                 &approval.session_key,
                 &approval.command_hash,
                 now_ms,
@@ -626,6 +657,46 @@ mod tests {
             .consume_approval(&approval.id, now_ms())
             .await
             .expect("approval should consume");
+        assert!(outcome.updated);
+        assert_eq!(outcome.approval.status, ApprovalStatus::Consumed);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn consume_approval_marks_apply_patch_record_consumed() {
+        let store = create_store().await;
+        store
+            .touch_session("terminal:test", "chat-1", "terminal")
+            .await
+            .expect("session should exist");
+        let manager = SqliteApprovalManager::from_store(store);
+        let approval = manager
+            .create_approval(ApprovalCreateInput {
+                session_key: "terminal:test".to_string(),
+                tool_name: "apply_patch".to_string(),
+                command_text: "add_file:/tmp/outside.txt".to_string(),
+                command_preview: Some("add_file:/tmp/outside.txt".to_string()),
+                command_hash: Some("patchhash".to_string()),
+                risk_level: None,
+                requested_by: None,
+                justification: None,
+                expires_in_minutes: Some(10),
+            })
+            .await
+            .expect("approval should be created");
+        let _ = manager
+            .resolve_approval(
+                &approval.id,
+                ApprovalResolveDecision::Approve,
+                Some("tester"),
+                now_ms(),
+            )
+            .await
+            .expect("approval should resolve");
+
+        let outcome = manager
+            .consume_approval(&approval.id, now_ms())
+            .await
+            .expect("apply_patch approval should consume");
         assert!(outcome.updated);
         assert_eq!(outcome.approval.status, ApprovalStatus::Consumed);
     }

--- a/klaw-runtime/CHANGELOG.md
+++ b/klaw-runtime/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2026-04-14
 
+### Changed
+
+- runtime 注册本地工具时，`apply_patch` 现在会像 `shell` 一样复用共享 session store 注入审批管理器，使越权补丁请求能进入统一的审批流并在批准后重试执行
+
 ### Fixed
 
 - `/approve` 现在会优先按触发审批的 `tool_audit` 重放原始 tool call，并把已批准工具的实际结果作为结构化 tool 历史交回模型；shell 与其它接入审批的工具都不再依赖 prompt 式 follow-up 或 runtime 侧第二轮强制重试

--- a/klaw-runtime/src/lib.rs
+++ b/klaw-runtime/src/lib.rs
@@ -1343,7 +1343,7 @@ async fn register_configured_tools(
         info!("voice tool disabled because voice.enabled=false");
     }
     if config.tools.apply_patch.enabled() {
-        tools.register(ApplyPatchTool::new(config));
+        tools.register(ApplyPatchTool::with_store(config, session_store.clone()));
     }
     if config.tools.shell.enabled() {
         tools.register(ShellTool::with_store(config, session_store.clone()));

--- a/klaw-storage/CHANGELOG.md
+++ b/klaw-storage/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 2026-04-14
 
+### Changed
+- approvals 的存储消费 API 现已支持按任意 `tool_name` 匹配并消费已批准请求，shell 专用入口改为复用通用实现，避免新增写类工具时重复维护第二套审批消费逻辑
+
 ### Added
 - added optional `metadata_json` on persisted `ChatRecord` history rows so websocket/webui clients can restore structured assistant message state such as interactive IM cards after reloads
 - added cursor-based `read_chat_records_page` storage APIs plus reverse JSONL paging so websocket history consumers can load only the latest N chat records and continue older history from a `message_id` cursor

--- a/klaw-storage/src/backend/sqlx.rs
+++ b/klaw-storage/src/backend/sqlx.rs
@@ -2620,9 +2620,10 @@ impl SessionStorage for SqlxSessionStore {
         self.get_approval(approval_id).await
     }
 
-    async fn consume_approved_shell_command(
+    async fn consume_approved_tool_command(
         &self,
         approval_id: &str,
+        tool_name: &str,
         session_key: &str,
         command_hash: &str,
         now_ms: i64,
@@ -2633,16 +2634,17 @@ impl SessionStorage for SqlxSessionStore {
                  consumed_at_ms = ?2,
                  updated_at_ms = ?2
              WHERE id = ?3
-               AND session_key = ?4
-               AND tool_name = 'shell'
-               AND command_hash = ?5
-               AND status = ?6
+               AND tool_name = ?4
+               AND session_key = ?5
+               AND command_hash = ?6
+               AND status = ?7
                AND consumed_at_ms IS NULL
                AND expires_at_ms >= ?2",
         )
         .bind(ApprovalStatus::Consumed.as_str())
         .bind(now_ms)
         .bind(approval_id)
+        .bind(tool_name)
         .bind(session_key)
         .bind(command_hash)
         .bind(ApprovalStatus::Approved.as_str())
@@ -2652,8 +2654,9 @@ impl SessionStorage for SqlxSessionStore {
         Ok(updated.rows_affected() > 0)
     }
 
-    async fn consume_latest_approved_shell_command(
+    async fn consume_latest_approved_tool_command(
         &self,
+        tool_name: &str,
         session_key: &str,
         command_hash: &str,
         now_ms: i64,
@@ -2661,15 +2664,16 @@ impl SessionStorage for SqlxSessionStore {
         let approval_id = sqlx::query_scalar::<_, String>(
             "SELECT id
              FROM approvals
-             WHERE session_key = ?1
-               AND tool_name = 'shell'
-               AND command_hash = ?2
-               AND status = ?3
+             WHERE tool_name = ?1
+               AND session_key = ?2
+               AND command_hash = ?3
+               AND status = ?4
                AND consumed_at_ms IS NULL
-               AND expires_at_ms >= ?4
+               AND expires_at_ms >= ?5
              ORDER BY created_at_ms DESC
              LIMIT 1",
         )
+        .bind(tool_name)
         .bind(session_key)
         .bind(command_hash)
         .bind(ApprovalStatus::Approved.as_str())
@@ -2680,7 +2684,7 @@ impl SessionStorage for SqlxSessionStore {
         let Some(approval_id) = approval_id else {
             return Ok(false);
         };
-        self.consume_approved_shell_command(&approval_id, session_key, command_hash, now_ms)
+        self.consume_approved_tool_command(&approval_id, tool_name, session_key, command_hash, now_ms)
             .await
     }
 

--- a/klaw-storage/src/backend/turso.rs
+++ b/klaw-storage/src/backend/turso.rs
@@ -2093,9 +2093,10 @@ impl SessionStorage for TursoSessionStore {
         self.get_approval(approval_id).await
     }
 
-    async fn consume_approved_shell_command(
+    async fn consume_approved_tool_command(
         &self,
         approval_id: &str,
+        tool_name: &str,
         session_key: &str,
         command_hash: &str,
         now_ms: i64,
@@ -2106,8 +2107,8 @@ impl SessionStorage for TursoSessionStore {
                  consumed_at_ms = {},
                  updated_at_ms = {}
              WHERE id = '{}'
+               AND tool_name = '{}'
                AND session_key = '{}'
-               AND tool_name = 'shell'
                AND command_hash = '{}'
                AND status = '{}'
                AND consumed_at_ms IS NULL
@@ -2116,6 +2117,7 @@ impl SessionStorage for TursoSessionStore {
             now_ms,
             now_ms,
             escape_sql_text(approval_id),
+            escape_sql_text(tool_name),
             escape_sql_text(session_key),
             escape_sql_text(command_hash),
             ApprovalStatus::Approved.as_str(),
@@ -2129,8 +2131,9 @@ impl SessionStorage for TursoSessionStore {
         Ok(affected > 0)
     }
 
-    async fn consume_latest_approved_shell_command(
+    async fn consume_latest_approved_tool_command(
         &self,
+        tool_name: &str,
         session_key: &str,
         command_hash: &str,
         now_ms: i64,
@@ -2138,14 +2141,15 @@ impl SessionStorage for TursoSessionStore {
         let sql = format!(
             "SELECT id
              FROM approvals
-             WHERE session_key = '{}'
-               AND tool_name = 'shell'
+             WHERE tool_name = '{}'
+               AND session_key = '{}'
                AND command_hash = '{}'
                AND status = '{}'
                AND consumed_at_ms IS NULL
                AND expires_at_ms >= {}
              ORDER BY created_at_ms DESC
              LIMIT 1",
+            escape_sql_text(tool_name),
             escape_sql_text(session_key),
             escape_sql_text(command_hash),
             ApprovalStatus::Approved.as_str(),
@@ -2159,7 +2163,7 @@ impl SessionStorage for TursoSessionStore {
             };
             value_to_string(row.get_value(0).map_err(StorageError::backend)?)?
         };
-        self.consume_approved_shell_command(&approval_id, session_key, command_hash, now_ms)
+        self.consume_approved_tool_command(&approval_id, tool_name, session_key, command_hash, now_ms)
             .await
     }
 

--- a/klaw-storage/src/lib.rs
+++ b/klaw-storage/src/lib.rs
@@ -1120,6 +1120,154 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    async fn approval_consume_tool_command_supports_non_shell_tools() {
+        let store = create_store().await;
+        store
+            .touch_session("terminal:approval3", "approval-chat3", "terminal")
+            .await
+            .expect("session should exist for approval foreign key");
+
+        store
+            .create_approval(&NewApprovalRecord {
+                id: "approval-apply-patch-1".to_string(),
+                session_key: "terminal:approval3".to_string(),
+                tool_name: "apply_patch".to_string(),
+                command_hash: "patchhash".to_string(),
+                command_preview: "add_file:/tmp/outside.txt".to_string(),
+                command_text: "add_file:/tmp/outside.txt".to_string(),
+                risk_level: "mutating".to_string(),
+                requested_by: "agent".to_string(),
+                justification: None,
+                expires_at_ms: util::now_ms() + 60_000,
+            })
+            .await
+            .expect("create approval should succeed");
+        store
+            .update_approval_status(
+                "approval-apply-patch-1",
+                ApprovalStatus::Approved,
+                Some("user"),
+            )
+            .await
+            .expect("approve should succeed");
+
+        let consumed = store
+            .consume_approved_tool_command(
+                "approval-apply-patch-1",
+                "apply_patch",
+                "terminal:approval3",
+                "patchhash",
+                util::now_ms(),
+            )
+            .await
+            .expect("generic consume should succeed");
+        assert!(consumed);
+
+        let post = store
+            .get_approval("approval-apply-patch-1")
+            .await
+            .expect("approval should still exist");
+        assert_eq!(post.status, ApprovalStatus::Consumed);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn approval_consume_tool_command_rejects_tool_name_mismatch() {
+        let store = create_store().await;
+        store
+            .touch_session("terminal:approval4", "approval-chat4", "terminal")
+            .await
+            .expect("session should exist for approval foreign key");
+
+        store
+            .create_approval(&NewApprovalRecord {
+                id: "approval-shell-only-1".to_string(),
+                session_key: "terminal:approval4".to_string(),
+                tool_name: "shell".to_string(),
+                command_hash: "shellhash".to_string(),
+                command_preview: "rm -rf /tmp/demo".to_string(),
+                command_text: "rm -rf /tmp/demo".to_string(),
+                risk_level: "unsafe".to_string(),
+                requested_by: "agent".to_string(),
+                justification: None,
+                expires_at_ms: util::now_ms() + 60_000,
+            })
+            .await
+            .expect("create approval should succeed");
+        store
+            .update_approval_status("approval-shell-only-1", ApprovalStatus::Approved, Some("user"))
+            .await
+            .expect("approve should succeed");
+
+        let consumed = store
+            .consume_approved_tool_command(
+                "approval-shell-only-1",
+                "apply_patch",
+                "terminal:approval4",
+                "shellhash",
+                util::now_ms(),
+            )
+            .await
+            .expect("generic consume should still return a boolean");
+        assert!(!consumed);
+
+        let post = store
+            .get_approval("approval-shell-only-1")
+            .await
+            .expect("approval should still exist");
+        assert_eq!(post.status, ApprovalStatus::Approved);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn approval_consume_latest_tool_command_supports_non_shell_tools() {
+        let store = create_store().await;
+        store
+            .touch_session("terminal:approval5", "approval-chat5", "terminal")
+            .await
+            .expect("session should exist for approval foreign key");
+
+        store
+            .create_approval(&NewApprovalRecord {
+                id: "approval-apply-patch-latest-1".to_string(),
+                session_key: "terminal:approval5".to_string(),
+                tool_name: "apply_patch".to_string(),
+                command_hash: "latesthash".to_string(),
+                command_preview: "move_file:/tmp/a->/tmp/b".to_string(),
+                command_text: "move_file:/tmp/a->/tmp/b".to_string(),
+                risk_level: "outside_workspace".to_string(),
+                requested_by: "agent".to_string(),
+                justification: None,
+                expires_at_ms: util::now_ms() + 60_000,
+            })
+            .await
+            .expect("create approval should succeed");
+        store
+            .update_approval_status(
+                "approval-apply-patch-latest-1",
+                ApprovalStatus::Approved,
+                Some("user"),
+            )
+            .await
+            .expect("approve should succeed");
+
+        let consumed = store
+            .consume_latest_approved_tool_command(
+                "apply_patch",
+                "terminal:approval5",
+                "latesthash",
+                util::now_ms(),
+            )
+            .await
+            .expect("generic latest consume should succeed");
+        assert!(consumed);
+
+        let post = store
+            .get_approval("approval-apply-patch-latest-1")
+            .await
+            .expect("approval should still exist");
+        assert_eq!(post.status, ApprovalStatus::Consumed);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
     async fn webhook_event_supports_append_update_and_filtering() {
         let store = create_store().await;
         store

--- a/klaw-storage/src/traits.rs
+++ b/klaw-storage/src/traits.rs
@@ -245,20 +245,43 @@ pub trait SessionStorage: Send + Sync {
         approved_by: Option<&str>,
     ) -> Result<ApprovalRecord, StorageError>;
 
+    async fn consume_approved_tool_command(
+        &self,
+        approval_id: &str,
+        tool_name: &str,
+        session_key: &str,
+        command_hash: &str,
+        now_ms: i64,
+    ) -> Result<bool, StorageError>;
+
+    async fn consume_latest_approved_tool_command(
+        &self,
+        tool_name: &str,
+        session_key: &str,
+        command_hash: &str,
+        now_ms: i64,
+    ) -> Result<bool, StorageError>;
+
     async fn consume_approved_shell_command(
         &self,
         approval_id: &str,
         session_key: &str,
         command_hash: &str,
         now_ms: i64,
-    ) -> Result<bool, StorageError>;
+    ) -> Result<bool, StorageError> {
+        self.consume_approved_tool_command(approval_id, "shell", session_key, command_hash, now_ms)
+            .await
+    }
 
     async fn consume_latest_approved_shell_command(
         &self,
         session_key: &str,
         command_hash: &str,
         now_ms: i64,
-    ) -> Result<bool, StorageError>;
+    ) -> Result<bool, StorageError> {
+        self.consume_latest_approved_tool_command("shell", session_key, command_hash, now_ms)
+            .await
+    }
 
     async fn create_pending_question(
         &self,

--- a/klaw-tool/CHANGELOG.md
+++ b/klaw-tool/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 2026-04-14
 
 ### Fixed
+- `apply_patch` 现在会在请求写入未授权目录时创建审批记录并返回 `approval_required` 结构化错误/信号，而不是直接以 `ExecutionFailed` 中断 agent loop；批准后可通过 `apply_patch.approval_id` 或最近一次匹配审批重试同一补丁请求
+
+### Fixed
 - `cron_manager` 现在会拒绝来自 `cron:*` 执行会话的 `create(message=...)` 调用，避免已触发的 cron 任务再次把建定时任务指令投回模型后自我复制出大量重复 cron
 
 ## 2026-04-13

--- a/klaw-tool/src/apply_patch.rs
+++ b/klaw-tool/src/apply_patch.rs
@@ -1,30 +1,37 @@
 use async_trait::async_trait;
+use klaw_approval::{ApprovalCreateInput, ApprovalManager, SqliteApprovalManager};
 use klaw_config::{AppConfig, ApplyPatchConfig};
 use klaw_util::{default_data_dir, workspace_dir};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
-use std::collections::BTreeMap;
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
+use time::OffsetDateTime;
 
-use crate::{Tool, ToolCategory, ToolContext, ToolError, ToolOutput};
+use crate::{Tool, ToolCategory, ToolContext, ToolError, ToolOutput, ToolSignal};
 
 const META_WORKSPACE: &str = "workspace";
+const META_APPLY_PATCH_APPROVED: &str = "apply_patch.approved";
+const META_APPLY_PATCH_APPROVAL_ID: &str = "apply_patch.approval_id";
 const MAX_PATCH_OPERATIONS: usize = 50;
 const MAX_CONTENT_BYTES: usize = 1_000_000;
+const APPROVAL_TTL_MINUTES: i64 = 10;
 
 pub struct ApplyPatchTool {
     config: ApplyPatchConfig,
     storage_root_dir: Option<String>,
+    approval_manager: Option<SqliteApprovalManager>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 struct ApplyPatchRequest {
     operations: Vec<PatchOperation>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(tag = "op", rename_all = "snake_case")]
 enum PatchOperation {
     AddFile { path: String, content: String },
@@ -52,6 +59,15 @@ impl ApplyPatchTool {
         Self {
             config: config.tools.apply_patch.clone(),
             storage_root_dir: config.storage.root_dir.clone(),
+            approval_manager: None,
+        }
+    }
+
+    pub fn with_store(config: &AppConfig, store: klaw_storage::DefaultSessionStore) -> Self {
+        Self {
+            config: config.tools.apply_patch.clone(),
+            storage_root_dir: config.storage.root_dir.clone(),
+            approval_manager: Some(SqliteApprovalManager::from_store(store)),
         }
     }
 
@@ -143,7 +159,129 @@ impl ApplyPatchTool {
         })
     }
 
-    fn resolve_workspace_path(&self, base: &Path, input_path: &str) -> Result<PathBuf, ToolError> {
+    async fn check_approval(
+        &self,
+        base: &Path,
+        request: &ApplyPatchRequest,
+        ctx: &ToolContext,
+    ) -> Result<bool, ToolError> {
+        let unauthorized_paths = self.collect_unauthorized_paths(base, &request.operations)?;
+        if unauthorized_paths.is_empty() {
+            return Ok(false);
+        }
+
+        let approved_via_flag = ctx
+            .metadata
+            .get(META_APPLY_PATCH_APPROVED)
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        if approved_via_flag {
+            return Ok(true);
+        }
+
+        let request_hash = Self::request_hash(request)?;
+        if let (Some(manager), Some(approval_id)) = (
+            self.approval_manager.as_ref(),
+            ctx.metadata
+                .get(META_APPLY_PATCH_APPROVAL_ID)
+                .and_then(Value::as_str),
+        ) {
+            let consumed = manager
+                .consume_tool_approval(
+                    approval_id,
+                    self.name(),
+                    &ctx.session_key,
+                    &request_hash,
+                    Self::now_ms(),
+                )
+                .await
+                .map_err(|err| {
+                    ToolError::ExecutionFailed(format!(
+                        "failed to validate approval `{approval_id}`: {err}"
+                    ))
+                })?;
+            if consumed {
+                return Ok(true);
+            }
+        }
+
+        if let Some(manager) = self.approval_manager.as_ref() {
+            let consumed = manager
+                .consume_latest_tool_approval(
+                    self.name(),
+                    &ctx.session_key,
+                    &request_hash,
+                    Self::now_ms(),
+                )
+                .await
+                .map_err(|err| {
+                    ToolError::ExecutionFailed(format!(
+                        "failed to consume approved apply_patch request for session `{}`: {err}",
+                        ctx.session_key
+                    ))
+                })?;
+            if consumed {
+                return Ok(true);
+            }
+        }
+
+        let preview = Self::request_preview(request);
+        let unauthorized = unauthorized_paths
+            .iter()
+            .map(|path| path.display().to_string())
+            .collect::<Vec<_>>();
+        if let Some(manager) = self.approval_manager.as_ref() {
+            let approval = manager
+                .create_approval(ApprovalCreateInput {
+                    session_key: ctx.session_key.clone(),
+                    tool_name: self.name().to_string(),
+                    command_text: preview.clone(),
+                    command_preview: Some(preview.clone()),
+                    command_hash: Some(request_hash),
+                    risk_level: Some("outside_workspace".to_string()),
+                    requested_by: Some("agent".to_string()),
+                    justification: None,
+                    expires_in_minutes: Some(APPROVAL_TTL_MINUTES),
+                })
+                .await
+                .map_err(|err| {
+                    ToolError::ExecutionFailed(format!("failed to create approval: {err}"))
+                })?;
+            let approval_id = approval.id.clone();
+            return Err(ToolError::structured_execution_failed(
+                format!(
+                    "This apply_patch request writes outside the allowed workspace and requires approval.\nApproval ID: {approval_id}\nPaths: {}\nAfter approval, retry the same tool call with metadata `apply_patch.approval_id` set to this ID.",
+                    unauthorized.join(", ")
+                ),
+                "approval_required",
+                Some(json!({
+                    "approval_id": approval_id,
+                    "tool_name": self.name(),
+                    "session_key": ctx.session_key,
+                    "risk_level": "outside_workspace",
+                    "command_preview": approval.command_preview,
+                    "command_hash": approval.command_hash,
+                    "expires_at_ms": approval.expires_at_ms,
+                    "unauthorized_paths": unauthorized,
+                })),
+                true,
+                vec![ToolSignal::approval_required(
+                    &approval.id,
+                    self.name(),
+                    &ctx.session_key,
+                    Some("outside_workspace"),
+                    Some(&approval.command_preview),
+                )],
+            ));
+        }
+
+        Err(ToolError::ExecutionFailed(format!(
+            "This apply_patch request writes outside the allowed workspace and requires approval. Unauthorized paths: {}. Retry with approval metadata once it has been granted.",
+            unauthorized.join(", ")
+        )))
+    }
+
+    fn resolve_candidate_path(&self, base: &Path, input_path: &str) -> Result<PathBuf, ToolError> {
         let raw = PathBuf::from(input_path.trim());
         let candidate = if raw.is_absolute() {
             raw
@@ -158,13 +296,7 @@ impl ApplyPatchTool {
                     candidate.display()
                 ))
             })?;
-            if self.is_allowed_path(base, &canonical)? {
-                return Ok(canonical);
-            }
-            return Err(ToolError::ExecutionFailed(format!(
-                "path `{}` is not allowed by apply_patch policy",
-                canonical.display(),
-            )));
+            return Ok(canonical);
         }
 
         let mut ancestor = candidate.as_path();
@@ -180,17 +312,26 @@ impl ApplyPatchTool {
                 ancestor.display()
             ))
         })?;
-        if !self.is_allowed_path(base, &canonical_ancestor)? {
-            return Err(ToolError::ExecutionFailed(format!(
-                "path `{}` is not allowed by apply_patch policy",
-                candidate.display(),
-            )));
-        }
-
         let suffix = candidate.strip_prefix(ancestor).map_err(|_| {
             ToolError::ExecutionFailed(format!("failed to resolve path `{}`", candidate.display()))
         })?;
         Ok(canonical_ancestor.join(suffix))
+    }
+
+    fn resolve_workspace_path(
+        &self,
+        base: &Path,
+        input_path: &str,
+        approval_granted: bool,
+    ) -> Result<PathBuf, ToolError> {
+        let candidate = self.resolve_candidate_path(base, input_path)?;
+        if approval_granted || self.is_allowed_path(base, &candidate)? {
+            return Ok(candidate);
+        }
+        Err(ToolError::ExecutionFailed(format!(
+            "path `{}` is not allowed by apply_patch policy",
+            candidate.display(),
+        )))
     }
 
     fn is_allowed_path(&self, workspace_base: &Path, path: &Path) -> Result<bool, ToolError> {
@@ -236,29 +377,87 @@ impl ApplyPatchTool {
         &self,
         base: &Path,
         operations: Vec<PatchOperation>,
+        approval_granted: bool,
     ) -> Result<Vec<ResolvedPatchOperation>, ToolError> {
         operations
             .into_iter()
             .map(|operation| match operation {
                 PatchOperation::AddFile { path, content } => Ok(ResolvedPatchOperation::AddFile {
-                    path: self.resolve_workspace_path(base, &path)?,
+                    path: self.resolve_workspace_path(base, &path, approval_granted)?,
                     content,
                 }),
                 PatchOperation::UpdateFile { path, content } => {
                     Ok(ResolvedPatchOperation::UpdateFile {
-                        path: self.resolve_workspace_path(base, &path)?,
+                        path: self.resolve_workspace_path(base, &path, approval_granted)?,
                         content,
                     })
                 }
                 PatchOperation::DeleteFile { path } => Ok(ResolvedPatchOperation::DeleteFile {
-                    path: self.resolve_workspace_path(base, &path)?,
+                    path: self.resolve_workspace_path(base, &path, approval_granted)?,
                 }),
                 PatchOperation::MoveFile { from, to } => Ok(ResolvedPatchOperation::MoveFile {
-                    from: self.resolve_workspace_path(base, &from)?,
-                    to: self.resolve_workspace_path(base, &to)?,
+                    from: self.resolve_workspace_path(base, &from, approval_granted)?,
+                    to: self.resolve_workspace_path(base, &to, approval_granted)?,
                 }),
             })
             .collect()
+    }
+
+    fn collect_unauthorized_paths(
+        &self,
+        base: &Path,
+        operations: &[PatchOperation],
+    ) -> Result<Vec<PathBuf>, ToolError> {
+        let mut unauthorized = BTreeSet::new();
+        for operation in operations {
+            let paths = match operation {
+                PatchOperation::AddFile { path, .. }
+                | PatchOperation::UpdateFile { path, .. }
+                | PatchOperation::DeleteFile { path } => vec![path.as_str()],
+                PatchOperation::MoveFile { from, to } => vec![from.as_str(), to.as_str()],
+            };
+            for raw_path in paths {
+                let resolved = self.resolve_candidate_path(base, raw_path)?;
+                if !self.is_allowed_path(base, &resolved)? {
+                    unauthorized.insert(resolved);
+                }
+            }
+        }
+        Ok(unauthorized.into_iter().collect())
+    }
+
+    fn request_hash(request: &ApplyPatchRequest) -> Result<String, ToolError> {
+        let serialized = serde_json::to_vec(request).map_err(|err| {
+            ToolError::ExecutionFailed(format!("failed to serialize apply_patch request: {err}"))
+        })?;
+        let mut hasher = Sha256::new();
+        hasher.update(&serialized);
+        Ok(format!("{:x}", hasher.finalize()))
+    }
+
+    fn request_preview(request: &ApplyPatchRequest) -> String {
+        let mut summary = request
+            .operations
+            .iter()
+            .map(|operation| match operation {
+                PatchOperation::AddFile { path, .. } => format!("add_file:{path}"),
+                PatchOperation::UpdateFile { path, .. } => format!("update_file:{path}"),
+                PatchOperation::DeleteFile { path } => format!("delete_file:{path}"),
+                PatchOperation::MoveFile { from, to } => format!("move_file:{from}->{to}"),
+            })
+            .collect::<Vec<_>>();
+        let extra_count = summary.len().saturating_sub(3);
+        summary.truncate(3);
+        let preview = summary.join(", ");
+        if extra_count == 0 {
+            preview
+        } else {
+            format!("{preview}, +{extra_count} more")
+        }
+    }
+
+    fn now_ms() -> i64 {
+        (OffsetDateTime::now_utc().unix_timestamp_nanos() / 1_000_000) as i64
     }
 
     fn validate_operations(operations: &[ResolvedPatchOperation]) -> Result<(), ToolError> {
@@ -326,8 +525,9 @@ impl ApplyPatchTool {
         &self,
         base: &Path,
         operations: Vec<PatchOperation>,
+        approval_granted: bool,
     ) -> Result<PatchResult, ToolError> {
-        let operations = self.resolve_operations(base, operations)?;
+        let operations = self.resolve_operations(base, operations, approval_granted)?;
         Self::validate_operations(&operations)?;
 
         let mut summary = Vec::with_capacity(operations.len());
@@ -402,6 +602,7 @@ impl Default for ApplyPatchTool {
         Self {
             config: ApplyPatchConfig::default(),
             storage_root_dir: None,
+            approval_manager: None,
         }
     }
 }
@@ -497,8 +698,11 @@ impl Tool for ApplyPatchTool {
     async fn execute(&self, args: Value, ctx: &ToolContext) -> Result<ToolOutput, ToolError> {
         let request = Self::parse_request(args)?;
         let base = self.resolve_workspace_base(ctx)?;
-        let payload =
-            serde_json::to_value(self.apply_patch(&base, request.operations)?).map_err(|err| {
+        let approval_granted = self.check_approval(&base, &request, ctx).await?;
+        let payload = serde_json::to_value(
+            self.apply_patch(&base, request.operations, approval_granted)?,
+        )
+        .map_err(|err| {
                 ToolError::ExecutionFailed(format!("serialize apply_patch result: {err}"))
             })?;
 
@@ -516,9 +720,13 @@ impl Tool for ApplyPatchTool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use klaw_storage::{ApprovalStatus, DefaultSessionStore, SessionStorage, StoragePaths};
     use klaw_config::AppConfig;
     use serde_json::json;
+    use std::sync::atomic::{AtomicU64, Ordering};
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    static TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
 
     fn temp_workspace() -> PathBuf {
         let nanos = SystemTime::now()
@@ -528,6 +736,18 @@ mod tests {
         let path = std::env::temp_dir().join(format!("klaw-fs-test-{nanos}"));
         fs::create_dir_all(&path).unwrap();
         path
+    }
+
+    async fn create_store() -> DefaultSessionStore {
+        let suffix = TEST_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let now_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_millis())
+            .unwrap_or(0);
+        let root = std::env::temp_dir().join(format!("klaw-apply-patch-test-{now_ms}-{suffix}"));
+        DefaultSessionStore::open(StoragePaths::from_root(root))
+            .await
+            .expect("session store should open")
     }
 
     fn test_ctx(workspace: &Path) -> ToolContext {
@@ -616,7 +836,166 @@ mod tests {
             .await;
 
         assert!(out.is_err());
-        assert!(out.unwrap_err().to_string().contains("not allowed"));
+        assert!(out.unwrap_err().to_string().contains("requires approval"));
+    }
+
+    #[tokio::test]
+    async fn unauthorized_path_returns_approval_required_when_store_is_available() {
+        let workspace = temp_workspace();
+        let store = create_store().await;
+        store
+            .touch_session("s1", "chat-1", "terminal")
+            .await
+            .expect("session should exist");
+        let tool = ApplyPatchTool::with_store(&AppConfig::default(), store);
+
+        let out = tool
+            .execute(
+                json!({
+                    "operations": [
+                        {"op": "add_file", "path": "/etc/hosts", "content": "x"}
+                    ]
+                }),
+                &test_ctx(&workspace),
+            )
+            .await;
+
+        let err = out.expect_err("approval should be required");
+        assert_eq!(err.code(), "approval_required");
+        let approval_signal = err
+            .signals()
+            .iter()
+            .find(|signal| signal.kind == "approval_required")
+            .expect("approval signal should be present");
+        assert_eq!(
+            approval_signal.payload.get("tool_name"),
+            Some(&json!("apply_patch"))
+        );
+    }
+
+    #[tokio::test]
+    async fn approved_apply_patch_request_succeeds_once_with_approval_id() {
+        let workspace = temp_workspace();
+        let outside_dir = temp_workspace();
+        let outside_file = outside_dir.join("approved.txt");
+        let store = create_store().await;
+        store
+            .touch_session("s1", "chat-1", "terminal")
+            .await
+            .expect("session should exist");
+        let tool = ApplyPatchTool::with_store(&AppConfig::default(), store.clone());
+
+        let first = tool
+            .execute(
+                json!({
+                    "operations": [
+                        {"op": "add_file", "path": outside_file.to_string_lossy(), "content": "ok"}
+                    ]
+                }),
+                &test_ctx(&workspace),
+            )
+            .await;
+        let first_err = first.expect_err("approval should be required").to_string();
+        let approval_id = first_err
+            .split("Approval ID: ")
+            .nth(1)
+            .and_then(|tail| tail.lines().next())
+            .map(str::trim)
+            .expect("approval id should be present")
+            .to_string();
+
+        store
+            .update_approval_status(&approval_id, ApprovalStatus::Approved, Some("user"))
+            .await
+            .expect("approval should transition to approved");
+
+        let mut metadata = BTreeMap::new();
+        metadata.insert(
+            META_WORKSPACE.to_string(),
+            json!(workspace.to_string_lossy().to_string()),
+        );
+        metadata.insert("apply_patch.approval_id".to_string(), json!(approval_id.clone()));
+        let approved_ctx = ToolContext {
+            session_key: "s1".to_string(),
+            metadata,
+        };
+
+        let approved_exec = tool
+            .execute(
+                json!({
+                    "operations": [
+                        {"op": "add_file", "path": outside_file.to_string_lossy(), "content": "ok"}
+                    ]
+                }),
+                &approved_ctx,
+            )
+            .await
+            .expect("approved apply_patch should execute");
+        assert!(approved_exec.content_for_model.contains("\"operations_applied\": 1"));
+        assert_eq!(fs::read_to_string(&outside_file).unwrap(), "ok");
+
+        let consumed = store
+            .get_approval(&approval_id)
+            .await
+            .expect("approval should exist");
+        assert_eq!(consumed.status, ApprovalStatus::Consumed);
+    }
+
+    #[tokio::test]
+    async fn approved_apply_patch_request_succeeds_with_latest_approval() {
+        let workspace = temp_workspace();
+        let outside_dir = temp_workspace();
+        let outside_file = outside_dir.join("latest-approved.txt");
+        let store = create_store().await;
+        store
+            .touch_session("s1", "chat-1", "terminal")
+            .await
+            .expect("session should exist");
+        let tool = ApplyPatchTool::with_store(&AppConfig::default(), store.clone());
+
+        let first = tool
+            .execute(
+                json!({
+                    "operations": [
+                        {"op": "add_file", "path": outside_file.to_string_lossy(), "content": "ok"}
+                    ]
+                }),
+                &test_ctx(&workspace),
+            )
+            .await;
+        let first_err = first.expect_err("approval should be required").to_string();
+        let approval_id = first_err
+            .split("Approval ID: ")
+            .nth(1)
+            .and_then(|tail| tail.lines().next())
+            .map(str::trim)
+            .expect("approval id should be present")
+            .to_string();
+
+        store
+            .update_approval_status(&approval_id, ApprovalStatus::Approved, Some("user"))
+            .await
+            .expect("approval should transition to approved");
+
+        let approved_exec = tool
+            .execute(
+                json!({
+                    "operations": [
+                        {"op": "add_file", "path": outside_file.to_string_lossy(), "content": "ok"}
+                    ]
+                }),
+                &test_ctx(&workspace),
+            )
+            .await
+            .expect("approved apply_patch should execute via latest approval");
+        assert!(approved_exec.content_for_model.contains("\"operations_applied\": 1"));
+        assert_eq!(fs::read_to_string(&outside_file).unwrap(), "ok");
+
+        let consumed = store
+            .get_approval(&approval_id)
+            .await
+            .expect("approval should exist");
+        assert_eq!(consumed.status, ApprovalStatus::Consumed);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- route unauthorized `apply_patch` writes through the shared approval flow instead of terminating the agent loop
- generalize approval consumption across storage and approval manager layers so non-shell tools can reuse approved retries safely
- add regression coverage for `apply_patch` approval creation, replay by approval id, replay by latest approval, and cross-tool approval isolation

Closes #195

## Test plan
- [x] `cargo test -p klaw-storage approval_`
- [x] `cargo test -p klaw-approval`
- [x] `cargo test -p klaw-tool apply_patch`
- [x] `cargo test -p klaw-runtime`


Made with [Cursor](https://cursor.com)