### PR TITLE
fix: simplify dingtalk outbound fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4143,6 +4143,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum 0.27.2",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tokio-tungstenite",

--- a/klaw-channel/Cargo.toml
+++ b/klaw-channel/Cargo.toml
@@ -17,6 +17,7 @@ time = { workspace = true }
 tokio = { workspace = true, features = ["io-util", "io-std", "net", "signal", "time"] }
 tokio-tungstenite = { workspace = true }
 tracing = { workspace = true }
+thiserror = { workspace = true }
 urlencoding = { workspace = true }
 uuid = { workspace = true }
 klaw-core = { workspace = true }

--- a/klaw-channel/src/dingtalk/client.rs
+++ b/klaw-channel/src/dingtalk/client.rs
@@ -1,4 +1,4 @@
-use super::config::DingtalkProxyConfig;
+use super::{config::DingtalkProxyConfig, error::DingtalkApiError};
 use crate::ChannelResult;
 use serde_json::Value;
 use std::sync::OnceLock;
@@ -10,6 +10,8 @@ const DINGTALK_OAPI_BASE: &str = "https://oapi.dingtalk.com";
 const CONNECTION_OPEN_PATH: &str = "/v1.0/gateway/connections/open";
 const ACCESS_TOKEN_PATH: &str = "/v1.0/oauth2/accessToken";
 const MESSAGE_FILE_DOWNLOAD_PATH: &str = "/v1.0/robot/messageFiles/download";
+const GROUP_MESSAGE_SEND_PATH: &str = "/v1.0/robot/groupMessages/send";
+const OTO_MESSAGE_BATCH_SEND_PATH: &str = "/v1.0/robot/oToMessages/batchSend";
 const OAPI_MEDIA_UPLOAD_PATH: &str = "/media/upload";
 const OAPI_ASR_TRANSLATE_PATH: &str = "/topapi/asr/voice/translate";
 const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
@@ -25,6 +27,46 @@ pub(super) struct DingtalkApiClient {
 pub(super) struct StreamConnectionTicket {
     pub endpoint: String,
     pub ticket: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ProactiveChatTargetKind {
+    Group,
+    User,
+}
+
+pub(super) fn proactive_chat_target_kind(chat_id: &str) -> ProactiveChatTargetKind {
+    if chat_id.trim_start().starts_with("cid") {
+        ProactiveChatTargetKind::Group
+    } else {
+        ProactiveChatTargetKind::User
+    }
+}
+
+pub(super) fn build_proactive_markdown_payload(
+    robot_code: &str,
+    chat_id: &str,
+    title: &str,
+    text: &str,
+) -> Value {
+    let mut payload = serde_json::json!({
+        "robotCode": robot_code.trim(),
+        "msgKey": "sampleMarkdown",
+        "msgParam": serde_json::to_string(&serde_json::json!({
+            "title": title,
+            "text": text,
+        }))
+        .expect("markdown payload should serialize"),
+    });
+    match proactive_chat_target_kind(chat_id) {
+        ProactiveChatTargetKind::Group => {
+            payload["openConversationId"] = Value::String(chat_id.trim().to_string());
+        }
+        ProactiveChatTargetKind::User => {
+            payload["userIds"] = serde_json::json!([chat_id.trim()]);
+        }
+    }
+    payload
 }
 
 impl DingtalkApiClient {
@@ -340,9 +382,12 @@ impl DingtalkApiClient {
             .get("errmsg")
             .and_then(Value::as_str)
             .unwrap_or("unknown");
-        Err(format!(
-            "dingtalk session webhook {context} failed: errcode={errcode} errmsg={errmsg} body={payload}"
-        )
+        Err(DingtalkApiError::SessionWebhookBusiness {
+            context: context.to_string(),
+            errcode,
+            errmsg: errmsg.to_string(),
+            body: payload,
+        }
         .into())
     }
 
@@ -472,6 +517,52 @@ impl DingtalkApiClient {
             .into());
         }
         Self::ensure_session_webhook_success(&body, "actionCard send")?;
+        Ok(())
+    }
+
+    pub(super) async fn send_proactive_markdown(
+        &self,
+        access_token: &str,
+        robot_code: &str,
+        chat_id: &str,
+        title: &str,
+        text: &str,
+    ) -> ChannelResult<()> {
+        let path = match proactive_chat_target_kind(chat_id) {
+            ProactiveChatTargetKind::Group => GROUP_MESSAGE_SEND_PATH,
+            ProactiveChatTargetKind::User => OTO_MESSAGE_BATCH_SEND_PATH,
+        };
+        let url = format!("{DINGTALK_OPEN_API_BASE}{path}");
+        let payload = build_proactive_markdown_payload(robot_code, chat_id, title, text);
+        let response = self
+            .http
+            .post(url)
+            .header("x-acs-dingtalk-access-token", access_token)
+            .json(&payload)
+            .send()
+            .await?;
+
+        let status = response.status();
+        let body: Value = response.json().await?;
+        if !status.is_success() {
+            return Err(format!(
+                "dingtalk proactive markdown send failed: HTTP {} body={}",
+                status, body
+            )
+            .into());
+        }
+        if let Some(errcode) = body.get("errcode").and_then(Value::as_i64)
+            && errcode != 0
+        {
+            let errmsg = body
+                .get("errmsg")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown");
+            return Err(format!(
+                "dingtalk proactive markdown send failed: errcode={errcode} errmsg={errmsg} body={body}"
+            )
+            .into());
+        }
         Ok(())
     }
 

--- a/klaw-channel/src/dingtalk/config.rs
+++ b/klaw-channel/src/dingtalk/config.rs
@@ -34,7 +34,7 @@ impl Default for DingtalkChannelConfig {
     }
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct DingtalkProxyConfig {
     pub enabled: bool,

--- a/klaw-channel/src/dingtalk/error.rs
+++ b/klaw-channel/src/dingtalk/error.rs
@@ -1,0 +1,34 @@
+use serde_json::Value;
+use std::error::Error;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum DingtalkApiError {
+    #[error(
+        "dingtalk session webhook {context} failed: errcode={errcode} errmsg={errmsg} body={body}"
+    )]
+    SessionWebhookBusiness {
+        context: String,
+        errcode: i64,
+        errmsg: String,
+        body: Value,
+    },
+}
+
+impl DingtalkApiError {
+    #[must_use]
+    pub fn is_session_not_found(&self) -> bool {
+        matches!(
+            self,
+            Self::SessionWebhookBusiness {
+                errcode: 300001,
+                ..
+            }
+        )
+    }
+}
+
+pub fn is_session_webhook_session_not_found_error(err: &(dyn Error + 'static)) -> bool {
+    err.downcast_ref::<DingtalkApiError>()
+        .is_some_and(DingtalkApiError::is_session_not_found)
+}

--- a/klaw-channel/src/dingtalk/mod.rs
+++ b/klaw-channel/src/dingtalk/mod.rs
@@ -1,6 +1,7 @@
 mod attachments;
 mod client;
 mod config;
+mod error;
 mod parsing;
 
 #[cfg(test)]
@@ -10,6 +11,7 @@ use self::attachments::deliver_dingtalk_attachments;
 use self::client::DingtalkApiClient;
 use self::config::resolve_local_attachment_policy;
 pub use self::config::{DingtalkChannelConfig, DingtalkProxyConfig};
+pub use self::error::{DingtalkApiError, is_session_webhook_session_not_found_error};
 use self::parsing::{
     EventDeduper, InboundEvent, StreamEnvelope, build_im_card_action_buttons,
     build_im_card_action_card_body, is_sender_allowed, parse_card_callback_event,
@@ -392,6 +394,21 @@ pub async fn send_session_webhook_markdown_via_proxy(
     let client = DingtalkApiClient::new(proxy)?;
     client
         .send_session_webhook_markdown(session_webhook, title, text)
+        .await
+}
+
+pub async fn send_proactive_markdown_via_proxy(
+    proxy: &DingtalkProxyConfig,
+    client_id: &str,
+    client_secret: &str,
+    chat_id: &str,
+    title: &str,
+    text: &str,
+) -> ChannelResult<()> {
+    let client = DingtalkApiClient::new(proxy)?;
+    let access_token = client.fetch_access_token(client_id, client_secret).await?;
+    client
+        .send_proactive_markdown(&access_token, client_id, chat_id, title, text)
         .await
 }
 

--- a/klaw-channel/src/dingtalk/tests.rs
+++ b/klaw-channel/src/dingtalk/tests.rs
@@ -3,7 +3,11 @@ use super::{
         build_unsupported_file_attachment_markdown, infer_dingtalk_file_type,
         supported_dingtalk_file_type,
     },
-    client::DingtalkApiClient,
+    client::{
+        DingtalkApiClient, ProactiveChatTargetKind, build_proactive_markdown_payload,
+        proactive_chat_target_kind,
+    },
+    error::{DingtalkApiError, is_session_webhook_session_not_found_error},
     parsing::{
         ApprovalAction, CardCallbackEvent, EventDeduper, InboundEvent,
         build_approval_action_card_body, build_im_card_action_buttons,
@@ -508,6 +512,28 @@ fn session_webhook_success_rejects_non_zero_errcode_json() {
     .expect_err("non-zero errcode should fail");
     assert!(err.to_string().contains("errcode=310000"));
     assert!(err.to_string().contains("invalid session"));
+    let typed = err
+        .downcast_ref::<DingtalkApiError>()
+        .expect("error should downcast to DingtalkApiError");
+    assert!(matches!(
+        typed,
+        DingtalkApiError::SessionWebhookBusiness {
+            errcode: 310000,
+            ..
+        }
+    ));
+    assert!(!is_session_webhook_session_not_found_error(err.as_ref()));
+}
+
+#[test]
+fn session_webhook_not_found_is_detected_via_typed_error() {
+    let err = DingtalkApiClient::ensure_session_webhook_success(
+        r#"{"errcode":300001,"errmsg":"session 不存在"}"#,
+        "markdown send",
+    )
+    .expect_err("session not found should fail");
+
+    assert!(is_session_webhook_session_not_found_error(err.as_ref()));
 }
 
 #[test]
@@ -834,4 +860,45 @@ fn parse_card_callback_event_reads_reject_token_from_nested_payload() {
     assert_eq!(parsed.chat_id, "staff-2");
     assert_eq!(parsed.sender_id, "staff-2");
     assert!(parsed.session_webhook.is_none());
+}
+
+#[test]
+fn proactive_chat_target_kind_treats_cid_as_group() {
+    assert_eq!(
+        proactive_chat_target_kind("cid-group-1"),
+        ProactiveChatTargetKind::Group
+    );
+    assert_eq!(
+        proactive_chat_target_kind(" user-1 "),
+        ProactiveChatTargetKind::User
+    );
+}
+
+#[test]
+fn build_proactive_markdown_payload_targets_user_ids_for_dm() {
+    let payload = build_proactive_markdown_payload("robot_1", "user-1", "Title", "Hello");
+
+    assert_eq!(
+        payload.get("robotCode").and_then(serde_json::Value::as_str),
+        Some("robot_1")
+    );
+    assert_eq!(
+        payload.get("msgKey").and_then(serde_json::Value::as_str),
+        Some("sampleMarkdown")
+    );
+    assert_eq!(payload.get("openConversationId"), None);
+    assert_eq!(payload.get("userIds"), Some(&serde_json::json!(["user-1"])));
+}
+
+#[test]
+fn build_proactive_markdown_payload_targets_group_conversation() {
+    let payload = build_proactive_markdown_payload("robot_group", "cid-group-1", "Title", "Hello");
+
+    assert_eq!(
+        payload
+            .get("openConversationId")
+            .and_then(serde_json::Value::as_str),
+        Some("cid-group-1")
+    );
+    assert_eq!(payload.get("userIds"), None);
 }

--- a/klaw-runtime/src/service_loop.rs
+++ b/klaw-runtime/src/service_loop.rs
@@ -1,5 +1,9 @@
 use super::{RuntimeBundle, drain_runtime_queue};
-use klaw_channel::dingtalk::{DingtalkProxyConfig, send_session_webhook_markdown_via_proxy};
+use klaw_channel::ChannelResult;
+use klaw_channel::dingtalk::{
+    DingtalkProxyConfig, is_session_webhook_session_not_found_error,
+    send_proactive_markdown_via_proxy, send_session_webhook_markdown_via_proxy,
+};
 use klaw_channel::telegram::dispatch_background_outbound as dispatch_telegram_background_outbound;
 use klaw_config::{AppConfig, CronMissedRunPolicy};
 use klaw_core::{
@@ -9,11 +13,11 @@ use klaw_core::{
 use klaw_cron::{CronWorker, CronWorkerConfig, MissedRunPolicy};
 use klaw_gateway::{GatewayWebsocketServerFrame, OutboundEvent};
 use klaw_heartbeat::{HeartbeatWorker, HeartbeatWorkerConfig, should_suppress_output};
-use klaw_session::{SessionManager, SqliteSessionManager};
 use klaw_storage::{ChatRecord, DefaultSessionStore, SessionStorage};
 use serde_json::Value;
 use std::{
     collections::BTreeMap,
+    io,
     sync::{Mutex, mpsc},
     thread,
     time::Duration,
@@ -79,6 +83,14 @@ impl ChannelAvailability {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BackgroundDingtalkAccountConfig {
+    pub client_id: String,
+    pub client_secret: String,
+    pub bot_title: String,
+    pub proxy: DingtalkProxyConfig,
+}
+
 #[derive(Debug, Clone)]
 pub struct BackgroundServiceConfig {
     pub cron_tick_interval: Duration,
@@ -87,8 +99,7 @@ pub struct BackgroundServiceConfig {
     pub cron_batch_limit: i64,
     pub cron_missed_run_policy: MissedRunPolicy,
     channel_availability: ChannelAvailability,
-    pub dingtalk_titles: BTreeMap<String, String>,
-    pub dingtalk_proxies: BTreeMap<String, DingtalkProxyConfig>,
+    pub dingtalk_accounts: BTreeMap<String, BackgroundDingtalkAccountConfig>,
     pub telegram_configs: BTreeMap<String, klaw_config::TelegramConfig>,
 }
 
@@ -104,22 +115,21 @@ impl BackgroundServiceConfig {
                 CronMissedRunPolicy::CatchUp => MissedRunPolicy::CatchUp,
             },
             channel_availability: ChannelAvailability::from_app_config(config),
-            dingtalk_titles: config
-                .channels
-                .dingtalk
-                .iter()
-                .map(|cfg| (cfg.id.clone(), cfg.bot_title.clone()))
-                .collect(),
-            dingtalk_proxies: config
+            dingtalk_accounts: config
                 .channels
                 .dingtalk
                 .iter()
                 .map(|cfg| {
                     (
                         cfg.id.clone(),
-                        DingtalkProxyConfig {
-                            enabled: cfg.proxy.enabled,
-                            url: cfg.proxy.url.clone(),
+                        BackgroundDingtalkAccountConfig {
+                            client_id: cfg.client_id.clone(),
+                            client_secret: cfg.client_secret.clone(),
+                            bot_title: cfg.bot_title.clone(),
+                            proxy: DingtalkProxyConfig {
+                                enabled: cfg.proxy.enabled,
+                                url: cfg.proxy.url.clone(),
+                            },
                         },
                     )
                 })
@@ -143,8 +153,7 @@ impl Default for BackgroundServiceConfig {
             cron_batch_limit: 64,
             cron_missed_run_policy: MissedRunPolicy::Skip,
             channel_availability: ChannelAvailability::default(),
-            dingtalk_titles: BTreeMap::new(),
-            dingtalk_proxies: BTreeMap::new(),
+            dingtalk_accounts: BTreeMap::new(),
             telegram_configs: BTreeMap::new(),
         }
     }
@@ -429,8 +438,23 @@ async fn dispatch_outbound_message(
 async fn dispatch_dingtalk_outbound_message(
     msg: &Envelope<OutboundMessage>,
     config: &BackgroundServiceConfig,
-    session_store: &DefaultSessionStore,
+    _session_store: &DefaultSessionStore,
 ) -> Result<(), String> {
+    let account_id = resolve_outbound_account_id(msg, "dingtalk").map(str::to_string);
+    let account = account_id
+        .as_deref()
+        .and_then(|account_id| config.dingtalk_accounts.get(account_id));
+    let bot_title = msg
+        .payload
+        .metadata
+        .get("channel.dingtalk.bot_title")
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.trim().is_empty())
+        .map(ToString::to_string)
+        .or_else(|| account.map(|account| account.bot_title.clone()))
+        .unwrap_or_else(|| "Klaw".to_string());
+    let body = render_outbound_markdown(&msg.payload);
+
     let Some(session_webhook) = msg
         .payload
         .metadata
@@ -439,74 +463,109 @@ async fn dispatch_dingtalk_outbound_message(
         .map(str::trim)
         .filter(|value| !value.is_empty())
     else {
-        return Ok(());
+        warn!(
+            account_id = account_id.as_deref().unwrap_or("unknown"),
+            chat_id = msg.payload.chat_id.as_str(),
+            "dingtalk outbound missing session webhook, falling back to proactive send"
+        );
+        return send_dingtalk_proactive_fallback(
+            msg,
+            account_id.as_deref(),
+            account,
+            &bot_title,
+            &body,
+        )
+        .await;
     };
 
-    let bot_title = msg
-        .payload
-        .metadata
-        .get("channel.dingtalk.bot_title")
-        .and_then(|value| value.as_str())
-        .filter(|value| !value.trim().is_empty())
-        .map(ToString::to_string)
-        .or_else(|| {
-            resolve_outbound_account_id(msg, "dingtalk")
-                .and_then(|account_id| config.dingtalk_titles.get(account_id).cloned())
-        })
-        .unwrap_or_else(|| "Klaw".to_string());
+    match send_dingtalk_session_markdown(
+        account.map(|account| &account.proxy),
+        session_webhook,
+        &bot_title,
+        &body,
+    )
+    .await
+    {
+        Ok(()) => return Ok(()),
+        Err(err) if !is_session_webhook_session_not_found_error(err.as_ref()) => {
+            return Err(err.to_string());
+        }
+        Err(err) => {
+            warn!(
+                account_id = account_id.as_deref().unwrap_or("unknown"),
+                chat_id = msg.payload.chat_id.as_str(),
+                error = %err,
+                "dingtalk outbound stale session webhook detected, falling back to proactive send"
+            );
+            send_dingtalk_proactive_fallback(msg, account_id.as_deref(), account, &bot_title, &body)
+                .await
+                .map_err(|fallback_err| format!("{err}; proactive_fallback={fallback_err}"))
+        }
+    }
+}
 
-    let proxy = resolve_outbound_account_id(msg, "dingtalk")
-        .and_then(|account_id| config.dingtalk_proxies.get(account_id))
-        .cloned()
-        .unwrap_or_default();
-
-    let body = render_outbound_markdown(&msg.payload);
-    let initial_result = timeout(
+async fn send_dingtalk_session_markdown(
+    proxy: Option<&DingtalkProxyConfig>,
+    session_webhook: &str,
+    bot_title: &str,
+    body: &str,
+) -> ChannelResult<()> {
+    let default_proxy = DingtalkProxyConfig::default();
+    let proxy = proxy.unwrap_or(&default_proxy);
+    timeout(
         OUTBOUND_DISPATCH_TIMEOUT,
-        send_session_webhook_markdown_via_proxy(&proxy, session_webhook, &bot_title, &body),
+        send_session_webhook_markdown_via_proxy(proxy, session_webhook, bot_title, body),
     )
     .await
     .map_err(|_| {
-        format!(
-            "dingtalk outbound delivery timed out after {}s",
-            OUTBOUND_DISPATCH_TIMEOUT.as_secs()
+        io::Error::new(
+            io::ErrorKind::TimedOut,
+            format!(
+                "dingtalk outbound delivery timed out after {}s",
+                OUTBOUND_DISPATCH_TIMEOUT.as_secs()
+            ),
         )
     })?
-    .map_err(|err| err.to_string());
-    let err = match initial_result {
-        Ok(()) => return Ok(()),
-        Err(err) => err,
-    };
-    if !is_dingtalk_session_not_found_error(&err) {
-        return Err(err);
-    }
+}
 
-    let Some(refreshed) =
-        refresh_dingtalk_delivery_target(session_store, &msg.payload.metadata).await
-    else {
-        return Err(err);
+async fn send_dingtalk_proactive_fallback(
+    msg: &Envelope<OutboundMessage>,
+    account_id: Option<&str>,
+    account: Option<&BackgroundDingtalkAccountConfig>,
+    bot_title: &str,
+    body: &str,
+) -> Result<(), String> {
+    let Some(account) = account else {
+        let reason = match account_id {
+            Some(account_id) => format!("missing dingtalk account config for '{account_id}'"),
+            None => "missing dingtalk account config for proactive fallback".to_string(),
+        };
+        return Err(reason);
     };
-    if refreshed.session_webhook == session_webhook {
-        return Err(err);
-    }
-    let retry_title = refreshed.bot_title.unwrap_or(bot_title);
+    warn!(
+        account_id = account_id.unwrap_or("unknown"),
+        chat_id = msg.payload.chat_id.as_str(),
+        "dingtalk outbound using proactive fallback"
+    );
     timeout(
         OUTBOUND_DISPATCH_TIMEOUT,
-        send_session_webhook_markdown_via_proxy(
-            &proxy,
-            &refreshed.session_webhook,
-            &retry_title,
-            &body,
+        send_proactive_markdown_via_proxy(
+            &account.proxy,
+            &account.client_id,
+            &account.client_secret,
+            &msg.payload.chat_id,
+            bot_title,
+            body,
         ),
     )
     .await
     .map_err(|_| {
         format!(
-            "dingtalk outbound delivery timed out after {}s",
+            "dingtalk proactive fallback timed out after {}s",
             OUTBOUND_DISPATCH_TIMEOUT.as_secs()
         )
     })?
-    .map_err(|retry_err| format!("{err}; retry_after_refresh={retry_err}"))
+    .map_err(|err| err.to_string())
 }
 
 struct OutboundDeliveryTarget {
@@ -705,60 +764,6 @@ fn resolve_outbound_channel_session_key<'a>(
         })
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct RefreshedDingtalkDeliveryTarget {
-    session_webhook: String,
-    bot_title: Option<String>,
-}
-
-fn is_dingtalk_session_not_found_error(err: &str) -> bool {
-    err.contains("errcode=300001") && err.contains("session 不存在")
-}
-
-async fn refresh_dingtalk_delivery_target(
-    session_store: &DefaultSessionStore,
-    metadata: &BTreeMap<String, Value>,
-) -> Option<RefreshedDingtalkDeliveryTarget> {
-    let manager = SqliteSessionManager::from_store(session_store.clone());
-    let target_session_key = if let Some(base_session_key) = metadata
-        .get("channel.base_session_key")
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
-        let base = manager.get_session(base_session_key).await.ok()?;
-        base.active_session_key
-            .filter(|value| !value.trim().is_empty())
-            .unwrap_or_else(|| base.session_key.clone())
-    } else {
-        metadata
-            .get("channel.delivery_session_key")
-            .and_then(Value::as_str)
-            .map(str::trim)
-            .filter(|value| !value.is_empty())?
-            .to_string()
-    };
-    let session = manager.get_session(&target_session_key).await.ok()?;
-    let raw = session.delivery_metadata_json.as_deref()?;
-    let persisted = serde_json::from_str::<serde_json::Map<String, Value>>(raw).ok()?;
-    let session_webhook = persisted
-        .get("channel.dingtalk.session_webhook")
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())?
-        .to_string();
-    let bot_title = persisted
-        .get("channel.dingtalk.bot_title")
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(ToString::to_string);
-    Some(RefreshedDingtalkDeliveryTarget {
-        session_webhook,
-        bot_title,
-    })
-}
-
 fn render_outbound_markdown(output: &OutboundMessage) -> String {
     match output
         .metadata
@@ -775,10 +780,10 @@ fn render_outbound_markdown(output: &OutboundMessage) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        BackgroundServiceConfig, ChannelAvailability, FilteringInboundTransport,
-        dispatch_outbound_message, is_dingtalk_session_not_found_error,
-        refresh_dingtalk_delivery_target, resolve_outbound_account_id,
+        BackgroundDingtalkAccountConfig, BackgroundServiceConfig, ChannelAvailability,
+        FilteringInboundTransport, dispatch_outbound_message, resolve_outbound_account_id,
     };
+    use klaw_channel::dingtalk::is_session_webhook_session_not_found_error;
     use klaw_config::{AppConfig, DingtalkConfig};
     use klaw_core::{
         Envelope, EnvelopeHeader, InMemoryTransport, InboundMessage, MessageTopic,
@@ -882,113 +887,57 @@ mod tests {
         assert_eq!(resolve_outbound_account_id(&msg, "telegram"), None);
     }
 
-    #[tokio::test(flavor = "current_thread")]
-    async fn refresh_dingtalk_delivery_target_uses_active_session_metadata() {
-        let store = create_store().await;
-        let manager = SqliteSessionManager::from_store(store.clone());
-        manager
-            .get_or_create_session_state(
-                "dingtalk:acc:chat-1",
-                "chat-1",
-                "dingtalk",
-                "provider",
-                "model",
-            )
-            .await
-            .expect("base session should exist");
-        manager
-            .get_or_create_session_state(
-                "dingtalk:acc:chat-1:child",
-                "chat-1",
-                "dingtalk",
-                "provider",
-                "model",
-            )
-            .await
-            .expect("child session should exist");
-        manager
-            .set_active_session(
-                "dingtalk:acc:chat-1",
-                "chat-1",
-                "dingtalk",
-                "dingtalk:acc:chat-1:child",
-            )
-            .await
-            .expect("active session should update");
-        manager
-            .set_delivery_metadata(
-                "dingtalk:acc:chat-1:child",
-                "chat-1",
-                "dingtalk",
-                Some(
-                    "{\"channel.dingtalk.session_webhook\":\"https://example/new\",\"channel.dingtalk.bot_title\":\"Klaw\"}",
-                ),
-            )
-            .await
-            .expect("delivery metadata should persist");
+    #[test]
+    fn background_service_config_collects_dingtalk_accounts() {
+        let config = BackgroundServiceConfig::from_app_config(&AppConfig {
+            channels: klaw_config::ChannelsConfig {
+                dingtalk: vec![DingtalkConfig {
+                    id: "acc-1".to_string(),
+                    client_id: "client-1".to_string(),
+                    client_secret: "secret-1".to_string(),
+                    bot_title: "Ops Bot".to_string(),
+                    proxy: klaw_config::DingtalkProxyConfig {
+                        enabled: true,
+                        url: "http://127.0.0.1:8080".to_string(),
+                    },
+                    ..DingtalkConfig::default()
+                }],
+                ..klaw_config::ChannelsConfig::default()
+            },
+            ..AppConfig::default()
+        });
 
-        let metadata = BTreeMap::from([
-            (
-                "channel.base_session_key".to_string(),
-                json!("dingtalk:acc:chat-1"),
-            ),
-            (
-                "channel.dingtalk.session_webhook".to_string(),
-                json!("https://example/stale"),
-            ),
-        ]);
-        let refreshed = refresh_dingtalk_delivery_target(&store, &metadata)
-            .await
-            .expect("refresh should succeed");
-
-        assert_eq!(refreshed.session_webhook, "https://example/new");
-        assert_eq!(refreshed.bot_title.as_deref(), Some("Klaw"));
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn refresh_dingtalk_delivery_target_falls_back_to_delivery_session_key() {
-        let store = create_store().await;
-        let manager = SqliteSessionManager::from_store(store.clone());
-        manager
-            .get_or_create_session_state(
-                "dingtalk:acc:chat-2:child",
-                "chat-2",
-                "dingtalk",
-                "provider",
-                "model",
-            )
-            .await
-            .expect("session should exist");
-        manager
-            .set_delivery_metadata(
-                "dingtalk:acc:chat-2:child",
-                "chat-2",
-                "dingtalk",
-                Some("{\"channel.dingtalk.session_webhook\":\"https://example/current\"}"),
-            )
-            .await
-            .expect("delivery metadata should persist");
-        let metadata = BTreeMap::from([(
-            "channel.delivery_session_key".to_string(),
-            json!("dingtalk:acc:chat-2:child"),
-        )]);
-
-        let refreshed = refresh_dingtalk_delivery_target(&store, &metadata)
-            .await
-            .expect("refresh should succeed");
-
-        assert_eq!(refreshed.session_webhook, "https://example/current");
-        assert_eq!(refreshed.bot_title, None);
+        assert_eq!(
+            config.dingtalk_accounts.get("acc-1"),
+            Some(&BackgroundDingtalkAccountConfig {
+                client_id: "client-1".to_string(),
+                client_secret: "secret-1".to_string(),
+                bot_title: "Ops Bot".to_string(),
+                proxy: klaw_channel::dingtalk::DingtalkProxyConfig {
+                    enabled: true,
+                    url: "http://127.0.0.1:8080".to_string(),
+                },
+            })
+        );
     }
 
     #[test]
     fn detects_dingtalk_session_not_found_error() {
-        assert!(is_dingtalk_session_not_found_error(
-            "dingtalk session webhook markdown send failed: errcode=300001 errmsg=session 不存在"
-        ));
-        assert!(!is_dingtalk_session_not_found_error(
-            "dingtalk session webhook markdown send failed: errcode=40035 errmsg=invalid"
-        ));
+        let not_found_err = klaw_channel::dingtalk::DingtalkApiError::SessionWebhookBusiness {
+            context: "markdown send".to_string(),
+            errcode: 300001,
+            errmsg: "session 不存在".to_string(),
+            body: json!({"errcode": 300001, "errmsg": "session 不存在"}),
+        };
+        let other_err = klaw_channel::dingtalk::DingtalkApiError::SessionWebhookBusiness {
+            context: "markdown send".to_string(),
+            errcode: 40035,
+            errmsg: "invalid".to_string(),
+            body: json!({"errcode": 40035, "errmsg": "invalid"}),
+        };
+
+        assert!(is_session_webhook_session_not_found_error(&not_found_err));
+        assert!(!is_session_webhook_session_not_found_error(&other_err));
     }
 
     #[test]

--- a/klaw-tool/src/cron_manager.rs
+++ b/klaw-tool/src/cron_manager.rs
@@ -700,7 +700,10 @@ fn inherited_channel_metadata(
     for (key, value) in metadata {
         if matches!(
             key.as_str(),
-            "channel.dingtalk.session_webhook" | "channel.dingtalk.bot_title"
+            "channel.base_session_key"
+                | "channel.delivery_session_key"
+                | "channel.dingtalk.session_webhook"
+                | "channel.dingtalk.bot_title"
         ) {
             out.insert(key.clone(), value.clone());
         }
@@ -1272,6 +1275,76 @@ mod tests {
         assert_eq!(
             payload.get("session_key").and_then(Value::as_str),
             Some("cron:job-dingtalk-shortcut")
+        );
+    }
+
+    #[tokio::test]
+    async fn create_message_shortcut_inherits_delivery_route_metadata_from_context() {
+        let storage = create_store().await;
+        let tool = CronManagerTool::from_storage(storage.clone());
+
+        storage
+            .touch_session("dingtalk:account-1:chat-99", "chat-99", "dingtalk")
+            .await
+            .expect("base session should exist");
+
+        tool.execute(
+            json!({
+                "action": "create",
+                "id": "job-dingtalk-route-shortcut",
+                "name": "weather route shortcut",
+                "schedule_expr": "24h",
+                "message": "请查询无锡今天的天气情况"
+            }),
+            &ToolContext {
+                session_key: "dingtalk:account-1:chat-99".to_string(),
+                metadata: BTreeMap::from([
+                    (
+                        "channel.base_session_key".to_string(),
+                        json!("dingtalk:account-1:chat-99"),
+                    ),
+                    (
+                        "channel.delivery_session_key".to_string(),
+                        json!("dingtalk:account-1:chat-99:active"),
+                    ),
+                    (
+                        "channel.dingtalk.session_webhook".to_string(),
+                        json!("https://example/session"),
+                    ),
+                    ("channel.dingtalk.bot_title".to_string(), json!("Klaw Bot")),
+                ]),
+            },
+        )
+        .await
+        .expect("create should succeed");
+
+        let job = storage
+            .get_cron("job-dingtalk-route-shortcut")
+            .await
+            .expect("job should exist");
+        let payload: Value = serde_json::from_str(&job.payload_json).expect("payload json");
+        let meta = payload
+            .get("metadata")
+            .and_then(Value::as_object)
+            .expect("metadata object");
+        assert_eq!(
+            meta.get("channel.base_session_key").and_then(Value::as_str),
+            Some("dingtalk:account-1:chat-99")
+        );
+        assert_eq!(
+            meta.get("channel.delivery_session_key")
+                .and_then(Value::as_str),
+            Some("dingtalk:account-1:chat-99:active")
+        );
+        assert_eq!(
+            meta.get("channel.dingtalk.session_webhook")
+                .and_then(Value::as_str),
+            Some("https://example/session")
+        );
+        assert_eq!(
+            meta.get("channel.dingtalk.bot_title")
+                .and_then(Value::as_str),
+            Some("Klaw Bot")
         );
     }
 

--- a/klaw-webui/src/lib.rs
+++ b/klaw-webui/src/lib.rs
@@ -3,9 +3,6 @@
 //! Refresh embedded assets from the workspace root: `make webui-wasm`
 
 #[cfg(any(test, target_arch = "wasm32"))]
-pub(crate) use klaw_ui_kit::ThemeMode;
-
-#[cfg(any(test, target_arch = "wasm32"))]
 use std::collections::BTreeMap;
 #[cfg(test)]
 use std::collections::VecDeque;

--- a/klaw-webui/src/web_chat/session.rs
+++ b/klaw-webui/src/web_chat/session.rs
@@ -5,8 +5,8 @@ use std::{
 };
 
 use crate::{
-    ImCard, MessageRole, ProviderCatalog, ResolvedSessionRoute, WebArchiveAttachment,
-    WorkspaceSessionEntry, resolve_im_card, resolve_session_route_inputs,
+    resolve_im_card, resolve_session_route_inputs, ImCard, MessageRole, ProviderCatalog,
+    ResolvedSessionRoute, WebArchiveAttachment, WorkspaceSessionEntry,
 };
 use eframe::epaint::{Color32, FontFamily, FontId};
 use js_sys::Date;
@@ -262,9 +262,44 @@ pub(super) fn current_timestamp_ms() -> i64 {
     Date::now().round() as i64
 }
 
-pub(super) fn format_message_timestamp(timestamp_ms: i64) -> String {
-    let date = Date::new(&wasm_bindgen::JsValue::from_f64(timestamp_ms as f64));
-    format!("{:02}:{:02}", date.get_hours(), date.get_minutes())
+pub(super) fn format_message_timestamp(timestamp_ms: i64, now_ms: i64) -> String {
+    let elapsed_ms = (now_ms - timestamp_ms).max(0);
+    let elapsed_secs = elapsed_ms / 1000;
+    if elapsed_secs < 60 {
+        let s = elapsed_secs.max(0);
+        format!("{s} sec{suffix(&s)} ago")
+    } else if elapsed_secs < 3600 {
+        let mins = elapsed_secs / 60;
+        format!("{mins} min{suffix(&mins)} ago")
+    } else {
+        let now_date = Date::new(&wasm_bindgen::JsValue::from_f64(now_ms as f64));
+        let msg_date = Date::new(&wasm_bindgen::JsValue::from_f64(timestamp_ms as f64));
+        let same_day = now_date.get_full_year() == msg_date.get_full_year()
+            && now_date.get_month() == msg_date.get_month()
+            && now_date.get_date() == msg_date.get_date();
+        if same_day {
+            let hours = elapsed_secs / 3600;
+            format!("{hours} hr{suffix(&hours)} ago")
+        } else {
+            format!(
+                "{}/{:02}/{:02} {:02}:{:02}:{:02}",
+                msg_date.get_full_year(),
+                msg_date.get_month() + 1,
+                msg_date.get_date(),
+                msg_date.get_hours(),
+                msg_date.get_minutes(),
+                msg_date.get_seconds(),
+            )
+        }
+    }
+}
+
+fn suffix(n: &i64) -> &'static str {
+    if *n == 1 {
+        ""
+    } else {
+        "s"
+    }
 }
 
 pub(super) fn format_datetime(timestamp_ms: i64) -> String {
@@ -284,25 +319,34 @@ pub(super) fn format_relative_time(created_at_ms: i64, now_ms: i64) -> String {
     let elapsed_ms = (now_ms - created_at_ms).max(0);
     let elapsed_secs = elapsed_ms / 1000;
     if elapsed_secs < 60 {
-        "just now".to_string()
+        let s = elapsed_secs.max(0);
+        format!("{s} sec{suffix(&s)} ago")
     } else if elapsed_secs < 3600 {
         let mins = elapsed_secs / 60;
-        format!("{mins}m ago")
+        format!("{mins} min{suffix(&mins)} ago")
     } else if elapsed_secs < 86400 {
         let hours = elapsed_secs / 3600;
-        format!("{hours}h ago")
+        format!("{hours} hr{suffix(&hours)} ago")
     } else if elapsed_secs < 604800 {
         let days = elapsed_secs / 86400;
-        format!("{days}d ago")
+        format!("{days} day{suffix(&days)} ago")
     } else {
-        let weeks = elapsed_secs / 604800;
-        format!("{weeks}w ago")
+        let date = Date::new(&wasm_bindgen::JsValue::from_f64(created_at_ms as f64));
+        format!(
+            "{}/{:02}/{:02} {:02}:{:02}:{:02}",
+            date.get_full_year(),
+            date.get_month() + 1,
+            date.get_date(),
+            date.get_hours(),
+            date.get_minutes(),
+            date.get_seconds(),
+        )
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{ProviderCatalog, ProviderCatalogEntry, resolve_session_route_choice};
+    use super::{resolve_session_route_choice, ProviderCatalog, ProviderCatalogEntry};
 
     #[test]
     fn session_route_prefers_explicit_workspace_route() {

--- a/klaw-webui/src/web_chat/session.rs
+++ b/klaw-webui/src/web_chat/session.rs
@@ -267,10 +267,12 @@ pub(super) fn format_message_timestamp(timestamp_ms: i64, now_ms: i64) -> String
     let elapsed_secs = elapsed_ms / 1000;
     if elapsed_secs < 60 {
         let s = elapsed_secs.max(0);
-        format!("{s} sec{suffix(&s)} ago")
+        let suf = suffix(&s);
+        format!("{s} sec{suf} ago")
     } else if elapsed_secs < 3600 {
         let mins = elapsed_secs / 60;
-        format!("{mins} min{suffix(&mins)} ago")
+        let suf = suffix(&mins);
+        format!("{mins} min{suf} ago")
     } else {
         let now_date = Date::new(&wasm_bindgen::JsValue::from_f64(now_ms as f64));
         let msg_date = Date::new(&wasm_bindgen::JsValue::from_f64(timestamp_ms as f64));
@@ -279,7 +281,8 @@ pub(super) fn format_message_timestamp(timestamp_ms: i64, now_ms: i64) -> String
             && now_date.get_date() == msg_date.get_date();
         if same_day {
             let hours = elapsed_secs / 3600;
-            format!("{hours} hr{suffix(&hours)} ago")
+            let suf = suffix(&hours);
+            format!("{hours} hr{suf} ago")
         } else {
             format!(
                 "{}/{:02}/{:02} {:02}:{:02}:{:02}",
@@ -320,16 +323,20 @@ pub(super) fn format_relative_time(created_at_ms: i64, now_ms: i64) -> String {
     let elapsed_secs = elapsed_ms / 1000;
     if elapsed_secs < 60 {
         let s = elapsed_secs.max(0);
-        format!("{s} sec{suffix(&s)} ago")
+        let suf = suffix(&s);
+        format!("{s} sec{suf} ago")
     } else if elapsed_secs < 3600 {
         let mins = elapsed_secs / 60;
-        format!("{mins} min{suffix(&mins)} ago")
+        let suf = suffix(&mins);
+        format!("{mins} min{suf} ago")
     } else if elapsed_secs < 86400 {
         let hours = elapsed_secs / 3600;
-        format!("{hours} hr{suffix(&hours)} ago")
+        let suf = suffix(&hours);
+        format!("{hours} hr{suf} ago")
     } else if elapsed_secs < 604800 {
         let days = elapsed_secs / 86400;
-        format!("{days} day{suffix(&days)} ago")
+        let suf = suffix(&days);
+        format!("{days} day{suf} ago")
     } else {
         let date = Date::new(&wasm_bindgen::JsValue::from_f64(created_at_ms as f64));
         format!(

--- a/klaw-webui/src/web_chat/session.rs
+++ b/klaw-webui/src/web_chat/session.rs
@@ -5,8 +5,8 @@ use std::{
 };
 
 use crate::{
-    resolve_im_card, resolve_session_route_inputs, ImCard, MessageRole, ProviderCatalog,
-    ResolvedSessionRoute, WebArchiveAttachment, WorkspaceSessionEntry,
+    ImCard, MessageRole, ProviderCatalog, ResolvedSessionRoute, WebArchiveAttachment,
+    WorkspaceSessionEntry, resolve_im_card, resolve_session_route_inputs,
 };
 use eframe::epaint::{Color32, FontFamily, FontId};
 use js_sys::Date;
@@ -298,11 +298,7 @@ pub(super) fn format_message_timestamp(timestamp_ms: i64, now_ms: i64) -> String
 }
 
 fn suffix(n: &i64) -> &'static str {
-    if *n == 1 {
-        ""
-    } else {
-        "s"
-    }
+    if *n == 1 { "" } else { "s" }
 }
 
 pub(super) fn format_datetime(timestamp_ms: i64) -> String {
@@ -353,7 +349,7 @@ pub(super) fn format_relative_time(created_at_ms: i64, now_ms: i64) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{resolve_session_route_choice, ProviderCatalog, ProviderCatalogEntry};
+    use super::{ProviderCatalog, ProviderCatalogEntry, resolve_session_route_choice};
 
     #[test]
     fn session_route_prefers_explicit_workspace_route() {

--- a/klaw-webui/src/web_chat/ui.rs
+++ b/klaw-webui/src/web_chat/ui.rs
@@ -703,6 +703,7 @@ impl ChatApp {
 
                 let messages_height = (ui.available_height() - INPUT_PANEL_HEIGHT).max(140.0);
                 ui.allocate_ui(vec2(ui.available_width(), messages_height), |ui| {
+                    session.prune_finished_animations();
                     let messages = session.buffers.messages.borrow();
                     let scroll_output = ScrollArea::vertical()
                         .auto_shrink([false, false])
@@ -717,8 +718,6 @@ impl ChatApp {
                                 render_empty_state(ui, &self.connection_state.borrow());
                                 return;
                             }
-
-                            session.prune_finished_animations();
                             if *session.buffers.history_loading.borrow() {
                                 render_history_page_loading_state(ui);
                                 ui.add_space(8.0);

--- a/klaw-webui/src/web_chat/ui.rs
+++ b/klaw-webui/src/web_chat/ui.rs
@@ -1325,7 +1325,8 @@ fn render_message(
     message_index: usize,
     card_state_overrides: &HashMap<String, CardInteractionState>,
 ) -> Option<CardActionRequest> {
-    let time_label = format_message_timestamp(message.timestamp_ms);
+    let now_ms = current_timestamp_ms();
+    let time_label = format_message_timestamp(message.timestamp_ms, now_ms);
     match message.role {
         MessageRole::System => {
             ui.vertical_centered(|ui| {


### PR DESCRIPTION
## Summary
Simplify background DingTalk outbound delivery by removing session-webhook refresh and falling back directly to proactive send when the webhook is missing or stale. This also replaces string-based stale-session detection with typed DingTalk API errors.

## Changes
- remove background DingTalk session-webhook refresh and retry logic
- fall back directly to proactive send when sessionWebhook is missing or returns DingTalk business error 300001
- introduce typed DingTalk API errors for session-webhook business failures and use downcast-based detection in runtime
- add tests for typed stale-session detection and proactive fallback helpers
- include the remaining klaw-webui/src/web_chat/session.rs formatting cleanup already present in the branch, per user request

## Validation
- cargo fmt --all
- cargo test -p klaw-channel dingtalk
- cargo test -p klaw-runtime service_loop

Closes #214
