### PR TITLE
fix: reduce webui history load overhead

### DIFF
--- a/klaw-webui/CHANGELOG.md
+++ b/klaw-webui/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## 2026-04-22
 
+### Changed
+
+- webui `session.history.load` 现在每次请求 30 条历史而不是 10 条，减少长会话向上滚动时的 websocket 往返次数
+
+### Fixed
+
+- agent 会话窗口渲染不再在每一帧先全量 clone 当前消息列表，长历史场景下可减少前端 transcript 重绘时的内存复制开销
+
+## 2026-04-22
+
 ### Fixed
 
 - webui 历史分页现在会连同 heartbeat operational prompt 一起过滤，不再只隐藏 heartbeat silent-ack；真正需要展示给用户的 heartbeat assistant 输出仍会保留

--- a/klaw-webui/src/web_chat/transport.rs
+++ b/klaw-webui/src/web_chat/transport.rs
@@ -245,7 +245,7 @@ impl ChatApp {
             json!({
                 "session_key": session_key,
                 "before_message_id": before_message_id,
-                "limit": 10,
+                "limit": 30,
             }),
         ) {
             *self.sessions[index].buffers.history_loading.borrow_mut() = false;

--- a/klaw-webui/src/web_chat/ui.rs
+++ b/klaw-webui/src/web_chat/ui.rs
@@ -677,7 +677,6 @@ impl ChatApp {
         let mut set_active = false;
         {
             let session = &mut self.sessions[index];
-            let messages = session.buffers.messages.borrow().clone();
             let mut open = session.open;
 
             let window = egui::Window::new(&session.title)
@@ -704,6 +703,7 @@ impl ChatApp {
 
                 let messages_height = (ui.available_height() - INPUT_PANEL_HEIGHT).max(140.0);
                 ui.allocate_ui(vec2(ui.available_width(), messages_height), |ui| {
+                    let messages = session.buffers.messages.borrow();
                     let scroll_output = ScrollArea::vertical()
                         .auto_shrink([false, false])
                         .stick_to_bottom(true)


### PR DESCRIPTION
## Summary
- raise websocket history page size from 10 to 30 to reduce upward-scroll websocket roundtrips
- stop cloning the full in-memory message list on each session window render in webui

## Related Issue
Fixes #211

## Test Plan
- [x] `cargo fmt --all`
- [x] `cargo test -p klaw-webui`
- [x] `cargo check -p klaw-webui`

## Risks
- larger history pages slightly increase per-request payload size, but reduce request count and should improve perceived history loading speed overall

## Rollback
- revert commit `7a0739c`
