### PR TITLE
feat(observability): add token cost estimation with interactive price editor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4067,7 +4067,7 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "klaw-acp"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "agent-client-protocol",
  "async-trait",
@@ -4084,7 +4084,7 @@ dependencies = [
 
 [[package]]
 name = "klaw-agent"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "klaw-config",
@@ -4099,7 +4099,7 @@ dependencies = [
 
 [[package]]
 name = "klaw-approval"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "klaw-storage",
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "klaw-archive"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "hex",
@@ -4128,7 +4128,7 @@ dependencies = [
 
 [[package]]
 name = "klaw-channel"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4153,7 +4153,7 @@ dependencies = [
 
 [[package]]
 name = "klaw-cli"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "clap",
@@ -4193,7 +4193,7 @@ dependencies = [
 
 [[package]]
 name = "klaw-config"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "humantime",
  "klaw-util",
@@ -4205,7 +4205,7 @@ dependencies = [
 
 [[package]]
 name = "klaw-core"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "klaw-agent",
@@ -4223,7 +4223,7 @@ dependencies = [
 
 [[package]]
 name = "klaw-cron"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4240,7 +4240,7 @@ dependencies = [
 
 [[package]]
 name = "klaw-gateway"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4270,7 +4270,7 @@ dependencies = [
 
 [[package]]
 name = "klaw-gui"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4331,7 +4331,7 @@ dependencies = [
 
 [[package]]
 name = "klaw-heartbeat"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "humantime",
@@ -4345,7 +4345,7 @@ dependencies = [
 
 [[package]]
 name = "klaw-llm"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -4360,7 +4360,7 @@ dependencies = [
 
 [[package]]
 name = "klaw-mcp"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "klaw-config",
@@ -4376,7 +4376,7 @@ dependencies = [
 
 [[package]]
 name = "klaw-memory"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "klaw-config",
@@ -4391,7 +4391,7 @@ dependencies = [
 
 [[package]]
 name = "klaw-observability"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "axum 0.8.8",
@@ -4416,7 +4416,7 @@ dependencies = [
 
 [[package]]
 name = "klaw-runtime"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "klaw-acp",
@@ -4451,7 +4451,7 @@ dependencies = [
 
 [[package]]
 name = "klaw-session"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "klaw-storage",
@@ -4461,7 +4461,7 @@ dependencies = [
 
 [[package]]
 name = "klaw-skill"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "klaw-util",
@@ -4475,7 +4475,7 @@ dependencies = [
 
 [[package]]
 name = "klaw-storage"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -4499,7 +4499,7 @@ dependencies = [
 
 [[package]]
 name = "klaw-tool"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4540,7 +4540,7 @@ dependencies = [
 
 [[package]]
 name = "klaw-tui"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "crossterm",
@@ -4553,7 +4553,7 @@ dependencies = [
 
 [[package]]
 name = "klaw-ui-kit"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "catppuccin-egui",
  "eframe",
@@ -4570,7 +4570,7 @@ dependencies = [
 
 [[package]]
 name = "klaw-util"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "iana-time-zone",
  "serde",
@@ -4579,7 +4579,7 @@ dependencies = [
 
 [[package]]
 name = "klaw-voice"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4599,7 +4599,7 @@ dependencies = [
 
 [[package]]
 name = "klaw-webui"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "console_error_panic_hook",
  "eframe",

--- a/klaw-config/src/io.rs
+++ b/klaw-config/src/io.rs
@@ -1,4 +1,4 @@
-use crate::{validate, AppConfig, ConfigError};
+use crate::{AppConfig, ConfigError, validate};
 use klaw_util::{config_path, default_data_dir};
 use std::{
     fs,

--- a/klaw-config/src/lib.rs
+++ b/klaw-config/src/lib.rs
@@ -1808,6 +1808,72 @@ fn default_tavily_search_depth() -> String {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PriceEntry {
+    pub input_rate: f64,
+    pub output_rate: f64,
+}
+
+pub type PriceTable = BTreeMap<String, BTreeMap<String, PriceEntry>>;
+
+fn default_price_table() -> PriceTable {
+    let mut openai = BTreeMap::new();
+    openai.insert(
+        "gpt-4.1".to_string(),
+        PriceEntry {
+            input_rate: 2.0,
+            output_rate: 8.0,
+        },
+    );
+    openai.insert(
+        "gpt-4.1-mini".to_string(),
+        PriceEntry {
+            input_rate: 0.4,
+            output_rate: 1.6,
+        },
+    );
+    openai.insert(
+        "gpt-4o".to_string(),
+        PriceEntry {
+            input_rate: 2.5,
+            output_rate: 10.0,
+        },
+    );
+    openai.insert(
+        "gpt-4o-mini".to_string(),
+        PriceEntry {
+            input_rate: 0.15,
+            output_rate: 0.6,
+        },
+    );
+    let mut anthropic = BTreeMap::new();
+    anthropic.insert(
+        "claude-3-7-sonnet".to_string(),
+        PriceEntry {
+            input_rate: 3.0,
+            output_rate: 15.0,
+        },
+    );
+    anthropic.insert(
+        "claude-sonnet-4".to_string(),
+        PriceEntry {
+            input_rate: 3.0,
+            output_rate: 15.0,
+        },
+    );
+    anthropic.insert(
+        "claude-opus-4".to_string(),
+        PriceEntry {
+            input_rate: 15.0,
+            output_rate: 75.0,
+        },
+    );
+    let mut table = BTreeMap::new();
+    table.insert("openai".to_string(), openai);
+    table.insert("anthropic".to_string(), anthropic);
+    table
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ObservabilityConfig {
     #[serde(default = "default_observability_enabled")]
     pub enabled: bool,
@@ -1827,6 +1893,8 @@ pub struct ObservabilityConfig {
     pub audit: ObservabilityAuditConfig,
     #[serde(default)]
     pub local_store: ObservabilityLocalStoreConfig,
+    #[serde(default = "default_price_table")]
+    pub price: PriceTable,
 }
 
 impl Default for ObservabilityConfig {
@@ -1841,6 +1909,7 @@ impl Default for ObservabilityConfig {
             prometheus: ObservabilityPrometheusConfig::default(),
             audit: ObservabilityAuditConfig::default(),
             local_store: ObservabilityLocalStoreConfig::default(),
+            price: default_price_table(),
         }
     }
 }
@@ -2064,9 +2133,9 @@ mod io;
 mod validate;
 
 pub use io::{
-    default_config_path, default_config_template, load_or_init, migrate_with_defaults,
-    reset_to_defaults, validate_config_file, ConfigSnapshot, ConfigStore, LoadedConfig,
-    MigratedConfig,
+    ConfigSnapshot, ConfigStore, LoadedConfig, MigratedConfig, default_config_path,
+    default_config_template, load_or_init, migrate_with_defaults, reset_to_defaults,
+    validate_config_file,
 };
 #[cfg(test)]
 pub(crate) use io::{load_from_path, migrate_path_with_defaults, reset_path_to_defaults};

--- a/klaw-config/src/tests.rs
+++ b/klaw-config/src/tests.rs
@@ -63,12 +63,14 @@ fn parse_default_template_succeeds() {
     assert!(parsed.tools.apply_patch.workspace.is_none());
     assert!(!parsed.tools.apply_patch.allow_absolute_paths);
     assert!(parsed.tools.apply_patch.allowed_roots.is_empty());
-    assert!(parsed
-        .tools
-        .channel_attachment
-        .local_attachments
-        .allowlist
-        .is_empty());
+    assert!(
+        parsed
+            .tools
+            .channel_attachment
+            .local_attachments
+            .allowlist
+            .is_empty()
+    );
     assert_eq!(
         parsed.tools.channel_attachment.local_attachments.max_bytes,
         10 * 1024 * 1024
@@ -107,11 +109,13 @@ fn parse_default_template_succeeds() {
             .map(|registry| registry.address.as_str()),
         Some("https://github.com/anthropics/skills")
     );
-    assert!(parsed
-        .skills
-        .registries
-        .get("anthropic")
-        .is_some_and(|registry| registry.installed.is_empty()));
+    assert!(
+        parsed
+            .skills
+            .registries
+            .get("anthropic")
+            .is_some_and(|registry| registry.installed.is_empty())
+    );
     assert_eq!(parsed.cron.tick_ms, 1_000);
     assert_eq!(parsed.cron.runtime_tick_ms, 200);
     assert_eq!(parsed.cron.runtime_drain_batch, 8);

--- a/klaw-gui/src/app/mod.rs
+++ b/klaw-gui/src/app/mod.rs
@@ -1,4 +1,4 @@
-use crate::runtime_bridge::{begin_set_provider_override_request, RuntimeRequestHandle};
+use crate::runtime_bridge::{RuntimeRequestHandle, begin_set_provider_override_request};
 use crate::state::persistence;
 use crate::state::{UiAction, UiState, WindowSize};
 use crate::theme;

--- a/klaw-gui/src/panels/analyze_dashboard.rs
+++ b/klaw-gui/src/panels/analyze_dashboard.rs
@@ -5,8 +5,8 @@ use egui_plot::{GridMark, Legend, Line, Plot, PlotPoints};
 use klaw_config::{ConfigStore, ObservabilityConfig};
 use klaw_observability::{
     LocalMetricsStore, LocalStoreConfig, ModelDashboardSnapshot, ModelStatsQuery, ModelStatsRow,
-    ModelToolBreakdownRow, SqliteLocalMetricsStore, ToolDashboardSnapshot, ToolSampleBucket,
-    ToolStatsQuery, ToolStatsRow, ToolTimeRange,
+    ModelToolBreakdownRow, PriceEntry, PriceTable, SqliteLocalMetricsStore, ToolDashboardSnapshot,
+    ToolSampleBucket, ToolStatsQuery, ToolStatsRow, ToolTimeRange,
 };
 use klaw_util::{default_data_dir, observability_db_path};
 use std::path::PathBuf;
@@ -89,6 +89,30 @@ impl AnalyzeDashboardPanel {
         }
     }
 
+    fn price_table(&self) -> PriceTable {
+        self.observability
+            .price
+            .iter()
+            .map(|(provider, models)| {
+                (
+                    provider.clone(),
+                    models
+                        .iter()
+                        .map(|(model, entry)| {
+                            (
+                                model.clone(),
+                                PriceEntry {
+                                    input_rate: entry.input_rate,
+                                    output_rate: entry.output_rate,
+                                },
+                            )
+                        })
+                        .collect(),
+                )
+            })
+            .collect()
+    }
+
     fn should_refresh(&self) -> bool {
         !self.loading
             && self
@@ -116,6 +140,7 @@ impl AnalyzeDashboardPanel {
         let model_query = self.model_query();
         let selected_tool = self.selected_tool.clone();
         let config = self.local_store_config();
+        let price_table = self.price_table();
         let (tx, rx) = mpsc::channel();
         self.load_rx = Some(rx);
         self.loading = true;
@@ -141,7 +166,7 @@ impl AnalyzeDashboardPanel {
                     .await
                     .map_err(|err| err.to_string())?;
                 let model_snapshot = store
-                    .query_model_dashboard_snapshot(&model_query)
+                    .query_model_dashboard_snapshot(&model_query, &price_table)
                     .await
                     .map_err(|err| err.to_string())?;
                 Ok(DashboardLoad {

--- a/klaw-gui/src/panels/mod.rs
+++ b/klaw-gui/src/panels/mod.rs
@@ -87,35 +87,110 @@ impl PanelRegistry {
         notifications: &mut NotificationCenter,
     ) {
         match ctx.menu {
-            WorkbenchMenu::Profile => { puffin::profile_scope!("panel_profile"); self.profile.render(ui, ctx, notifications) }
-            WorkbenchMenu::System => { puffin::profile_scope!("panel_system"); self.system.render(ui, ctx, notifications) }
-            WorkbenchMenu::Setting => { puffin::profile_scope!("panel_setting"); self.setting.render(ui, ctx, notifications) }
-            WorkbenchMenu::Terminal => { puffin::profile_scope!("panel_terminal"); self.terminal.render(ui, ctx, notifications) }
-            WorkbenchMenu::Session => { puffin::profile_scope!("panel_session"); self.session.render(ui, ctx, notifications) }
-            WorkbenchMenu::Approval => { puffin::profile_scope!("panel_approval"); self.approval.render(ui, ctx, notifications) }
-            WorkbenchMenu::Acp => { puffin::profile_scope!("panel_acp"); self.acp.render(ui, ctx, notifications) }
-            WorkbenchMenu::Configuration => { puffin::profile_scope!("panel_configuration"); self.configuration.render(ui, ctx, notifications) }
-            WorkbenchMenu::Provider => { puffin::profile_scope!("panel_provider"); self.provider.render(ui, ctx, notifications) }
-            WorkbenchMenu::Llm => { puffin::profile_scope!("panel_llm"); self.llm.render(ui, ctx, notifications) }
-            WorkbenchMenu::Channel => { puffin::profile_scope!("panel_channel"); self.channel.render(ui, ctx, notifications) }
-            WorkbenchMenu::Voice => { puffin::profile_scope!("panel_voice"); self.voice.render(ui, ctx, notifications) }
-            WorkbenchMenu::Cron => { puffin::profile_scope!("panel_cron"); self.cron.render(ui, ctx, notifications) }
-            WorkbenchMenu::Heartbeat => { puffin::profile_scope!("panel_heartbeat"); self.heartbeat.render(ui, ctx, notifications) }
-            WorkbenchMenu::Gateway => { puffin::profile_scope!("panel_gateway"); self.gateway.render(ui, ctx, notifications) }
-            WorkbenchMenu::Webhook => { puffin::profile_scope!("panel_webhook"); self.webhook.render(ui, ctx, notifications) }
-            WorkbenchMenu::Mcp => { puffin::profile_scope!("panel_mcp"); self.mcp.render(ui, ctx, notifications) }
-            WorkbenchMenu::Skill => { puffin::profile_scope!("panel_skill"); self.skills_registry.render(ui, ctx, notifications) }
-            WorkbenchMenu::SkillsManager => { puffin::profile_scope!("panel_skills_manager"); self.skills_manager.render(ui, ctx, notifications) }
-            WorkbenchMenu::Memory => { puffin::profile_scope!("panel_memory"); self.memory.render(ui, ctx, notifications) }
-            WorkbenchMenu::Archive => { puffin::profile_scope!("panel_archive"); self.archive.render(ui, ctx, notifications) }
-            WorkbenchMenu::Tool => { puffin::profile_scope!("panel_tool"); self.tool.render(ui, ctx, notifications) }
-            WorkbenchMenu::Monitor => { puffin::profile_scope!("panel_monitor"); self.monitor.render(ui, ctx, notifications) }
-            WorkbenchMenu::Logs => { puffin::profile_scope!("panel_logs"); self.logs.render(ui, ctx, notifications) }
+            WorkbenchMenu::Profile => {
+                puffin::profile_scope!("panel_profile");
+                self.profile.render(ui, ctx, notifications)
+            }
+            WorkbenchMenu::System => {
+                puffin::profile_scope!("panel_system");
+                self.system.render(ui, ctx, notifications)
+            }
+            WorkbenchMenu::Setting => {
+                puffin::profile_scope!("panel_setting");
+                self.setting.render(ui, ctx, notifications)
+            }
+            WorkbenchMenu::Terminal => {
+                puffin::profile_scope!("panel_terminal");
+                self.terminal.render(ui, ctx, notifications)
+            }
+            WorkbenchMenu::Session => {
+                puffin::profile_scope!("panel_session");
+                self.session.render(ui, ctx, notifications)
+            }
+            WorkbenchMenu::Approval => {
+                puffin::profile_scope!("panel_approval");
+                self.approval.render(ui, ctx, notifications)
+            }
+            WorkbenchMenu::Acp => {
+                puffin::profile_scope!("panel_acp");
+                self.acp.render(ui, ctx, notifications)
+            }
+            WorkbenchMenu::Configuration => {
+                puffin::profile_scope!("panel_configuration");
+                self.configuration.render(ui, ctx, notifications)
+            }
+            WorkbenchMenu::Provider => {
+                puffin::profile_scope!("panel_provider");
+                self.provider.render(ui, ctx, notifications)
+            }
+            WorkbenchMenu::Llm => {
+                puffin::profile_scope!("panel_llm");
+                self.llm.render(ui, ctx, notifications)
+            }
+            WorkbenchMenu::Channel => {
+                puffin::profile_scope!("panel_channel");
+                self.channel.render(ui, ctx, notifications)
+            }
+            WorkbenchMenu::Voice => {
+                puffin::profile_scope!("panel_voice");
+                self.voice.render(ui, ctx, notifications)
+            }
+            WorkbenchMenu::Cron => {
+                puffin::profile_scope!("panel_cron");
+                self.cron.render(ui, ctx, notifications)
+            }
+            WorkbenchMenu::Heartbeat => {
+                puffin::profile_scope!("panel_heartbeat");
+                self.heartbeat.render(ui, ctx, notifications)
+            }
+            WorkbenchMenu::Gateway => {
+                puffin::profile_scope!("panel_gateway");
+                self.gateway.render(ui, ctx, notifications)
+            }
+            WorkbenchMenu::Webhook => {
+                puffin::profile_scope!("panel_webhook");
+                self.webhook.render(ui, ctx, notifications)
+            }
+            WorkbenchMenu::Mcp => {
+                puffin::profile_scope!("panel_mcp");
+                self.mcp.render(ui, ctx, notifications)
+            }
+            WorkbenchMenu::Skill => {
+                puffin::profile_scope!("panel_skill");
+                self.skills_registry.render(ui, ctx, notifications)
+            }
+            WorkbenchMenu::SkillsManager => {
+                puffin::profile_scope!("panel_skills_manager");
+                self.skills_manager.render(ui, ctx, notifications)
+            }
+            WorkbenchMenu::Memory => {
+                puffin::profile_scope!("panel_memory");
+                self.memory.render(ui, ctx, notifications)
+            }
+            WorkbenchMenu::Archive => {
+                puffin::profile_scope!("panel_archive");
+                self.archive.render(ui, ctx, notifications)
+            }
+            WorkbenchMenu::Tool => {
+                puffin::profile_scope!("panel_tool");
+                self.tool.render(ui, ctx, notifications)
+            }
+            WorkbenchMenu::Monitor => {
+                puffin::profile_scope!("panel_monitor");
+                self.monitor.render(ui, ctx, notifications)
+            }
+            WorkbenchMenu::Logs => {
+                puffin::profile_scope!("panel_logs");
+                self.logs.render(ui, ctx, notifications)
+            }
             WorkbenchMenu::AnalyzeDashboard => {
                 puffin::profile_scope!("panel_analyze_dashboard");
                 self.analyze_dashboard.render(ui, ctx, notifications)
             }
-            WorkbenchMenu::Observability => { puffin::profile_scope!("panel_observability"); self.observability.render(ui, ctx, notifications) }
+            WorkbenchMenu::Observability => {
+                puffin::profile_scope!("panel_observability");
+                self.observability.render(ui, ctx, notifications)
+            }
         }
     }
 

--- a/klaw-gui/src/panels/observability.rs
+++ b/klaw-gui/src/panels/observability.rs
@@ -1,9 +1,79 @@
 use crate::notifications::NotificationCenter;
 use crate::panels::{PanelRenderer, RenderCtx};
-use egui::Color32;
-use egui_extras::{Size, StripBuilder};
+use egui::{Color32, RichText};
+use egui_extras::{Column, Size, StripBuilder, TableBuilder};
 use egui_phosphor::regular;
-use klaw_config::{ConfigStore, ObservabilityConfig};
+use klaw_config::{ConfigStore, ObservabilityConfig, PriceEntry, PriceTable};
+
+const PRICE_TABLE_HEIGHT: f32 = 280.0;
+const PRICE_ROW_HEIGHT: f32 = 24.0;
+
+#[derive(Debug, Clone)]
+struct PriceForm {
+    original_provider: Option<String>,
+    original_model: Option<String>,
+    provider: String,
+    model: String,
+    input_rate: f64,
+    output_rate: f64,
+}
+
+impl PriceForm {
+    fn new() -> Self {
+        Self {
+            original_provider: None,
+            original_model: None,
+            provider: String::new(),
+            model: String::new(),
+            input_rate: 0.0,
+            output_rate: 0.0,
+        }
+    }
+
+    fn edit(provider: &str, model: &str, entry: &PriceEntry) -> Self {
+        Self {
+            original_provider: Some(provider.to_string()),
+            original_model: Some(model.to_string()),
+            provider: provider.to_string(),
+            model: model.to_string(),
+            input_rate: entry.input_rate,
+            output_rate: entry.output_rate,
+        }
+    }
+
+    fn title(&self) -> &'static str {
+        if self.original_provider.is_some() {
+            "Edit Price Entry"
+        } else {
+            "Add Price Entry"
+        }
+    }
+
+    fn validate(&self) -> Result<(String, String, PriceEntry), String> {
+        let provider = self.provider.trim().to_string();
+        if provider.is_empty() {
+            return Err("Provider must not be empty".to_string());
+        }
+        let model = self.model.trim().to_string();
+        if model.is_empty() {
+            return Err("Model must not be empty".to_string());
+        }
+        if self.input_rate < 0.0 {
+            return Err("Input rate must not be negative".to_string());
+        }
+        if self.output_rate < 0.0 {
+            return Err("Output rate must not be negative".to_string());
+        }
+        Ok((
+            provider,
+            model,
+            PriceEntry {
+                input_rate: self.input_rate,
+                output_rate: self.output_rate,
+            },
+        ))
+    }
+}
 
 #[derive(Default)]
 pub struct ObservabilityPanel {
@@ -21,6 +91,9 @@ pub struct ObservabilityPanel {
     export_interval_buffer: String,
     local_store_retention_days_buffer: String,
     local_store_flush_interval_buffer: String,
+    price_form: Option<PriceForm>,
+    price_delete_confirm: Option<(String, String)>,
+    selected_price_row: Option<(String, String)>,
 }
 
 impl ObservabilityPanel {
@@ -175,6 +248,345 @@ impl ObservabilityPanel {
 
     fn status_indicator(&self) -> (bool, &'static str, &'static str) {
         (self.config.enabled, "Enabled", "Disabled")
+    }
+
+    fn save_price_form(&mut self, notifications: &mut NotificationCenter) {
+        let Some(form) = self.price_form.take() else {
+            return;
+        };
+        match form.validate() {
+            Ok((provider, model, entry)) => {
+                if form.original_provider.is_some() {
+                    if let Some(old_provider) = &form.original_provider {
+                        if let Some(old_model) = &form.original_model {
+                            if old_provider != &provider || old_model != &model {
+                                if let Some(models) = self.config.price.get_mut(old_provider) {
+                                    models.remove(old_model.as_str());
+                                }
+                            }
+                        }
+                    }
+                }
+                let is_dup = self
+                    .config
+                    .price
+                    .get(&provider)
+                    .is_some_and(|m| m.contains_key(&model));
+                if is_dup && form.original_provider.is_none() {
+                    notifications
+                        .error(format!("Price entry for {provider}/{model} already exists"));
+                    self.price_form = Some(form);
+                    return;
+                }
+                self.config
+                    .price
+                    .entry(provider)
+                    .or_default()
+                    .insert(model, entry);
+                self.mark_dirty();
+            }
+            Err(err) => {
+                notifications.error(err);
+                self.price_form = Some(form);
+            }
+        }
+    }
+
+    fn delete_price_entry(&mut self, provider: &str, model: &str) {
+        if let Some(models) = self.config.price.get_mut(provider) {
+            models.remove(model);
+            if models.is_empty() {
+                self.config.price.remove(provider);
+            }
+        }
+        self.mark_dirty();
+    }
+
+    fn flattened_price_rows(price: &PriceTable) -> Vec<(String, String, PriceEntry)> {
+        let mut rows: Vec<(String, String, PriceEntry)> = Vec::new();
+        for (provider, models) in price {
+            for (model, entry) in models {
+                rows.push((provider.clone(), model.clone(), entry.clone()));
+            }
+        }
+        rows.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+        rows
+    }
+
+    fn known_providers(&self) -> Vec<String> {
+        let mut providers: Vec<String> = self
+            .store
+            .as_ref()
+            .map(|store| {
+                store
+                    .snapshot()
+                    .config
+                    .model_providers
+                    .keys()
+                    .cloned()
+                    .collect()
+            })
+            .unwrap_or_default();
+        providers.sort();
+        providers
+    }
+
+    fn render_price_section(&mut self, ui: &mut egui::Ui) {
+        let mut edit_provider = None;
+        let mut edit_model = None;
+        let mut delete_provider = None;
+        let mut delete_model = None;
+
+        ui.collapsing("Model Pricing", |ui| {
+            ui.horizontal(|ui| {
+                if ui
+                    .add(egui::Button::new(format!(
+                        "{} Add Price Entry",
+                        regular::PLUS_CIRCLE
+                    )))
+                    .clicked()
+                {
+                    self.price_form = Some(PriceForm::new());
+                }
+                ui.label("Rates are per 1M tokens in USD");
+            });
+            ui.add_space(4.0);
+
+            let rows = Self::flattened_price_rows(&self.config.price);
+
+            if rows.is_empty() {
+                ui.label("No price entries configured. Click Add to create one.");
+                return;
+            }
+
+            let selected_row = self.selected_price_row.clone();
+
+            TableBuilder::new(ui)
+                .striped(true)
+                .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
+                .column(Column::auto().at_least(100.0))
+                .column(Column::auto().at_least(140.0))
+                .column(Column::auto().at_least(96.0))
+                .column(Column::auto().at_least(96.0))
+                .min_scrolled_height(PRICE_TABLE_HEIGHT)
+                .max_scroll_height(PRICE_TABLE_HEIGHT)
+                .sense(egui::Sense::click())
+                .header(PRICE_ROW_HEIGHT, |mut header| {
+                    header.col(|ui| {
+                        ui.strong("Provider");
+                    });
+                    header.col(|ui| {
+                        ui.strong("Model");
+                    });
+                    header.col(|ui| {
+                        ui.strong("Input Rate");
+                    });
+                    header.col(|ui| {
+                        ui.strong("Output Rate");
+                    });
+                })
+                .body(|body| {
+                    body.rows(PRICE_ROW_HEIGHT, rows.len(), |mut row| {
+                        let idx = row.index();
+                        let (provider, model, entry) = &rows[idx];
+                        let is_selected =
+                            selected_row.as_ref() == Some(&(provider.clone(), model.clone()));
+
+                        row.set_selected(is_selected);
+                        row.col(|ui| {
+                            ui.label(provider);
+                        });
+                        row.col(|ui| {
+                            ui.label(model);
+                        });
+                        row.col(|ui| {
+                            ui.label(format!("${:.2}", entry.input_rate));
+                        });
+                        row.col(|ui| {
+                            ui.label(format!("${:.2}", entry.output_rate));
+                        });
+
+                        let response = row.response();
+                        if response.clicked() {
+                            self.selected_price_row = if is_selected {
+                                None
+                            } else {
+                                Some((provider.clone(), model.clone()))
+                            };
+                        }
+
+                        let p = provider.clone();
+                        let m = model.clone();
+                        response.context_menu(|ui: &mut egui::Ui| {
+                            if ui
+                                .button(format!("{} Edit", regular::PENCIL_SIMPLE))
+                                .clicked()
+                            {
+                                edit_provider = Some(p.clone());
+                                edit_model = Some(m.clone());
+                                ui.close();
+                            }
+                            ui.separator();
+                            if ui
+                                .add(egui::Button::new(
+                                    RichText::new(format!("{} Delete", regular::TRASH))
+                                        .color(ui.visuals().warn_fg_color),
+                                ))
+                                .clicked()
+                            {
+                                delete_provider = Some(p.clone());
+                                delete_model = Some(m.clone());
+                                ui.close();
+                            }
+                        });
+                    });
+                });
+        });
+
+        if let (Some(provider), Some(model)) = (edit_provider, edit_model) {
+            if let Some(entry) = self
+                .config
+                .price
+                .get(&provider)
+                .and_then(|models| models.get(&model))
+            {
+                self.price_form = Some(PriceForm::edit(&provider, &model, entry));
+            }
+        }
+        if let (Some(provider), Some(model)) = (delete_provider, delete_model) {
+            self.price_delete_confirm = Some((provider, model));
+        }
+    }
+
+    fn render_price_form_window(
+        &mut self,
+        ui: &mut egui::Ui,
+        notifications: &mut NotificationCenter,
+    ) {
+        let providers = self.known_providers();
+        let Some(form) = self.price_form.as_mut() else {
+            return;
+        };
+        let mut save_clicked = false;
+        let mut cancel_clicked = false;
+
+        egui::Window::new(form.title())
+            .anchor(egui::Align2::CENTER_CENTER, egui::Vec2::ZERO)
+            .collapsible(false)
+            .resizable(false)
+            .show(ui.ctx(), |ui| {
+                ui.set_min_width(400.0);
+                egui::Grid::new("price-form-grid")
+                    .num_columns(2)
+                    .spacing([12.0, 8.0])
+                    .show(ui, |ui| {
+                        ui.label("Provider");
+                        egui::ComboBox::from_id_salt("price-form-provider")
+                            .selected_text(if form.provider.is_empty() {
+                                "Select or type"
+                            } else {
+                                &form.provider
+                            })
+                            .show_ui(ui, |ui| {
+                                if ui
+                                    .selectable_label(form.provider.is_empty(), "(custom)")
+                                    .clicked()
+                                {
+                                    form.provider.clear();
+                                }
+                                for p in &providers {
+                                    if ui.selectable_label(form.provider == *p, p).clicked() {
+                                        form.provider = p.clone();
+                                    }
+                                }
+                            });
+                        ui.end_row();
+
+                        ui.label("Model");
+                        ui.text_edit_singleline(&mut form.model);
+                        ui.end_row();
+
+                        ui.label("Input Rate ($/1M tokens)");
+                        ui.add(
+                            egui::DragValue::new(&mut form.input_rate)
+                                .speed(0.01)
+                                .range(0.0..=f64::MAX)
+                                .custom_formatter(|n, _| format!("${n:.2}"))
+                                .custom_parser(|s| s.trim_start_matches('$').parse().ok()),
+                        );
+                        ui.end_row();
+
+                        ui.label("Output Rate ($/1M tokens)");
+                        ui.add(
+                            egui::DragValue::new(&mut form.output_rate)
+                                .speed(0.01)
+                                .range(0.0..=f64::MAX)
+                                .custom_formatter(|n, _| format!("${n:.2}"))
+                                .custom_parser(|s| s.trim_start_matches('$').parse().ok()),
+                        );
+                        ui.end_row();
+                    });
+                ui.add_space(6.0);
+                ui.horizontal(|ui| {
+                    if ui.button("Save").clicked() {
+                        save_clicked = true;
+                    }
+                    if ui.button("Cancel").clicked() {
+                        cancel_clicked = true;
+                    }
+                });
+            });
+
+        if save_clicked {
+            self.save_price_form(notifications);
+        }
+        if cancel_clicked {
+            self.price_form = None;
+        }
+    }
+
+    fn render_price_delete_confirm(&mut self, ui: &mut egui::Ui) {
+        let Some((provider, model)) = self.price_delete_confirm.clone() else {
+            return;
+        };
+        let mut confirmed = false;
+        let mut cancelled = false;
+
+        egui::Window::new("Delete Price Entry")
+            .anchor(egui::Align2::CENTER_CENTER, egui::Vec2::ZERO)
+            .collapsible(false)
+            .resizable(false)
+            .show(ui.ctx(), |ui| {
+                ui.set_min_width(360.0);
+                ui.label(
+                    RichText::new(format!("Delete price entry for {provider}/{model}?")).strong(),
+                );
+                ui.add_space(8.0);
+                ui.label("This removes the pricing rule from config.toml.");
+                ui.add_space(12.0);
+                ui.horizontal(|ui| {
+                    if ui
+                        .add(egui::Button::new(
+                            RichText::new(format!("{} Delete", regular::TRASH))
+                                .color(ui.visuals().warn_fg_color),
+                        ))
+                        .clicked()
+                    {
+                        confirmed = true;
+                    }
+                    if ui.button("Cancel").clicked() {
+                        cancelled = true;
+                    }
+                });
+            });
+
+        if confirmed {
+            self.delete_price_entry(&provider, &model);
+            self.price_delete_confirm = None;
+        }
+        if cancelled {
+            self.price_delete_confirm = None;
+        }
     }
 }
 
@@ -412,6 +824,10 @@ impl PanelRenderer for ObservabilityPanel {
                                         }
                                     });
                                 });
+
+                                ui.separator();
+
+                                this.render_price_section(ui);
                             });
                     });
                 });
@@ -429,6 +845,9 @@ impl PanelRenderer for ObservabilityPanel {
         } else {
             render_strip(ui, self);
         }
+
+        self.render_price_form_window(ui, notifications);
+        self.render_price_delete_confirm(ui);
     }
 }
 

--- a/klaw-gui/src/panels/system.rs
+++ b/klaw-gui/src/panels/system.rs
@@ -12,9 +12,7 @@ use std::process::Command;
 use std::sync::mpsc::{self, Receiver};
 use std::thread;
 use std::time::{Duration, Instant};
-use sysinfo::{
-    CpuRefreshKind, DiskRefreshKind, Disks, MemoryRefreshKind, RefreshKind, System,
-};
+use sysinfo::{CpuRefreshKind, DiskRefreshKind, Disks, MemoryRefreshKind, RefreshKind, System};
 
 const TASK_POLL_INTERVAL: Duration = Duration::from_millis(200);
 const HOST_INFO_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
@@ -107,7 +105,8 @@ struct HostDataDirStats {
 
 fn collect_host_data_dir_stats(data_dir_path: &Path) -> HostDataDirStats {
     let (used_bytes, file_count) = host_dir_size_and_file_count(data_dir_path);
-    let (disk_total_bytes, disk_available_bytes, mount_point) = host_disk_space_for_path(data_dir_path);
+    let (disk_total_bytes, disk_available_bytes, mount_point) =
+        host_disk_space_for_path(data_dir_path);
 
     HostDataDirStats {
         used_bytes,
@@ -548,9 +547,21 @@ impl SystemPanel {
                         host_info_row(ui, "Total Memory", format_bytes_si(total_memory));
                         host_info_row(ui, "Used Memory", format_bytes_si(used_memory));
                         host_info_row(ui, "Free Memory", format_bytes_si(free_memory));
-                        host_info_row(ui, "Total Swap", format_bytes_si(self.host_info.system.total_swap()));
-                        host_info_row(ui, "Used Swap", format_bytes_si(self.host_info.system.used_swap()));
-                        host_info_row(ui, "System Uptime", format_host_duration(system_uptime_secs));
+                        host_info_row(
+                            ui,
+                            "Total Swap",
+                            format_bytes_si(self.host_info.system.total_swap()),
+                        );
+                        host_info_row(
+                            ui,
+                            "Used Swap",
+                            format_bytes_si(self.host_info.system.used_swap()),
+                        );
+                        host_info_row(
+                            ui,
+                            "System Uptime",
+                            format_host_duration(system_uptime_secs),
+                        );
                         host_info_row(
                             ui,
                             "System Boot Time",
@@ -564,7 +575,11 @@ impl SystemPanel {
                         );
 
                         if let Some(stats) = self.host_info.data_dir_stats.as_ref() {
-                            host_info_row(ui, "Data Directory Size", format_bytes_si(stats.used_bytes));
+                            host_info_row(
+                                ui,
+                                "Data Directory Size",
+                                format_bytes_si(stats.used_bytes),
+                            );
                             host_info_row(
                                 ui,
                                 "Data Directory File Count",
@@ -591,9 +606,21 @@ impl SystemPanel {
                             );
                         } else {
                             host_info_row(ui, "Data Directory Size", "Loading...".to_string());
-                            host_info_row(ui, "Data Directory File Count", "Loading...".to_string());
-                            host_info_row(ui, "Data Directory Mount Point", "Loading...".to_string());
-                            host_info_row(ui, "Data Directory Disk Capacity", "Loading...".to_string());
+                            host_info_row(
+                                ui,
+                                "Data Directory File Count",
+                                "Loading...".to_string(),
+                            );
+                            host_info_row(
+                                ui,
+                                "Data Directory Mount Point",
+                                "Loading...".to_string(),
+                            );
+                            host_info_row(
+                                ui,
+                                "Data Directory Disk Capacity",
+                                "Loading...".to_string(),
+                            );
                             host_info_row(
                                 ui,
                                 "Data Directory Disk Available",
@@ -880,10 +907,16 @@ impl PanelRenderer for SystemPanel {
             let disk_selected = self.current_view == SystemView::ProgramDiskUsage;
             let env_selected = self.current_view == SystemView::Environment;
 
-            if ui.selectable_label(host_selected, "Host Information").clicked() {
+            if ui
+                .selectable_label(host_selected, "Host Information")
+                .clicked()
+            {
                 self.current_view = SystemView::HostInformation;
             }
-            if ui.selectable_label(disk_selected, "Program Disk Usage").clicked() {
+            if ui
+                .selectable_label(disk_selected, "Program Disk Usage")
+                .clicked()
+            {
                 self.current_view = SystemView::ProgramDiskUsage;
             }
             if ui.selectable_label(env_selected, "Environment").clicked() {

--- a/klaw-observability/src/config.rs
+++ b/klaw-observability/src/config.rs
@@ -2,6 +2,72 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PriceEntry {
+    pub input_rate: f64,
+    pub output_rate: f64,
+}
+
+pub type PriceTable = BTreeMap<String, BTreeMap<String, PriceEntry>>;
+
+pub fn default_price_table() -> PriceTable {
+    let mut openai = BTreeMap::new();
+    openai.insert(
+        "gpt-4.1".to_string(),
+        PriceEntry {
+            input_rate: 2.0,
+            output_rate: 8.0,
+        },
+    );
+    openai.insert(
+        "gpt-4.1-mini".to_string(),
+        PriceEntry {
+            input_rate: 0.4,
+            output_rate: 1.6,
+        },
+    );
+    openai.insert(
+        "gpt-4o".to_string(),
+        PriceEntry {
+            input_rate: 2.5,
+            output_rate: 10.0,
+        },
+    );
+    openai.insert(
+        "gpt-4o-mini".to_string(),
+        PriceEntry {
+            input_rate: 0.15,
+            output_rate: 0.6,
+        },
+    );
+    let mut anthropic = BTreeMap::new();
+    anthropic.insert(
+        "claude-3-7-sonnet".to_string(),
+        PriceEntry {
+            input_rate: 3.0,
+            output_rate: 15.0,
+        },
+    );
+    anthropic.insert(
+        "claude-sonnet-4".to_string(),
+        PriceEntry {
+            input_rate: 3.0,
+            output_rate: 15.0,
+        },
+    );
+    anthropic.insert(
+        "claude-opus-4".to_string(),
+        PriceEntry {
+            input_rate: 15.0,
+            output_rate: 75.0,
+        },
+    );
+    let mut table = BTreeMap::new();
+    table.insert("openai".to_string(), openai);
+    table.insert("anthropic".to_string(), anthropic);
+    table
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ObservabilityConfig {
     #[serde(default = "default_enabled")]
     pub enabled: bool,
@@ -21,6 +87,8 @@ pub struct ObservabilityConfig {
     pub audit: AuditConfig,
     #[serde(default)]
     pub local_store: LocalStoreConfig,
+    #[serde(default = "default_price_table")]
+    pub price: PriceTable,
 }
 
 impl Default for ObservabilityConfig {
@@ -35,6 +103,7 @@ impl Default for ObservabilityConfig {
             prometheus: PrometheusConfig::default(),
             audit: AuditConfig::default(),
             local_store: LocalStoreConfig::default(),
+            price: default_price_table(),
         }
     }
 }

--- a/klaw-observability/src/lib.rs
+++ b/klaw-observability/src/lib.rs
@@ -8,7 +8,7 @@ pub mod telemetry;
 pub mod tracing_ext;
 
 pub use audit::{AuditEvent, AuditLogger};
-pub use config::{LocalStoreConfig, ObservabilityConfig};
+pub use config::{LocalStoreConfig, ObservabilityConfig, PriceEntry, PriceTable};
 pub use health::{HealthRegistry, HealthStatus};
 pub use local_store::{
     LocalMetricsStore, LocalMetricsStoreError, ModelDashboardSnapshot, ModelErrorBreakdownRow,

--- a/klaw-observability/src/local_store.rs
+++ b/klaw-observability/src/local_store.rs
@@ -1,4 +1,4 @@
-use crate::config::LocalStoreConfig;
+use crate::config::{LocalStoreConfig, PriceTable};
 use async_trait::async_trait;
 use klaw_core::observability::{
     ModelRequestRecord, ModelRequestStatus, ModelToolOutcomeRecord, ToolOutcomeStatus,
@@ -360,6 +360,7 @@ pub trait LocalMetricsStore: Send + Sync {
     async fn query_model_dashboard_snapshot(
         &self,
         query: &ModelStatsQuery,
+        price_table: &PriceTable,
     ) -> Result<ModelDashboardSnapshot, LocalMetricsStoreError>;
 }
 
@@ -1173,6 +1174,7 @@ impl LocalMetricsStore for SqliteLocalMetricsStore {
     async fn query_model_dashboard_snapshot(
         &self,
         query: &ModelStatsQuery,
+        price_table: &PriceTable,
     ) -> Result<ModelDashboardSnapshot, LocalMetricsStoreError> {
         let now_unix_ms = now_unix_ms();
         let from_unix_ms = query.time_range.window_start_unix_ms(now_unix_ms);
@@ -1383,8 +1385,13 @@ impl LocalMetricsStore for SqliteLocalMetricsStore {
                     .get(&(provider.clone(), model.clone()))
                     .map(|values| percentile(values, 0.95))
                     .unwrap_or(0.0);
-                let estimated_cost_usd =
-                    estimate_cost_usd(&provider, &model, total_input_tokens, total_output_tokens);
+                let estimated_cost_usd = estimate_cost_usd(
+                    price_table,
+                    &provider,
+                    &model,
+                    total_input_tokens,
+                    total_output_tokens,
+                );
                 let completed_turns = turn_agg.completed;
                 let successful_tool_calls = tool_agg.successes;
 
@@ -2002,24 +2009,18 @@ fn sum_rows<T>(rows: &[T], value: impl Fn(&T) -> u64) -> u64 {
 }
 
 fn estimate_cost_usd(
+    price_table: &PriceTable,
     provider: &str,
     model: &str,
     input_tokens: u64,
     output_tokens: u64,
 ) -> Option<f64> {
-    let (input_rate, output_rate) = match (provider, model) {
-        ("openai", "gpt-4.1") => (2.0, 8.0),
-        ("openai", "gpt-4.1-mini") => (0.4, 1.6),
-        ("openai", "gpt-4o") => (2.5, 10.0),
-        ("openai", "gpt-4o-mini") => (0.15, 0.6),
-        ("anthropic", "claude-3-7-sonnet") => (3.0, 15.0),
-        ("anthropic", "claude-sonnet-4") => (3.0, 15.0),
-        ("anthropic", "claude-opus-4") => (15.0, 75.0),
-        _ => return None,
-    };
+    let entry = price_table
+        .get(provider)
+        .and_then(|models| models.get(model))?;
     Some(
-        (input_tokens as f64 / 1_000_000.0) * input_rate
-            + (output_tokens as f64 / 1_000_000.0) * output_rate,
+        (input_tokens as f64 / 1_000_000.0) * entry.input_rate
+            + (output_tokens as f64 / 1_000_000.0) * entry.output_rate,
     )
 }
 
@@ -2195,7 +2196,10 @@ mod tests {
             .expect("turn outcome should persist");
 
         let snapshot = store
-            .query_model_dashboard_snapshot(&ModelStatsQuery::default())
+            .query_model_dashboard_snapshot(
+                &ModelStatsQuery::default(),
+                &crate::config::default_price_table(),
+            )
             .await
             .expect("model snapshot should load");
         assert_eq!(snapshot.summary.total_requests, 2);
@@ -2203,6 +2207,7 @@ mod tests {
         assert_eq!(snapshot.model_rows.len(), 1);
         assert_eq!(snapshot.model_rows[0].provider, "openai");
         assert_eq!(snapshot.model_rows[0].model, "gpt-4o-mini");
+        assert!(snapshot.model_rows[0].estimated_cost_usd.is_some());
         assert_eq!(snapshot.error_breakdown[0].error_code, "timeout");
         assert_eq!(snapshot.tool_breakdown[0].tool_name, "shell");
     }

--- a/klaw-runtime/src/lib.rs
+++ b/klaw-runtime/src/lib.rs
@@ -3735,6 +3735,27 @@ async fn init_observability_from_config(config: &AppConfig) -> Option<Observabil
             retention_days: obs.local_store.retention_days,
             flush_interval_seconds: obs.local_store.flush_interval_seconds,
         },
+        price: obs
+            .price
+            .iter()
+            .map(|(provider, models)| {
+                (
+                    provider.clone(),
+                    models
+                        .iter()
+                        .map(|(model, entry)| {
+                            (
+                                model.clone(),
+                                klaw_observability::PriceEntry {
+                                    input_rate: entry.input_rate,
+                                    output_rate: entry.output_rate,
+                                },
+                            )
+                        })
+                        .collect(),
+                )
+            })
+            .collect(),
     };
     let data_root = config.storage.root_dir.as_ref().map(PathBuf::from);
     match init_observability(&obs_config, data_root).await {


### PR DESCRIPTION
## Summary

This PR adds token cost estimation to the observability analyze dashboard, plus an interactive UI for managing model pricing configuration.

### Changes

**Core functionality:**
- Add `PriceEntry` and `PriceTable` types to define model pricing per provider/model
- Add default price table for common models:
  - OpenAI: GPT-4.1, GPT-4.1-mini, GPT-4o, GPT-4o-mini
  - Anthropic: Claude 3.7 Sonnet, Claude Sonnet 4, Claude Opus 4
- Add `price` field to `ObservabilityConfig` for configurable pricing
- Update `query_model_dashboard_snapshot` to calculate estimated cost based on actual token usage

**GUI features:**
- Add interactive price table editor in the Observability panel
- Modal form for adding/editing price entries with validation
- Delete confirmation dialog
- Sorted table view of all configured price entries
- Automatic integration with existing config persistence

### Screenshot

The price editor UI looks like this:
- Collapsible "Model Pricing" section with table of all entries
- Add button to create new price entries
- Edit/Delete actions per row
- Rates are in USD per 1M tokens (input + output)

Closes #205
