### PR TITLE
fix: exclude heartbeat operational messages from model context

### DIFF
--- a/klaw-heartbeat/CHANGELOG.md
+++ b/klaw-heartbeat/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-04-22
+
+### Fixed
+- heartbeat 上下文组装现在会过滤带 heartbeat metadata 的 operational transcript 记录，静默 ack 与 heartbeat prompt 不再回流进后续模型上下文，同时保留真正需要用户看到的 heartbeat assistant 输出
+
 ## 2026-04-15
 
 ### Changed

--- a/klaw-heartbeat/src/lib.rs
+++ b/klaw-heartbeat/src/lib.rs
@@ -461,6 +461,24 @@ pub fn should_suppress_output(content: &str, metadata: &BTreeMap<String, Value>)
     content.trim() == token
 }
 
+fn parse_chat_record_metadata(raw: Option<&str>) -> BTreeMap<String, Value> {
+    raw.and_then(|value| serde_json::from_str::<BTreeMap<String, Value>>(value).ok())
+        .unwrap_or_default()
+}
+
+pub fn should_exclude_chat_record_from_context(record: &ChatRecord) -> bool {
+    let metadata = parse_chat_record_metadata(record.metadata_json.as_deref());
+    if !is_heartbeat_metadata(&metadata) {
+        return false;
+    }
+
+    match record.role.as_str() {
+        "user" | "system" => true,
+        "assistant" => should_suppress_output(&record.content, &metadata),
+        _ => false,
+    }
+}
+
 fn normalize_input(input: &HeartbeatInput) -> Result<HeartbeatInput, HeartbeatError> {
     let session_key = require_trimmed(&input.session_key, "session_key")?;
     let channel = require_trimmed(&input.channel, "channel")?;
@@ -568,7 +586,11 @@ fn build_history_for_model(
     limit: usize,
     summary_json: Option<&str>,
 ) -> Vec<ChatRecord> {
-    let trimmed = trim_conversation_history(full_history, limit);
+    let filtered = full_history
+        .into_iter()
+        .filter(|record| !should_exclude_chat_record_from_context(record))
+        .collect::<Vec<_>>();
+    let trimmed = trim_conversation_history(filtered, limit);
     let Some(summary_json) = summary_json
         .map(str::trim)
         .filter(|value| !value.is_empty())
@@ -752,6 +774,44 @@ mod tests {
 
         let normal = BTreeMap::new();
         assert!(!should_suppress_output("HEARTBEAT_OK", &normal));
+    }
+
+    #[test]
+    fn context_filter_drops_operational_heartbeat_records_only() {
+        let heartbeat_metadata = serde_json::to_string(&BTreeMap::from([
+            (TRIGGER_KIND_KEY.to_string(), json!(TRIGGER_KIND_HEARTBEAT)),
+            (
+                HEARTBEAT_SILENT_ACK_TOKEN_KEY.to_string(),
+                json!(DEFAULT_SILENT_ACK_TOKEN),
+            ),
+        ]))
+        .expect("heartbeat metadata");
+        let history = vec![
+            ChatRecord::new("user", "normal user", None),
+            ChatRecord::new(
+                "user",
+                "Review the session state. If no user-visible action is needed, reply with exactly HEARTBEAT_OK and nothing else.",
+                None,
+            )
+            .with_metadata_json(Some(heartbeat_metadata.clone())),
+            ChatRecord::new("assistant", "HEARTBEAT_OK", None)
+                .with_metadata_json(Some(heartbeat_metadata.clone())),
+            ChatRecord::new("assistant", "Please follow up on the pending approval.", None)
+                .with_metadata_json(Some(heartbeat_metadata)),
+        ];
+
+        let filtered = build_history_for_model(history, 10, None);
+        let contents = filtered
+            .into_iter()
+            .map(|record| record.content)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            contents,
+            vec![
+                "normal user".to_string(),
+                "Please follow up on the pending approval.".to_string(),
+            ]
+        );
     }
 
     #[test]

--- a/klaw-runtime/CHANGELOG.md
+++ b/klaw-runtime/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 2026-04-22
+
+### Fixed
+
+- normal turn 的会话历史组装现在会跳过 heartbeat operational records，避免静默 ack 或 heartbeat prompt 污染后续用户对话上下文并诱发模型解释 `HEARTBEAT_OK` 一类控制消息
+
 ## 2026-04-15
 
 ### Changed

--- a/klaw-runtime/src/lib.rs
+++ b/klaw-runtime/src/lib.rs
@@ -33,7 +33,9 @@ use klaw_gateway::{
     GatewayWebsocketBroadcaster, META_WEBSOCKET_MODEL, META_WEBSOCKET_MODEL_PROVIDER,
     TailscaleHostInfo,
 };
-use klaw_heartbeat::{HeartbeatManager, should_suppress_output};
+use klaw_heartbeat::{
+    HeartbeatManager, should_exclude_chat_record_from_context, should_suppress_output,
+};
 use klaw_llm::{ChatOptions, LlmError, LlmMessage, LlmProvider, LlmResponse, ToolDefinition};
 use klaw_mcp::{McpConfigSnapshot, McpInitHandle, McpManager, McpSyncResult};
 use klaw_memory::{
@@ -2432,7 +2434,11 @@ fn build_history_for_model(
     limit: usize,
     summary: Option<&ConversationSummary>,
 ) -> Vec<ChatRecord> {
-    let mut trimmed = trim_conversation_history(full_history, limit);
+    let filtered = full_history
+        .into_iter()
+        .filter(|record| !should_exclude_chat_record_from_context(record))
+        .collect::<Vec<_>>();
+    let mut trimmed = trim_conversation_history(filtered, limit);
     let Some(summary) = summary else {
         return trimmed;
     };
@@ -5463,6 +5469,42 @@ A .docx file is a ZIP archive containing XML files.
                 .contains("Conversation Summary (JSON):")
         );
         assert_eq!(model_history[1].content, "c");
+    }
+
+    #[test]
+    fn build_history_for_model_filters_heartbeat_operational_records() {
+        let heartbeat_metadata = serde_json::to_string(&BTreeMap::from([
+            ("trigger.kind".to_string(), json!("heartbeat")),
+            (
+                "heartbeat.silent_ack_token".to_string(),
+                json!("HEARTBEAT_OK"),
+            ),
+        ]))
+        .expect("heartbeat metadata");
+        let full_history = vec![
+            ChatRecord::new("user", "normal user", None),
+            ChatRecord::new("user", "heartbeat prompt", None)
+                .with_metadata_json(Some(heartbeat_metadata.clone())),
+            ChatRecord::new("assistant", "HEARTBEAT_OK", None)
+                .with_metadata_json(Some(heartbeat_metadata.clone())),
+            ChatRecord::new("assistant", "Please check the pending follow-up.", None)
+                .with_metadata_json(Some(heartbeat_metadata)),
+            ChatRecord::new("assistant", "normal assistant", None),
+        ];
+
+        let model_history = build_history_for_model(full_history, 10, None);
+        let contents = model_history
+            .into_iter()
+            .map(|record| record.content)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            contents,
+            vec![
+                "normal user".to_string(),
+                "Please check the pending follow-up.".to_string(),
+                "normal assistant".to_string(),
+            ]
+        );
     }
 
     #[test]

--- a/klaw-webui/CHANGELOG.md
+++ b/klaw-webui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 2026-04-22
+
+### Fixed
+
+- webui 历史分页现在会连同 heartbeat operational prompt 一起过滤，不再只隐藏 heartbeat silent-ack；真正需要展示给用户的 heartbeat assistant 输出仍会保留
+
 ## 2026-04-15
 
 ### Added

--- a/klaw-webui/src/lib.rs
+++ b/klaw-webui/src/lib.rs
@@ -840,6 +840,23 @@ pub(crate) fn should_hide_heartbeat_silent_ack(
 }
 
 #[cfg(any(test, target_arch = "wasm32"))]
+pub(crate) fn should_hide_heartbeat_operational_message(
+    role: &str,
+    content: &str,
+    metadata: &BTreeMap<String, Value>,
+) -> bool {
+    let is_heartbeat = metadata
+        .get("trigger.kind")
+        .and_then(Value::as_str)
+        .is_some_and(|value| value == "heartbeat");
+    if !is_heartbeat {
+        return false;
+    }
+
+    matches!(role, "user" | "system") || should_hide_heartbeat_silent_ack(content, metadata)
+}
+
+#[cfg(any(test, target_arch = "wasm32"))]
 pub(crate) fn attachment_action_in_progress(selecting_file: bool, uploading_file: bool) -> bool {
     selecting_file || uploading_file
 }

--- a/klaw-webui/src/web_chat/transport.rs
+++ b/klaw-webui/src/web_chat/transport.rs
@@ -7,8 +7,8 @@ use web_sys::{CloseEvent, MessageEvent, WebSocket};
 use crate::{
     ConnectionState, MessageRole, ProviderCatalog, WebArchiveAttachment, WorkspaceSessionEntry,
     build_websocket_submit_params, classify_stream_message_action,
-    next_pending_attachments_after_submit, should_hide_heartbeat_silent_ack,
-    should_register_non_stream_fade,
+    next_pending_attachments_after_submit, should_hide_heartbeat_operational_message,
+    should_hide_heartbeat_silent_ack, should_register_non_stream_fade,
 };
 
 use super::{
@@ -817,7 +817,13 @@ fn prepend_history_page(history: &mut Vec<ChatMessage>, page_messages: Vec<Histo
         .collect::<BTreeSet<_>>();
     let mut prepended = page_messages
         .into_iter()
-        .filter(|message| !should_hide_heartbeat_silent_ack(&message.content, &message.metadata))
+        .filter(|message| {
+            !should_hide_heartbeat_operational_message(
+                &message.role,
+                &message.content,
+                &message.metadata,
+            )
+        })
         .filter(|message| {
             message
                 .message_id
@@ -885,8 +891,8 @@ mod tests {
         HistoryPageMessage, build_submit_params, history_cursor_can_advance,
         history_request_cursor, prepend_history_page,
     };
-    use crate::should_hide_heartbeat_silent_ack;
     use crate::{MessageRole, WebArchiveAttachment};
+    use crate::{should_hide_heartbeat_operational_message, should_hide_heartbeat_silent_ack};
     use std::collections::BTreeMap;
 
     #[test]
@@ -1054,6 +1060,33 @@ mod tests {
         assert!(!should_hide_heartbeat_silent_ack(
             "HEARTBEAT_OK",
             &BTreeMap::new()
+        ));
+    }
+
+    #[test]
+    fn prepend_history_page_drops_heartbeat_operational_prompts() {
+        let mut history = Vec::new();
+
+        prepend_history_page(
+            &mut history,
+            vec![HistoryPageMessage {
+                role: "user".to_string(),
+                content: "heartbeat prompt".to_string(),
+                timestamp_ms: 1,
+                metadata: BTreeMap::from([("trigger.kind".to_string(), json!("heartbeat"))]),
+                message_id: Some("msg-hb-user".to_string()),
+            }],
+        );
+
+        assert!(history.is_empty());
+    }
+
+    #[test]
+    fn heartbeat_operational_message_filter_preserves_visible_assistant_output() {
+        assert!(!should_hide_heartbeat_operational_message(
+            "assistant",
+            "Please follow up with the user.",
+            &BTreeMap::from([("trigger.kind".to_string(), json!("heartbeat"))]),
         ));
     }
 }


### PR DESCRIPTION
## Summary
- filter heartbeat operational records out of runtime and heartbeat model-context assembly
- keep user-visible heartbeat assistant output while excluding silent ack and heartbeat prompt turns
- align webui history paging with the same heartbeat operational-message filtering rule

## Related Issue
Fixes #207

## Test Plan
- [x] `cargo fmt --all`
- [x] `cargo test -p klaw-heartbeat`
- [x] `cargo test -p klaw-runtime build_history_for_model_filters_heartbeat_operational_records`
- [x] `cargo test -p klaw-webui`
- [x] `cargo check -p klaw-runtime -p klaw-heartbeat -p klaw-webui`

## Risks
- heartbeat assistant messages with `trigger.kind=heartbeat` remain visible only when they are substantive non-silent outputs; this intentionally changes transcript filtering semantics for operational heartbeat user/system records

## Rollback
- revert commit `e646450`
