### PR TITLE
feat(gui): integrate puffin profiler for GUI performance profiling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -820,6 +820,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2231,6 +2240,7 @@ dependencies = [
  "log",
  "mime_guess2",
  "profiling",
+ "serde",
 ]
 
 [[package]]
@@ -2356,6 +2366,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9"
 dependencies = [
  "enum-map-derive",
+ "serde",
 ]
 
 [[package]]
@@ -4300,6 +4311,8 @@ dependencies = [
  "objc2-app-kit 0.2.2",
  "objc2-core-location",
  "objc2-foundation 0.2.2",
+ "puffin",
+ "puffin_egui",
  "reqwest",
  "rodio",
  "semver",
@@ -4814,6 +4827,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "log-once"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d8a05e3879b317b1b6dbf353e5bba7062bedcc59815267bb23eaa0c576cebf0"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "lru"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4827,6 +4849,12 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lz4_flex"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db9a0d582c2874f68138a16ce1867e0ffde6c0bb0a0df85e1f36d04146db488a"
 
 [[package]]
 name = "mach2"
@@ -5139,6 +5167,12 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "natord"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "308d96db8debc727c3fd9744aac51751243420e46edf401010908da7f8d5e57c"
 
 [[package]]
 name = "ndk"
@@ -6414,6 +6448,39 @@ name = "protobuf"
 version = "2.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+
+[[package]]
+name = "puffin"
+version = "0.20.0"
+source = "git+https://github.com/zhubby/puffin?branch=dev-egui-0.33#ed242bb4d3080a6eb252158d8ba46c2ebddd354e"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "byteorder",
+ "cfg-if",
+ "itertools 0.14.0",
+ "lz4_flex",
+ "parking_lot",
+ "serde",
+]
+
+[[package]]
+name = "puffin_egui"
+version = "0.30.0"
+source = "git+https://github.com/zhubby/puffin?branch=dev-egui-0.33#ed242bb4d3080a6eb252158d8ba46c2ebddd354e"
+dependencies = [
+ "egui",
+ "egui_extras",
+ "indexmap 2.13.0",
+ "log",
+ "log-once",
+ "natord",
+ "parking_lot",
+ "puffin",
+ "time",
+ "vec1",
+ "web-time",
+]
 
 [[package]]
 name = "pulldown-cmark"
@@ -9062,6 +9129,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vec1"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eab68b56840f69efb0fefbe3ab6661499217ffdc58e2eef7c3f6f69835386322"
 
 [[package]]
 name = "vergen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,6 +152,8 @@ opentelemetry-otlp = { version = "0.27", features = ["metrics", "trace", "grpc-t
 opentelemetry-prometheus = "0.27"
 prometheus = "0.13"
 tracing-opentelemetry = "0.28"
+puffin = { git = "https://github.com/zhubby/puffin", branch = "dev-egui-0.33" }
+puffin_egui = { git = "https://github.com/zhubby/puffin", branch = "dev-egui-0.33" }
 cpal = "0.16"
 hound = "3.5"
 rodio = "0.20"

--- a/klaw-config/src/io.rs
+++ b/klaw-config/src/io.rs
@@ -1,4 +1,4 @@
-use crate::{AppConfig, ConfigError, validate};
+use crate::{validate, AppConfig, ConfigError};
 use klaw_util::{config_path, default_data_dir};
 use std::{
     fs,

--- a/klaw-config/src/lib.rs
+++ b/klaw-config/src/lib.rs
@@ -40,6 +40,8 @@ pub struct AppConfig {
     pub storage: StorageConfig,
     #[serde(default)]
     pub observability: ObservabilityConfig,
+    #[serde(default)]
+    pub profiler: ProfilerConfig,
 }
 
 impl Default for AppConfig {
@@ -64,6 +66,7 @@ impl Default for AppConfig {
             skills: SkillsConfig::default(),
             storage: StorageConfig::default(),
             observability: ObservabilityConfig::default(),
+            profiler: ProfilerConfig::default(),
         }
     }
 }
@@ -1850,6 +1853,18 @@ fn default_observability_service_name() -> String {
     "klaw".to_string()
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProfilerConfig {
+    #[serde(default)]
+    pub enabled: bool,
+}
+
+impl Default for ProfilerConfig {
+    fn default() -> Self {
+        Self { enabled: true }
+    }
+}
+
 fn default_observability_service_version() -> String {
     "0.1.0".to_string()
 }
@@ -2049,9 +2064,9 @@ mod io;
 mod validate;
 
 pub use io::{
-    ConfigSnapshot, ConfigStore, LoadedConfig, MigratedConfig, default_config_path,
-    default_config_template, load_or_init, migrate_with_defaults, reset_to_defaults,
-    validate_config_file,
+    default_config_path, default_config_template, load_or_init, migrate_with_defaults,
+    reset_to_defaults, validate_config_file, ConfigSnapshot, ConfigStore, LoadedConfig,
+    MigratedConfig,
 };
 #[cfg(test)]
 pub(crate) use io::{load_from_path, migrate_path_with_defaults, reset_path_to_defaults};

--- a/klaw-config/src/tests.rs
+++ b/klaw-config/src/tests.rs
@@ -63,14 +63,12 @@ fn parse_default_template_succeeds() {
     assert!(parsed.tools.apply_patch.workspace.is_none());
     assert!(!parsed.tools.apply_patch.allow_absolute_paths);
     assert!(parsed.tools.apply_patch.allowed_roots.is_empty());
-    assert!(
-        parsed
-            .tools
-            .channel_attachment
-            .local_attachments
-            .allowlist
-            .is_empty()
-    );
+    assert!(parsed
+        .tools
+        .channel_attachment
+        .local_attachments
+        .allowlist
+        .is_empty());
     assert_eq!(
         parsed.tools.channel_attachment.local_attachments.max_bytes,
         10 * 1024 * 1024
@@ -109,13 +107,11 @@ fn parse_default_template_succeeds() {
             .map(|registry| registry.address.as_str()),
         Some("https://github.com/anthropics/skills")
     );
-    assert!(
-        parsed
-            .skills
-            .registries
-            .get("anthropic")
-            .is_some_and(|registry| registry.installed.is_empty())
-    );
+    assert!(parsed
+        .skills
+        .registries
+        .get("anthropic")
+        .is_some_and(|registry| registry.installed.is_empty()));
     assert_eq!(parsed.cron.tick_ms, 1_000);
     assert_eq!(parsed.cron.runtime_tick_ms, 200);
     assert_eq!(parsed.cron.runtime_drain_batch, 8);

--- a/klaw-gui/Cargo.toml
+++ b/klaw-gui/Cargo.toml
@@ -42,6 +42,8 @@ semver = { workspace = true }
 tokio = { workspace = true }
 toml = { workspace = true }
 sysinfo = { workspace = true }
+puffin = { workspace = true }
+puffin_egui = { workspace = true }
 hostname = { workspace = true }
 uuid = { workspace = true }
 time = { workspace = true }

--- a/klaw-gui/src/app/mod.rs
+++ b/klaw-gui/src/app/mod.rs
@@ -5,6 +5,7 @@ use crate::theme;
 use crate::tray::{self, TrayCommand, TrayIntegration};
 use crate::ui::shell::ShellUi;
 use crate::{hide_macos_app, show_macos_app};
+use klaw_config::ConfigStore;
 use klaw_ui_kit::install_fonts;
 use std::time::{Duration, Instant};
 
@@ -45,7 +46,7 @@ impl KlawGuiApp {
             should_quit: false,
             pending_provider_override: None,
         };
-        puffin::set_scopes_on(true);
+        puffin::set_scopes_on(Self::profiler_enabled());
 
         install_fonts(&creation_ctx.egui_ctx);
         theme::apply_theme(&creation_ctx.egui_ctx, &app.state);
@@ -136,6 +137,13 @@ impl KlawGuiApp {
         self.save_state_now();
         ctx.send_viewport_cmd(egui::ViewportCommand::Visible(false));
         hide_macos_app();
+    }
+
+    fn profiler_enabled() -> bool {
+        ConfigStore::open(None)
+            .ok()
+            .map(|store| store.snapshot().config.profiler.enabled)
+            .unwrap_or(false)
     }
 
     fn mark_state_dirty(&mut self) {

--- a/klaw-gui/src/app/mod.rs
+++ b/klaw-gui/src/app/mod.rs
@@ -1,4 +1,4 @@
-use crate::runtime_bridge::{RuntimeRequestHandle, begin_set_provider_override_request};
+use crate::runtime_bridge::{begin_set_provider_override_request, RuntimeRequestHandle};
 use crate::state::persistence;
 use crate::state::{UiAction, UiState, WindowSize};
 use crate::theme;
@@ -45,6 +45,8 @@ impl KlawGuiApp {
             should_quit: false,
             pending_provider_override: None,
         };
+        puffin::set_scopes_on(true);
+
         install_fonts(&creation_ctx.egui_ctx);
         theme::apply_theme(&creation_ctx.egui_ctx, &app.state);
         creation_ctx
@@ -247,6 +249,9 @@ impl KlawGuiApp {
 
 impl eframe::App for KlawGuiApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        puffin::profile_function!();
+        puffin::GlobalProfiler::lock().new_frame();
+
         self.drain_tray_commands(ctx);
         self.poll_pending_actions();
         self.sync_fullscreen_from_viewport(ctx);

--- a/klaw-gui/src/panels/logs.rs
+++ b/klaw-gui/src/panels/logs.rs
@@ -121,6 +121,7 @@ impl LogsPanel {
     }
 
     pub fn tick(&mut self, ctx: &egui::Context) {
+        puffin::profile_scope!("logs_tick");
         self.ensure_defaults();
         if !self.paused {
             self.drain_runtime_logs(LOG_BACKGROUND_DRAIN_BATCH);
@@ -129,6 +130,7 @@ impl LogsPanel {
     }
 
     fn drain_runtime_logs(&mut self, max_batch: usize) {
+        puffin::profile_scope!("drain_logs");
         let chunks = runtime_bridge::drain_log_chunks(max_batch);
         for chunk in chunks {
             self.absorb_chunk(&chunk);

--- a/klaw-gui/src/panels/mod.rs
+++ b/klaw-gui/src/panels/mod.rs
@@ -76,6 +76,7 @@ pub struct PanelRegistry {
 
 impl PanelRegistry {
     pub fn tick(&mut self, ctx: &egui::Context) {
+        puffin::profile_scope!("panels_tick");
         self.logs.tick(ctx);
     }
 
@@ -86,34 +87,35 @@ impl PanelRegistry {
         notifications: &mut NotificationCenter,
     ) {
         match ctx.menu {
-            WorkbenchMenu::Profile => self.profile.render(ui, ctx, notifications),
-            WorkbenchMenu::System => self.system.render(ui, ctx, notifications),
-            WorkbenchMenu::Setting => self.setting.render(ui, ctx, notifications),
-            WorkbenchMenu::Terminal => self.terminal.render(ui, ctx, notifications),
-            WorkbenchMenu::Session => self.session.render(ui, ctx, notifications),
-            WorkbenchMenu::Approval => self.approval.render(ui, ctx, notifications),
-            WorkbenchMenu::Acp => self.acp.render(ui, ctx, notifications),
-            WorkbenchMenu::Configuration => self.configuration.render(ui, ctx, notifications),
-            WorkbenchMenu::Provider => self.provider.render(ui, ctx, notifications),
-            WorkbenchMenu::Llm => self.llm.render(ui, ctx, notifications),
-            WorkbenchMenu::Channel => self.channel.render(ui, ctx, notifications),
-            WorkbenchMenu::Voice => self.voice.render(ui, ctx, notifications),
-            WorkbenchMenu::Cron => self.cron.render(ui, ctx, notifications),
-            WorkbenchMenu::Heartbeat => self.heartbeat.render(ui, ctx, notifications),
-            WorkbenchMenu::Gateway => self.gateway.render(ui, ctx, notifications),
-            WorkbenchMenu::Webhook => self.webhook.render(ui, ctx, notifications),
-            WorkbenchMenu::Mcp => self.mcp.render(ui, ctx, notifications),
-            WorkbenchMenu::Skill => self.skills_registry.render(ui, ctx, notifications),
-            WorkbenchMenu::SkillsManager => self.skills_manager.render(ui, ctx, notifications),
-            WorkbenchMenu::Memory => self.memory.render(ui, ctx, notifications),
-            WorkbenchMenu::Archive => self.archive.render(ui, ctx, notifications),
-            WorkbenchMenu::Tool => self.tool.render(ui, ctx, notifications),
-            WorkbenchMenu::Monitor => self.monitor.render(ui, ctx, notifications),
-            WorkbenchMenu::Logs => self.logs.render(ui, ctx, notifications),
+            WorkbenchMenu::Profile => { puffin::profile_scope!("panel_profile"); self.profile.render(ui, ctx, notifications) }
+            WorkbenchMenu::System => { puffin::profile_scope!("panel_system"); self.system.render(ui, ctx, notifications) }
+            WorkbenchMenu::Setting => { puffin::profile_scope!("panel_setting"); self.setting.render(ui, ctx, notifications) }
+            WorkbenchMenu::Terminal => { puffin::profile_scope!("panel_terminal"); self.terminal.render(ui, ctx, notifications) }
+            WorkbenchMenu::Session => { puffin::profile_scope!("panel_session"); self.session.render(ui, ctx, notifications) }
+            WorkbenchMenu::Approval => { puffin::profile_scope!("panel_approval"); self.approval.render(ui, ctx, notifications) }
+            WorkbenchMenu::Acp => { puffin::profile_scope!("panel_acp"); self.acp.render(ui, ctx, notifications) }
+            WorkbenchMenu::Configuration => { puffin::profile_scope!("panel_configuration"); self.configuration.render(ui, ctx, notifications) }
+            WorkbenchMenu::Provider => { puffin::profile_scope!("panel_provider"); self.provider.render(ui, ctx, notifications) }
+            WorkbenchMenu::Llm => { puffin::profile_scope!("panel_llm"); self.llm.render(ui, ctx, notifications) }
+            WorkbenchMenu::Channel => { puffin::profile_scope!("panel_channel"); self.channel.render(ui, ctx, notifications) }
+            WorkbenchMenu::Voice => { puffin::profile_scope!("panel_voice"); self.voice.render(ui, ctx, notifications) }
+            WorkbenchMenu::Cron => { puffin::profile_scope!("panel_cron"); self.cron.render(ui, ctx, notifications) }
+            WorkbenchMenu::Heartbeat => { puffin::profile_scope!("panel_heartbeat"); self.heartbeat.render(ui, ctx, notifications) }
+            WorkbenchMenu::Gateway => { puffin::profile_scope!("panel_gateway"); self.gateway.render(ui, ctx, notifications) }
+            WorkbenchMenu::Webhook => { puffin::profile_scope!("panel_webhook"); self.webhook.render(ui, ctx, notifications) }
+            WorkbenchMenu::Mcp => { puffin::profile_scope!("panel_mcp"); self.mcp.render(ui, ctx, notifications) }
+            WorkbenchMenu::Skill => { puffin::profile_scope!("panel_skill"); self.skills_registry.render(ui, ctx, notifications) }
+            WorkbenchMenu::SkillsManager => { puffin::profile_scope!("panel_skills_manager"); self.skills_manager.render(ui, ctx, notifications) }
+            WorkbenchMenu::Memory => { puffin::profile_scope!("panel_memory"); self.memory.render(ui, ctx, notifications) }
+            WorkbenchMenu::Archive => { puffin::profile_scope!("panel_archive"); self.archive.render(ui, ctx, notifications) }
+            WorkbenchMenu::Tool => { puffin::profile_scope!("panel_tool"); self.tool.render(ui, ctx, notifications) }
+            WorkbenchMenu::Monitor => { puffin::profile_scope!("panel_monitor"); self.monitor.render(ui, ctx, notifications) }
+            WorkbenchMenu::Logs => { puffin::profile_scope!("panel_logs"); self.logs.render(ui, ctx, notifications) }
             WorkbenchMenu::AnalyzeDashboard => {
+                puffin::profile_scope!("panel_analyze_dashboard");
                 self.analyze_dashboard.render(ui, ctx, notifications)
             }
-            WorkbenchMenu::Observability => self.observability.render(ui, ctx, notifications),
+            WorkbenchMenu::Observability => { puffin::profile_scope!("panel_observability"); self.observability.render(ui, ctx, notifications) }
         }
     }
 

--- a/klaw-gui/src/panels/monitor.rs
+++ b/klaw-gui/src/panels/monitor.rs
@@ -1,16 +1,19 @@
 use crate::panels::{PanelRenderer, RenderCtx};
+use klaw_config::ConfigStore;
 use std::time::Duration;
 
 const REFRESH_INTERVAL: Duration = Duration::from_secs(1);
 
 pub struct MonitorPanel {
     profiler_ui: puffin_egui::GlobalProfilerUi,
+    profiler_enabled: bool,
 }
 
 impl Default for MonitorPanel {
     fn default() -> Self {
         Self {
             profiler_ui: puffin_egui::GlobalProfilerUi::default(),
+            profiler_enabled: false,
         }
     }
 }
@@ -22,6 +25,16 @@ impl PanelRenderer for MonitorPanel {
         _ctx: &RenderCtx<'_>,
         _notifications: &mut crate::notifications::NotificationCenter,
     ) {
+        let enabled = ConfigStore::open(None)
+            .ok()
+            .map(|store| store.snapshot().config.profiler.enabled)
+            .unwrap_or(false);
+
+        if enabled != self.profiler_enabled {
+            puffin::set_scopes_on(enabled);
+            self.profiler_enabled = enabled;
+        }
+
         ui.ctx().request_repaint_after(REFRESH_INTERVAL);
         self.profiler_ui.ui(ui);
     }

--- a/klaw-gui/src/panels/monitor.rs
+++ b/klaw-gui/src/panels/monitor.rs
@@ -1,58 +1,17 @@
 use crate::panels::{PanelRenderer, RenderCtx};
-use std::time::{Duration, Instant};
-use sysinfo::{CpuRefreshKind, MemoryRefreshKind, RefreshKind, System};
+use std::time::Duration;
 
 const REFRESH_INTERVAL: Duration = Duration::from_secs(1);
-const PROGRESS_BAR_HEIGHT: f32 = 12.0;
-
-fn format_bytes(value: u64) -> String {
-    const KB: f64 = 1024.0;
-    const MB: f64 = KB * 1024.0;
-    const GB: f64 = MB * 1024.0;
-
-    let raw = value as f64;
-    if raw >= GB {
-        format!("{:.2} GB", raw / GB)
-    } else if raw >= MB {
-        format!("{:.2} MB", raw / MB)
-    } else if raw >= KB {
-        format!("{:.2} KB", raw / KB)
-    } else {
-        format!("{value} B")
-    }
-}
 
 pub struct MonitorPanel {
-    system: System,
-    last_refreshed_at: Instant,
+    profiler_ui: puffin_egui::GlobalProfilerUi,
 }
 
 impl Default for MonitorPanel {
     fn default() -> Self {
-        let mut system = System::new_with_specifics(
-            RefreshKind::nothing()
-                .with_cpu(CpuRefreshKind::everything())
-                .with_memory(MemoryRefreshKind::everything()),
-        );
-        system.refresh_cpu_usage();
-        system.refresh_memory();
-
         Self {
-            system,
-            last_refreshed_at: Instant::now(),
+            profiler_ui: puffin_egui::GlobalProfilerUi::default(),
         }
-    }
-}
-
-impl MonitorPanel {
-    fn refresh_if_due(&mut self) {
-        if self.last_refreshed_at.elapsed() < REFRESH_INTERVAL {
-            return;
-        }
-
-        self.system.refresh_cpu_usage();
-        self.system.refresh_memory();
-        self.last_refreshed_at = Instant::now();
     }
 }
 
@@ -60,61 +19,10 @@ impl PanelRenderer for MonitorPanel {
     fn render(
         &mut self,
         ui: &mut egui::Ui,
-        ctx: &RenderCtx<'_>,
+        _ctx: &RenderCtx<'_>,
         _notifications: &mut crate::notifications::NotificationCenter,
     ) {
-        self.refresh_if_due();
         ui.ctx().request_repaint_after(REFRESH_INTERVAL);
-
-        let cpu_usage = self.system.global_cpu_usage();
-        let logical_cpus = self.system.cpus().len();
-        let physical_cores = System::physical_core_count().unwrap_or_default();
-
-        let total_memory = self.system.total_memory();
-        let used_memory = self.system.used_memory();
-        let free_memory = total_memory.saturating_sub(used_memory);
-        let memory_usage = if total_memory == 0 {
-            0.0
-        } else {
-            (used_memory as f32 / total_memory as f32) * 100.0
-        };
-
-        ui.heading(ctx.tab_title);
-        ui.label("Real-time resource and system information");
-        ui.separator();
-
-        ui.columns(2, |cols| {
-            cols[0].vertical(|ui| {
-                ui.strong("CPU Usage");
-                ui.horizontal(|ui| {
-                    let bar = egui::ProgressBar::new((cpu_usage / 100.0).clamp(0.0, 1.0))
-                        .show_percentage()
-                        .desired_height(PROGRESS_BAR_HEIGHT);
-                    ui.add(bar);
-                    ui.monospace(format!("{cpu_usage:.1}%"));
-                });
-                ui.label(format!(
-                    "{} logical / {} physical cores",
-                    logical_cpus, physical_cores
-                ));
-            });
-
-            cols[1].vertical(|ui| {
-                ui.strong("Memory Usage");
-                ui.horizontal(|ui| {
-                    let bar = egui::ProgressBar::new((memory_usage / 100.0).clamp(0.0, 1.0))
-                        .show_percentage()
-                        .desired_height(PROGRESS_BAR_HEIGHT);
-                    ui.add(bar);
-                    ui.monospace(format!(
-                        "{:.1}% ({}/{})",
-                        memory_usage,
-                        format_bytes(used_memory),
-                        format_bytes(total_memory),
-                    ));
-                });
-                ui.label(format!("Free: {}", format_bytes(free_memory)));
-            });
-        });
+        self.profiler_ui.ui(ui);
     }
 }

--- a/klaw-gui/src/ui/shell.rs
+++ b/klaw-gui/src/ui/shell.rs
@@ -201,6 +201,7 @@ impl ShellUi {
     }
 
     pub fn render(&mut self, ctx: &egui::Context, state: &UiState) -> Vec<UiAction> {
+        puffin::profile_function!();
         let mut actions = Vec::new();
         self.panels.tick(ctx);
         self.sync_provider_choices();

--- a/klaw-gui/src/ui/shell.rs
+++ b/klaw-gui/src/ui/shell.rs
@@ -124,6 +124,7 @@ impl ShellUi {
     }
 
     fn sync_provider_choices(&mut self) {
+        puffin::profile_scope!("sync_provider_choices");
         if let Some(request) = self.provider_status_request.as_mut()
             && let Some(result) = request.try_take_result()
         {
@@ -157,6 +158,7 @@ impl ShellUi {
     }
 
     fn poll_release_check(&mut self) {
+        puffin::profile_scope!("poll_release_check");
         let Some(rx) = self.release_check_request.as_ref() else {
             return;
         };


### PR DESCRIPTION
## Summary

This PR integrates the **puffin** frame profiler into the Klaw GUI to enable real-time performance profiling of the egui rendering pipeline.

### Changes
- Add `puffin` and `puffin_egui` dependencies (fork from https://github.com/zhubby/puffin branch `dev-egui-0.33` that supports egui 0.33)
- Enable puffin profiling on app startup
- Add profiling scope to `KlawGuiApp::update` and `ShellUi::tick`
- Refactor Monitor panel to display the puffin profiler UI instead of system resource monitoring
- System resource/host information has been moved to the System panel (completed in previous refactor)

### Benefits
The integrated profiler allows visualizing where time is spent each frame, helping identify performance bottlenecks in the GUI quickly during development.

Closes #203

Screenshot (puffin example):
![puffin_egui](https://raw.githubusercontent.com/zhubby/puffin/dev/puffin_egui.gif)
