### PR TITLE
feat(memory): add long-term archiving and summary rollups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4196,6 +4196,7 @@ dependencies = [
 name = "klaw-config"
 version = "0.14.1"
 dependencies = [
+ "cron",
  "humantime",
  "klaw-util",
  "serde",

--- a/docs/src/configration/fields.md
+++ b/docs/src/configration/fields.md
@@ -1871,6 +1871,58 @@ provider = "openai"
 model = "text-embedding-3-small"
 ```
 
+### `memory.archive.enabled`
+
+**类型**: `boolean`
+**默认值**: `true`
+**必填**: 否
+
+是否启用长期记忆自动归档与摘要。
+
+```toml
+[memory.archive]
+enabled = true
+```
+
+### `memory.archive.schedule`
+
+**类型**: `string`
+**默认值**: `"0 0 2 * * *"`
+**必填**: 条件必填
+
+自动归档的 cron 表达式，按系统时区解释。默认表示每天凌晨 `2:00`。
+
+```toml
+[memory.archive]
+schedule = "0 0 2 * * *"
+```
+
+### `memory.archive.max_age_days`
+
+**类型**: `integer`
+**默认值**: `30`
+**必填**: 否
+
+超过多少天未更新的低优先级长期记忆会进入归档候选集。
+
+```toml
+[memory.archive]
+max_age_days = 30
+```
+
+### `memory.archive.summary_max_sources`
+
+**类型**: `integer`
+**默认值**: `8`
+**必填**: 否
+
+单条归档摘要最多内联多少条来源内容片段。
+
+```toml
+[memory.archive]
+summary_max_sources = 8
+```
+
 ---
 
 ## 语音配置

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -148,8 +148,14 @@ search_limit = 8
 use_vector = true
 
 [memory.embedding]
+enabled = true
 provider = "openai"
 model = "text-embedding-3-small"
+
+[memory.archive]
+schedule = "0 0 2 * * *"
+max_age_days = 30
+summary_max_sources = 8
 ```
 
 ### 配置 Skills

--- a/docs/src/storage/cron.md
+++ b/docs/src/storage/cron.md
@@ -98,6 +98,17 @@ worker 处理到期任务时不会直接执行，而是先调用：
 
 该操作在数据库侧执行条件更新（`WHERE next_run_at_ms = expected...`），只有一个 worker 能成功 claim，避免同一触发时刻重复执行。
 
+## Memory 后台维护
+
+除持久化 `cron` 任务外，runtime 还挂载了一个内建的 memory 维护 worker：
+
+- 使用固定计划：系统时区每天凌晨 `2:00`
+- 不写入 `cron` / `cron_task` 表
+- 在后台 `on_cron_tick()` 中顺带执行
+- 负责长期记忆的低优先级归档与摘要索引生成
+
+这条路径适合纯内存维护类任务，因为它不需要构造 `InboundMessage` 进入完整 agent 回路；执行完成后 runtime 会刷新长期记忆 prompt 片段。
+
 ## 状态流转
 
 单次运行典型过程：

--- a/docs/src/storage/memory.md
+++ b/docs/src/storage/memory.md
@@ -1,12 +1,13 @@
 # Memory 存储
 
-`klaw-memory` 提供长期记忆的 CRUD、混合检索（FTS + vector）、写入治理、prompt 渲染和统计聚合，是 Klaw 记忆系统的核心模块。
+`klaw-memory` 提供长期记忆的 CRUD、混合检索（FTS + vector）、写入治理、自动归档、prompt 渲染和统计聚合，是 Klaw 记忆系统的核心模块。
 
 ## 设计目标
 
 - **事实替换而非日志累积**：长期记忆的写入目标是维护一组稳定、可追溯的事实，而不是简单堆叠每轮对话日志
 - **混合检索最优排序**：同时利用 BM25 全文检索和向量语义检索，通过 RRF 融合取得稳定排名
 - **治理驱动的写入**：长期记忆的 add 操作经过规范化、重复检测和冲突替换后才入库
+- **生命周期归档**：低优先级长期记忆在后台按主题归档，并生成摘要索引保持可追溯性
 - **受控的 prompt 注入**：长期记忆以受预算控制的章节形式注入 system prompt，避免 prompt 膨胀
 - **后端可替换**：同一套 `MemoryService` trait 支持 turso（libSQL）和 sqlx 后端
 
@@ -19,6 +20,7 @@ klaw-memory/src/
 ├── service.rs      # SqliteMemoryService 实现
 ├── provider.rs     # OpenAiEmbeddingProvider、配置工厂
 ├── governance.rs   # 长期记忆写入治理规则
+├── maintenance.rs  # 长期记忆归档与摘要索引
 ├── prompt.rs       # 长期记忆 prompt 渲染
 ├── stats.rs        # SqliteMemoryStatsService、统计聚合
 ├── error.rs        # MemoryError 错误枚举
@@ -39,7 +41,7 @@ klaw-memory/src/
 | `id` | TEXT PK | 记录 ID（UUID v4 或用户指定） |
 | `scope` | TEXT NOT NULL | 作用域（`long_term`、`session:xxx` 等） |
 | `content` | TEXT NOT NULL | 记忆内容 |
-| `metadata_json` | TEXT NOT NULL | 结构化元数据 JSON（`kind`、`status`、`topic`、`supersedes` 等） |
+| `metadata_json` | TEXT NOT NULL | 结构化元数据 JSON（`kind`、`priority`、`status`、`topic`、`supersedes`、`summary`、`source_ids`、`archived_at` 等） |
 | `pinned` | INTEGER NOT NULL DEFAULT 0 | 是否置顶 |
 | `embedding` | BLOB | 向量嵌入（`f32` 数组的小端字节序 blob） |
 | `created_at_ms` | INTEGER NOT NULL | 创建时间（毫秒 epoch） |
@@ -131,7 +133,7 @@ pub trait MemoryService: Send + Sync {
 设计考量：
 
 - `upsert` 使用 `INSERT ... ON CONFLICT DO UPDATE` 实现，新记录自动生成 ID，已有记录按 ID 更新
-- `search` 内部执行 FTS + vector 双通道检索，RRF 融合后再按 `pinned > fused_score > updated_at_ms` 排序
+- `search` 内部执行 FTS + vector 双通道检索，RRF 融合后再按 `pinned > fused_score > updated_at_ms` 排序；`long_term` scope 下会跳过 `archived/rejected/superseded`
 - `delete` 同步清理主表和 FTS 表中的记录
 - `pin` 更新 `pinned` 标记并刷新 `updated_at_ms`
 
@@ -189,6 +191,8 @@ pub async fn new(
 - FTS 行采用"删除旧 + 插入新"策略而非 `INSERT OR REPLACE`，避免 FTS5 内部状态残留
 - embedding 在写入时即时计算，后续检索无需重复调用 API
 - `ON CONFLICT DO UPDATE` 确保同一 ID 的记录只保留一份，metadata 和 embedding 均随内容更新
+- `long_term` 写入治理会规范化 `priority`；若未显式提供，则根据 `kind` 生成默认优先级
+- 自动归档会把低优先级旧记录转为 `archived`，并把 `source_ids` 汇总进 `summary=true` 的摘要记录
 
 ### Search 流程
 
@@ -217,7 +221,20 @@ pub async fn new(
   其中 `RRF_K = 60.0`（经验常数）
 - 双通道命中的记录获得更高分数，单通道命中的记录分数较低
 - 排序优先级：`pinned DESC > fused_score DESC > updated_at_ms DESC`
+- 对 `long_term` scope，`archived/rejected/superseded` 记录会在融合后统一过滤，避免旧事实继续参与候选
 - 最终裁剪到 `limit` 条记录返回
+
+### 自动归档与摘要
+
+`archive_stale_long_term_memories` 负责长期记忆的生命周期整理：
+
+1. 读取 `long_term` 全量记录
+2. 挑出 `priority=low`、active、未 pinned、超过 30 天未更新的旧记录
+3. 按 `kind + topic` 分组
+4. 将原记录更新为 `status=archived`，写入 `archived_at` 与 `archived_by_summary`
+5. 生成或更新 `summary=true` 的摘要索引记录，并维护 `source_ids`
+
+摘要记录保持 `status=active` 以便检索与展示，但 `render_long_term_memory_section` 会主动跳过它们，因此不会污染 runtime 的 `## Memory` 段。
 
 设计考量：
 
@@ -491,6 +508,8 @@ runtime（`klaw-cli/src/runtime/mod.rs`）在每轮构建上下文时：
 3. 拼入 system prompt 的 `Memory` 章节
 
 长期记忆不通过工具检索给模型，而是由 runtime 在每轮开始前自动注入。这避免了模型需要主动搜索长期记忆的不确定性，也确保所有长期记忆在 prompt 中受预算控制。
+
+另外，runtime 背景服务会在 cron tick 期间按系统时区每天凌晨 `2:00` 运行一次长期记忆归档；当归档结果有变更时，会刷新 runtime system prompt，确保后续轮次使用最新的长期记忆视图。
 
 ### 统计面板
 

--- a/docs/src/tools/built-in/memory.md
+++ b/docs/src/tools/built-in/memory.md
@@ -37,6 +37,7 @@
 其中 `metadata` 支持的治理字段：
 
 - `kind`：`identity | preference | project_rule | workflow | fact | constraint`
+- `priority`：可选，`high | medium | low`，用于覆盖默认的 prompt 注入优先级
 - `topic`：可选，用于冲突替换
 - `supersedes`：可选，字符串或字符串数组
 
@@ -77,7 +78,9 @@
 
 - 仅渲染 `status=active` 的长期记忆
 - 跳过 `superseded`、`archived`、`rejected`
+- 跳过 `summary=true` 的归档摘要记录
 - 先按 `pinned` 排序
+- 再按显式 `priority` 排序（若未提供则根据 `kind` 推导默认值）
 - 再按 `kind` 优先级排序
 - 最后按更新时间排序
 - 做去重、单条裁剪和整体字符预算控制
@@ -101,6 +104,23 @@
 - 新：`kind=preference`，`topic=reply_language`，内容为“默认使用中文回复”
 
 则新记录会生效，旧记录会被标记为 `superseded`，不再进入 prompt。
+
+### 自动归档
+
+runtime 在后台 tick 期间会执行一个内建的长期记忆维护任务：
+
+- 以系统时区每天凌晨 `2:00` 为目标窗口
+- 扫描 `long_term` 中 `priority=low`、未 pinned、超过 `30` 天未更新的 active 记录
+- 将原记录标记为 `archived`
+- 为同一 `kind + topic` 分组生成或更新一条 `summary=true` 的摘要索引记录
+
+摘要记录写回同一个 `long_term` scope，并带有：
+
+- `source_ids`
+- `archived_at`
+- `summary_type = "archive_rollup"`
+
+它们默认不会进入 prompt，但会保留为可追溯的检索索引和 GUI 明细。
 
 ## Session 记忆方案
 

--- a/klaw-config/Cargo.toml
+++ b/klaw-config/Cargo.toml
@@ -9,5 +9,6 @@ serde = { workspace = true }
 thiserror = { workspace = true }
 toml = { workspace = true }
 humantime = { workspace = true }
+cron = { workspace = true }
 url = { workspace = true }
 klaw-util = { workspace = true }

--- a/klaw-config/src/lib.rs
+++ b/klaw-config/src/lib.rs
@@ -899,6 +899,31 @@ fn default_codex_acp_agent() -> AcpAgentConfig {
 pub struct MemoryConfig {
     #[serde(default)]
     pub embedding: EmbeddingConfig,
+    #[serde(default)]
+    pub archive: MemoryArchiveConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MemoryArchiveConfig {
+    #[serde(default = "default_memory_archive_enabled")]
+    pub enabled: bool,
+    #[serde(default = "default_memory_archive_schedule")]
+    pub schedule: String,
+    #[serde(default = "default_memory_archive_max_age_days")]
+    pub max_age_days: i64,
+    #[serde(default = "default_memory_archive_summary_max_sources")]
+    pub summary_max_sources: usize,
+}
+
+impl Default for MemoryArchiveConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_memory_archive_enabled(),
+            schedule: default_memory_archive_schedule(),
+            max_age_days: default_memory_archive_max_age_days(),
+            summary_max_sources: default_memory_archive_summary_max_sources(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -927,6 +952,22 @@ fn default_memory_embedding_provider() -> String {
 
 fn default_memory_embedding_model() -> String {
     "text-embedding-3-small".to_string()
+}
+
+fn default_memory_archive_enabled() -> bool {
+    true
+}
+
+fn default_memory_archive_schedule() -> String {
+    "0 0 2 * * *".to_string()
+}
+
+fn default_memory_archive_max_age_days() -> i64 {
+    30
+}
+
+fn default_memory_archive_summary_max_sources() -> usize {
+    8
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/klaw-config/src/tests.rs
+++ b/klaw-config/src/tests.rs
@@ -33,6 +33,10 @@ fn parse_default_template_succeeds() {
     assert!(!parsed.memory.embedding.enabled);
     assert_eq!(parsed.memory.embedding.provider, "openai");
     assert_eq!(parsed.memory.embedding.model, "text-embedding-3-small");
+    assert!(parsed.memory.archive.enabled);
+    assert_eq!(parsed.memory.archive.schedule, "0 0 2 * * *");
+    assert_eq!(parsed.memory.archive.max_age_days, 30);
+    assert_eq!(parsed.memory.archive.summary_max_sources, 8);
     assert_eq!(
         parsed.tools.shell.blocked_patterns,
         default_shell_blocked_patterns()
@@ -1488,6 +1492,38 @@ fn validate_allows_missing_embedding_provider_when_disabled() {
     cfg.memory.embedding.provider = String::new();
     cfg.memory.embedding.model = String::new();
     validate(&cfg).expect("should be valid when embedding disabled");
+}
+
+#[test]
+fn validate_fails_when_memory_archive_schedule_missing() {
+    let mut cfg = AppConfig::default();
+    cfg.memory.archive.schedule = String::new();
+    let err = validate(&cfg).expect_err("should fail");
+    assert!(format!("{err}").contains("memory.archive.schedule"));
+}
+
+#[test]
+fn validate_fails_when_memory_archive_schedule_invalid() {
+    let mut cfg = AppConfig::default();
+    cfg.memory.archive.schedule = "not-a-cron".to_string();
+    let err = validate(&cfg).expect_err("should fail");
+    assert!(format!("{err}").contains("memory.archive.schedule"));
+}
+
+#[test]
+fn validate_fails_when_memory_archive_max_age_days_is_zero() {
+    let mut cfg = AppConfig::default();
+    cfg.memory.archive.max_age_days = 0;
+    let err = validate(&cfg).expect_err("should fail");
+    assert!(format!("{err}").contains("memory.archive.max_age_days"));
+}
+
+#[test]
+fn validate_fails_when_memory_archive_summary_max_sources_is_zero() {
+    let mut cfg = AppConfig::default();
+    cfg.memory.archive.summary_max_sources = 0;
+    let err = validate(&cfg).expect_err("should fail");
+    assert!(format!("{err}").contains("memory.archive.summary_max_sources"));
 }
 
 #[test]

--- a/klaw-config/src/validate.rs
+++ b/klaw-config/src/validate.rs
@@ -4,6 +4,8 @@ use crate::{
 };
 use std::net::IpAddr;
 
+use std::str::FromStr;
+
 pub(crate) fn validate(config: &AppConfig) -> Result<(), ConfigError> {
     if config.model_provider.trim().is_empty() {
         return Err(ConfigError::InvalidConfig(
@@ -118,6 +120,31 @@ pub(crate) fn validate(config: &AppConfig) -> Result<(), ConfigError> {
                 "memory.embedding.provider '{}' not found in model_providers",
                 config.memory.embedding.provider
             )));
+        }
+    }
+    if config.memory.archive.enabled {
+        let schedule = config.memory.archive.schedule.trim();
+        if schedule.is_empty() {
+            return Err(ConfigError::InvalidConfig(
+                "memory.archive.schedule cannot be empty when memory.archive.enabled=true"
+                    .to_string(),
+            ));
+        }
+        cron::Schedule::from_str(schedule).map_err(|err| {
+            ConfigError::InvalidConfig(format!(
+                "memory.archive.schedule '{}' is invalid: {}",
+                config.memory.archive.schedule, err
+            ))
+        })?;
+        if config.memory.archive.max_age_days <= 0 {
+            return Err(ConfigError::InvalidConfig(
+                "memory.archive.max_age_days must be greater than 0".to_string(),
+            ));
+        }
+        if config.memory.archive.summary_max_sources == 0 {
+            return Err(ConfigError::InvalidConfig(
+                "memory.archive.summary_max_sources must be greater than 0".to_string(),
+            ));
         }
     }
 

--- a/klaw-gui/src/panels/memory.rs
+++ b/klaw-gui/src/panels/memory.rs
@@ -5,12 +5,13 @@ use egui_extras::{Column, TableBuilder};
 use egui_phosphor::regular;
 use klaw_config::{AppConfig, ConfigError, ConfigSnapshot, ConfigStore, EmbeddingConfig};
 use klaw_memory::{
-    LongTermMemoryKind, LongTermMemoryPromptOptions, LongTermMemoryStatus, MemoryError,
-    MemoryRecord, MemoryStats, SqliteMemoryStatsService, is_summary_record,
+    LongTermArchiveConfig, LongTermMemoryKind, LongTermMemoryPromptOptions, LongTermMemoryStatus,
+    MemoryError, MemoryRecord, MemoryStats, SqliteMemoryStatsService,
+    archive_stale_long_term_memories, is_summary_record,
     read_long_term_archived_at, read_long_term_kind, read_long_term_priority,
     read_long_term_status, read_long_term_topic, render_long_term_memory_section,
 };
-use klaw_storage::{ChatRecord, SessionStorage, open_default_store};
+use klaw_storage::{ChatRecord, SessionStorage, open_default_memory_db, open_default_store};
 use serde_json::Value;
 use std::collections::HashSet;
 use std::future::Future;
@@ -199,6 +200,11 @@ struct PendingSessionSearch {
     receiver: Receiver<Result<SessionSearchOutput, String>>,
 }
 
+#[derive(Debug)]
+struct PendingArchiveRun {
+    receiver: Receiver<Result<String, String>>,
+}
+
 #[derive(Debug, Clone)]
 struct SessionSearchHit {
     session_key: String,
@@ -238,6 +244,8 @@ pub struct MemoryPanel {
     session_search_request: Option<PendingSessionSearch>,
     session_search_loading: bool,
     session_search_result: Option<SessionSearchOutput>,
+    archive_run_request: Option<PendingArchiveRun>,
+    archive_run_loading: bool,
 }
 
 impl Default for MemoryPanel {
@@ -262,6 +270,8 @@ impl Default for MemoryPanel {
             session_search_request: None,
             session_search_loading: false,
             session_search_result: None,
+            archive_run_request: None,
+            archive_run_loading: false,
         }
     }
 }
@@ -588,6 +598,48 @@ impl MemoryPanel {
             Err(TryRecvError::Disconnected) => {
                 self.session_search_loading = false;
                 notifications.error("Session search task disconnected unexpectedly");
+            }
+        }
+    }
+
+    fn begin_archive_run(&mut self, notifications: &mut NotificationCenter) {
+        if self.archive_run_request.is_some() {
+            return;
+        }
+        self.archive_run_loading = true;
+        let archive_config = LongTermArchiveConfig {
+            max_age_days: self.config.memory.archive.max_age_days,
+            summary_max_sources: self.config.memory.archive.summary_max_sources,
+        };
+        self.archive_run_request = Some(PendingArchiveRun {
+            receiver: spawn_archive_run_task(archive_config),
+        });
+        notifications.info("Running long-term memory archive...");
+    }
+
+    fn poll_archive_run_request(&mut self, notifications: &mut NotificationCenter) {
+        let Some(request) = self.archive_run_request.take() else {
+            return;
+        };
+
+        match request.receiver.try_recv() {
+            Ok(result) => match result {
+                Ok(message) => {
+                    self.archive_run_loading = false;
+                    notifications.success(message);
+                    self.refresh(notifications);
+                }
+                Err(err) => {
+                    self.archive_run_loading = false;
+                    notifications.error(format!("Archive run failed: {err}"));
+                }
+            },
+            Err(TryRecvError::Empty) => {
+                self.archive_run_request = Some(request);
+            }
+            Err(TryRecvError::Disconnected) => {
+                self.archive_run_loading = false;
+                notifications.error("Archive task disconnected unexpectedly");
             }
         }
     }
@@ -1012,7 +1064,11 @@ impl PanelRenderer for MemoryPanel {
         self.ensure_loaded(notifications);
         self.poll_load_request(notifications);
         self.poll_session_search_request(notifications);
-        if self.load_request.is_some() || self.session_search_request.is_some() {
+        self.poll_archive_run_request(notifications);
+        if self.load_request.is_some()
+            || self.session_search_request.is_some()
+            || self.archive_run_request.is_some()
+        {
             ui.ctx().request_repaint_after(POLL_INTERVAL);
         }
 
@@ -1024,12 +1080,22 @@ impl PanelRenderer for MemoryPanel {
             if ui.button("Config").clicked() {
                 self.open_config_form();
             }
+            if ui
+                .add_enabled(!self.archive_run_loading, egui::Button::new("Archive Now"))
+                .clicked()
+            {
+                self.begin_archive_run(notifications);
+            }
             if ui.button(format!("{} Info", regular::INFO)).clicked() {
                 self.stats_window_open = true;
             }
-            if self.loading {
+            if self.loading || self.archive_run_loading {
                 ui.add(egui::Spinner::new());
-                ui.small("Loading...");
+                ui.small(if self.archive_run_loading {
+                    "Archiving..."
+                } else {
+                    "Loading..."
+                });
             }
         });
         ui.separator();
@@ -1301,6 +1367,34 @@ where
                     op(service)
                         .await
                         .map_err(|err| format!("memory stats operation failed: {err}"))
+                })
+            });
+        let _ = tx.send(result);
+    });
+    rx
+}
+
+fn spawn_archive_run_task(config: LongTermArchiveConfig) -> Receiver<Result<String, String>> {
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let result = Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|err| format!("failed to build runtime: {err}"))
+            .and_then(|runtime| {
+                runtime.block_on(async move {
+                    let memory_db = open_default_memory_db()
+                        .await
+                        .map_err(|err| format!("failed to open memory db: {err}"))?;
+                    let outcome = archive_stale_long_term_memories(std::sync::Arc::new(memory_db), config)
+                        .await
+                        .map_err(|err| format!("archive operation failed: {err}"))?;
+                    Ok(format!(
+                        "Archive complete: {} archived, {} summaries updated, {} skipped",
+                        outcome.archived_records,
+                        outcome.summary_records_upserted,
+                        outcome.skipped_records
+                    ))
                 })
             });
         let _ = tx.send(result);

--- a/klaw-gui/src/panels/memory.rs
+++ b/klaw-gui/src/panels/memory.rs
@@ -1,13 +1,14 @@
 use crate::notifications::NotificationCenter;
 use crate::panels::{PanelRenderer, RenderCtx};
 use crate::time_format::format_timestamp_millis;
+use egui::{Color32, RichText};
 use egui_extras::{Column, TableBuilder};
 use egui_phosphor::regular;
 use klaw_config::{AppConfig, ConfigError, ConfigSnapshot, ConfigStore, EmbeddingConfig};
 use klaw_memory::{
     LongTermArchiveConfig, LongTermMemoryKind, LongTermMemoryPromptOptions, LongTermMemoryStatus,
-    MemoryError, MemoryRecord, MemoryStats, SqliteMemoryStatsService,
-    archive_stale_long_term_memories, is_summary_record,
+    MemoryError, MemoryRecord, MemoryService, MemoryStats, SqliteMemoryService,
+    SqliteMemoryStatsService, archive_stale_long_term_memories, is_summary_record,
     read_long_term_archived_at, read_long_term_kind, read_long_term_priority,
     read_long_term_status, read_long_term_topic, render_long_term_memory_section,
 };
@@ -23,7 +24,7 @@ use time::{Duration, OffsetDateTime};
 use tokio::runtime::Builder;
 
 const POLL_INTERVAL: StdDuration = StdDuration::from_millis(150);
-const LONG_TERM_TABLE_HEIGHT: f32 = 320.0;
+
 const SESSION_RESULTS_HEIGHT: f32 = 280.0;
 const DIAGNOSTICS_SCOPES_HEIGHT: f32 = 220.0;
 
@@ -205,6 +206,10 @@ struct PendingArchiveRun {
     receiver: Receiver<Result<String, String>>,
 }
 
+struct PendingDelete {
+    receiver: Receiver<Result<bool, String>>,
+}
+
 #[derive(Debug, Clone)]
 struct SessionSearchHit {
     session_key: String,
@@ -240,6 +245,10 @@ pub struct MemoryPanel {
     kind_filter: KindFilter,
     topic_filter: String,
     selected_long_term_id: Option<String>,
+    detail_record_id: Option<String>,
+    delete_confirm_id: Option<String>,
+    delete_request: Option<PendingDelete>,
+    delete_loading: bool,
     session_form: SessionSearchForm,
     session_search_request: Option<PendingSessionSearch>,
     session_search_loading: bool,
@@ -266,6 +275,10 @@ impl Default for MemoryPanel {
             kind_filter: KindFilter::All,
             topic_filter: String::new(),
             selected_long_term_id: None,
+            detail_record_id: None,
+            delete_confirm_id: None,
+            delete_request: None,
+            delete_loading: false,
             session_form: SessionSearchForm::default(),
             session_search_request: None,
             session_search_loading: false,
@@ -617,6 +630,208 @@ impl MemoryPanel {
         notifications.info("Running long-term memory archive...");
     }
 
+    fn begin_delete(&mut self, id: &str, notifications: &mut NotificationCenter) {
+        if self.delete_request.is_some() {
+            notifications.warning("A delete operation is already in progress");
+            return;
+        }
+        self.delete_loading = true;
+        let id = id.to_string();
+        self.delete_request = Some(PendingDelete {
+            receiver: spawn_delete_task(id, self.config.clone()),
+        });
+    }
+
+    fn poll_delete_request(&mut self, notifications: &mut NotificationCenter) {
+        let Some(request) = self.delete_request.take() else {
+            return;
+        };
+        match request.receiver.try_recv() {
+            Ok(result) => {
+                self.delete_loading = false;
+                self.delete_confirm_id = None;
+                match result {
+                    Ok(deleted) => {
+                        if deleted {
+                            notifications.success("Memory record deleted");
+                        } else {
+                            notifications.warning("Record not found or already deleted");
+                        }
+                        self.refresh(notifications);
+                    }
+                    Err(err) => notifications.error(format!("Failed to delete record: {err}")),
+                }
+            }
+            Err(TryRecvError::Empty) => {
+                self.delete_request = Some(request);
+            }
+            Err(TryRecvError::Disconnected) => {
+                self.delete_loading = false;
+                notifications.error("Delete operation closed unexpectedly");
+            }
+        }
+    }
+
+    fn render_detail_window(&mut self, ctx: &egui::Context, overview: &MemoryOverview) {
+        let Some(record_id) = self.detail_record_id.clone() else {
+            return;
+        };
+        let mut close = false;
+
+        let filtered = filter_long_term_records(
+            &overview.long_term_records,
+            self.status_filter,
+            self.kind_filter,
+            &self.topic_filter,
+        );
+        let record = selected_long_term_record(&filtered, Some(record_id.as_str()));
+
+        egui::Window::new(format!(
+            "Memory Detail — {}",
+            &record_id[..8.min(record_id.len())]
+        ))
+        .anchor(egui::Align2::CENTER_CENTER, egui::Vec2::ZERO)
+        .collapsible(false)
+        .resizable(false)
+        .fixed_size([560.0, 480.0])
+        .show(ctx, |ui| {
+            egui::ScrollArea::vertical()
+                .auto_shrink([false, false])
+                .show(ui, |ui| {
+                    match record {
+                        Some(rec) => {
+                            egui::Grid::new("memory-detail-grid")
+                                .num_columns(2)
+                                .spacing([12.0, 6.0])
+                                .show(ui, |ui| {
+                                    ui.strong("ID");
+                                    ui.monospace(&rec.id);
+                                    ui.end_row();
+
+                                    ui.strong("Kind");
+                                    ui.monospace(kind_label(rec));
+                                    ui.end_row();
+
+                                    ui.strong("Status");
+                                    ui.monospace(status_label(rec));
+                                    ui.end_row();
+
+                                    ui.strong("Priority");
+                                    ui.monospace(priority_label(rec));
+                                    ui.end_row();
+
+                                    ui.strong("Topic");
+                                    ui.label(
+                                        read_long_term_topic(rec)
+                                            .unwrap_or_else(|| "-".to_string()),
+                                    );
+                                    ui.end_row();
+
+                                    ui.strong("Pinned");
+                                    ui.monospace(if rec.pinned { "yes" } else { "no" });
+                                    ui.end_row();
+
+                                    ui.strong("Created");
+                                    ui.monospace(format_timestamp_millis(rec.created_at_ms));
+                                    ui.end_row();
+
+                                    ui.strong("Updated");
+                                    ui.monospace(format_timestamp_millis(rec.updated_at_ms));
+                                    ui.end_row();
+
+                                    ui.strong("Archived at");
+                                    ui.monospace(
+                                        read_long_term_archived_at(rec)
+                                            .map(format_timestamp_millis)
+                                            .unwrap_or_else(|| "-".to_string()),
+                                    );
+                                    ui.end_row();
+                                });
+
+                            let governance = governance_summary(rec);
+                            if governance != "-" {
+                                ui.add_space(4.0);
+                                ui.small(
+                                    RichText::new(format!("Governance: {governance}")).strong(),
+                                );
+                            }
+
+                            ui.add_space(8.0);
+                            ui.strong("Content");
+                            ui.add_space(4.0);
+                            let mut content = rec.content.clone();
+                            ui.add(
+                                egui::TextEdit::multiline(&mut content)
+                                    .desired_width(f32::INFINITY)
+                                    .desired_rows(12)
+                                    .interactive(false),
+                            );
+                        }
+                        None => {
+                            ui.label("Record not found or does not match the current filters.");
+                        }
+                    }
+
+                    ui.add_space(8.0);
+                    ui.horizontal(|ui| {
+                        if ui.button("Close").clicked() {
+                            close = true;
+                        }
+                    });
+                });
+        });
+
+        if close {
+            self.detail_record_id = None;
+        }
+    }
+
+    fn render_delete_confirm_window(&mut self, ctx: &egui::Context) {
+        let Some(record_id) = self.delete_confirm_id.clone() else {
+            return;
+        };
+        let mut confirmed = false;
+        let mut cancelled = false;
+
+        egui::Window::new("Delete Memory Record")
+            .anchor(egui::Align2::CENTER_CENTER, egui::Vec2::ZERO)
+            .collapsible(false)
+            .resizable(false)
+            .show(ctx, |ui| {
+                ui.set_min_width(320.0);
+                ui.label(
+                    RichText::new(format!(
+                        "Are you sure you want to delete memory record '{}'?",
+                        &record_id[..8.min(record_id.len())]
+                    ))
+                    .strong(),
+                );
+                ui.add_space(4.0);
+                ui.small("This permanently removes the record from the memory database.");
+                ui.add_space(12.0);
+                ui.horizontal(|ui| {
+                    if ui
+                        .add(egui::Button::new(
+                            RichText::new(format!("{} Delete", regular::TRASH)).color(Color32::RED),
+                        ))
+                        .clicked()
+                    {
+                        confirmed = true;
+                    }
+                    if ui.button("Cancel").clicked() {
+                        cancelled = true;
+                    }
+                });
+            });
+
+        if confirmed {
+            self.delete_confirm_id = Some(record_id);
+            // begin_delete will be called from render after we have notifications
+        } else if cancelled {
+            self.delete_confirm_id = None;
+        }
+    }
+
     fn poll_archive_run_request(&mut self, notifications: &mut NotificationCenter) {
         let Some(request) = self.archive_run_request.take() else {
             return;
@@ -688,7 +903,12 @@ impl MemoryPanel {
         });
     }
 
-    fn render_long_term_tab(&mut self, ui: &mut egui::Ui, overview: &MemoryOverview) {
+    fn render_long_term_tab(
+        &mut self,
+        ui: &mut egui::Ui,
+        notifications: &mut NotificationCenter,
+        overview: &MemoryOverview,
+    ) {
         ui.horizontal_wrapped(|ui| {
             egui::ComboBox::from_id_salt("memory-status-filter")
                 .selected_text(self.status_filter.label())
@@ -744,26 +964,39 @@ impl MemoryPanel {
         }
         ui.label(format!("Records: {}", filtered.len()));
 
+        // Collect context menu / double-click actions to apply after the table closure.
+        let mut detail_id = None;
+        let mut delete_id = None;
+
         egui::ScrollArea::vertical()
-            .max_height(LONG_TERM_TABLE_HEIGHT)
+            .max_height(ui.available_height() - 4.0)
             .show(ui, |ui| {
                 let row_height = ui.spacing().interact_size.y;
                 TableBuilder::new(ui)
                     .striped(true)
                     .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
                     .sense(egui::Sense::click())
-                    .column(Column::auto().at_least(90.0))
-                    .column(Column::auto().at_least(110.0))
-                    .column(Column::auto().at_least(120.0))
-                    .column(Column::auto().at_least(60.0))
-                    .column(Column::remainder().at_least(180.0))
-                    .column(Column::auto().at_least(170.0))
+                    .column(Column::auto().at_least(70.0))
+                    .column(Column::auto().at_least(80.0))
+                    .column(Column::auto().at_least(70.0))
+                    .column(Column::auto().at_least(70.0))
+                    .column(Column::auto().at_least(100.0))
+                    .column(Column::auto().at_least(50.0))
+                    .column(Column::auto().at_least(80.0))
+                    .column(Column::remainder().at_least(200.0))
+                    .column(Column::auto().at_least(130.0))
                     .header(row_height, |mut header| {
+                        header.col(|ui| {
+                            ui.strong("ID");
+                        });
+                        header.col(|ui| {
+                            ui.strong("Kind");
+                        });
                         header.col(|ui| {
                             ui.strong("Status");
                         });
                         header.col(|ui| {
-                            ui.strong("Kind");
+                            ui.strong("Priority");
                         });
                         header.col(|ui| {
                             ui.strong("Topic");
@@ -772,7 +1005,10 @@ impl MemoryPanel {
                             ui.strong("Pin");
                         });
                         header.col(|ui| {
-                            ui.strong("Governance");
+                            ui.strong("Summary");
+                        });
+                        header.col(|ui| {
+                            ui.strong("Content");
                         });
                         header.col(|ui| {
                             ui.strong("Updated");
@@ -784,11 +1020,19 @@ impl MemoryPanel {
                             let is_selected =
                                 self.selected_long_term_id.as_deref() == Some(record.id.as_str());
                             row.set_selected(is_selected);
+
+                            let record_id_short = &record.id[..8.min(record.id.len())];
+                            row.col(|ui| {
+                                ui.monospace(record_id_short);
+                            });
+                            row.col(|ui| {
+                                ui.monospace(kind_label(record));
+                            });
                             row.col(|ui| {
                                 ui.monospace(status_label(record));
                             });
                             row.col(|ui| {
-                                ui.monospace(kind_label(record));
+                                ui.monospace(priority_label(record));
                             });
                             row.col(|ui| {
                                 ui.label(
@@ -799,7 +1043,18 @@ impl MemoryPanel {
                                 ui.monospace(if record.pinned { "yes" } else { "no" });
                             });
                             row.col(|ui| {
-                                ui.small(governance_summary(record));
+                                let label = summary_label(record);
+                                if label == "summary" {
+                                    ui.colored_label(Color32::from_rgb(0x22, 0xC5, 0x5E), label);
+                                } else if label == "source" {
+                                    ui.colored_label(Color32::from_rgb(0xF5, 0x9E, 0x0B), label);
+                                } else {
+                                    ui.monospace(label);
+                                }
+                            });
+                            row.col(|ui| {
+                                let preview = content_preview(record.content.as_str(), 60);
+                                ui.small(preview);
                             });
                             row.col(|ui| {
                                 ui.monospace(format_timestamp_millis(record.updated_at_ms));
@@ -809,43 +1064,49 @@ impl MemoryPanel {
                             if response.clicked() {
                                 self.selected_long_term_id = Some(record.id.clone());
                             }
+                            if response.double_clicked() {
+                                detail_id = Some(record.id.clone());
+                            }
+
+                            let id_for_menu = record.id.clone();
+                            response.context_menu(|ui| {
+                                if ui
+                                    .button(format!("{} Detail", regular::FILE_TEXT))
+                                    .clicked()
+                                {
+                                    detail_id = Some(id_for_menu.clone());
+                                    ui.close();
+                                }
+                                ui.separator();
+                                if ui
+                                    .add(egui::Button::new(
+                                        RichText::new(format!("{} Delete", regular::TRASH))
+                                            .color(Color32::RED),
+                                    ))
+                                    .clicked()
+                                {
+                                    delete_id = Some(id_for_menu.clone());
+                                    ui.close();
+                                }
+                            });
                         });
                     });
             });
 
-        ui.add_space(10.0);
-        ui.separator();
-        ui.strong("Content");
-        match selected_long_term_record(&filtered, self.selected_long_term_id.as_deref()) {
-            Some(record) => {
-                ui.small(format!(
-                    "ID: {} | kind: {} | priority: {} | status: {} | topic: {} | archived_at: {} | updated: {}",
-                    record.id,
-                    kind_label(record),
-                    priority_label(record),
-                    status_label(record),
-                    read_long_term_topic(record).unwrap_or_else(|| "-".to_string()),
-                    read_long_term_archived_at(record)
-                        .map(format_timestamp_millis)
-                        .unwrap_or_else(|| "-".to_string()),
-                    format_timestamp_millis(record.updated_at_ms)
-                ));
-                let governance = governance_summary(record);
-                if governance != "-" {
-                    ui.small(format!("Governance: {governance}"));
-                }
-                ui.add_space(6.0);
-                let mut content = record.content.clone();
-                ui.add(
-                    egui::TextEdit::multiline(&mut content)
-                        .desired_width(f32::INFINITY)
-                        .desired_rows(10)
-                        .interactive(false),
-                );
-            }
-            None => {
-                ui.label("No long-term memory matches the current filters.");
-            }
+        if let Some(id) = detail_id {
+            self.selected_long_term_id = Some(id.clone());
+            self.detail_record_id = Some(id);
+        }
+        if let Some(id) = delete_id {
+            self.delete_confirm_id = Some(id);
+        }
+
+        // If user confirmed delete in the confirm dialog, trigger the delete operation here
+        // where we have access to notifications.
+        if self.delete_confirm_id.is_some() && self.delete_request.is_none() && !self.delete_loading
+        {
+            let id = self.delete_confirm_id.clone().unwrap_or_default();
+            self.begin_delete(&id, notifications);
         }
     }
 
@@ -1065,9 +1326,11 @@ impl PanelRenderer for MemoryPanel {
         self.poll_load_request(notifications);
         self.poll_session_search_request(notifications);
         self.poll_archive_run_request(notifications);
+        self.poll_delete_request(notifications);
         if self.load_request.is_some()
             || self.session_search_request.is_some()
             || self.archive_run_request.is_some()
+            || self.delete_request.is_some()
         {
             ui.ctx().request_repaint_after(POLL_INTERVAL);
         }
@@ -1089,10 +1352,12 @@ impl PanelRenderer for MemoryPanel {
             if ui.button(format!("{} Info", regular::INFO)).clicked() {
                 self.stats_window_open = true;
             }
-            if self.loading || self.archive_run_loading {
+            if self.loading || self.archive_run_loading || self.delete_loading {
                 ui.add(egui::Spinner::new());
                 ui.small(if self.archive_run_loading {
                     "Archiving..."
+                } else if self.delete_loading {
+                    "Deleting..."
                 } else {
                     "Loading..."
                 });
@@ -1112,7 +1377,7 @@ impl PanelRenderer for MemoryPanel {
         ui.separator();
 
         match self.tab {
-            MemoryTab::LongTerm => self.render_long_term_tab(ui, &overview),
+            MemoryTab::LongTerm => self.render_long_term_tab(ui, notifications, &overview),
             MemoryTab::SessionSearch => {
                 self.render_session_search_tab(ui, notifications, &overview)
             }
@@ -1122,6 +1387,12 @@ impl PanelRenderer for MemoryPanel {
         self.render_form_window(ui, notifications);
         if self.stats_window_open {
             self.render_stats_window(ui.ctx(), &overview);
+        }
+        if self.detail_record_id.is_some() {
+            self.render_detail_window(ui.ctx(), &overview);
+        }
+        if self.delete_confirm_id.is_some() {
+            self.render_delete_confirm_window(ui.ctx());
         }
     }
 }
@@ -1270,6 +1541,38 @@ fn count_records_with_status(
         .count()
 }
 
+fn content_preview(content: &str, max_chars: usize) -> String {
+    let trimmed = content.lines().next().unwrap_or_default().trim();
+    if trimmed.chars().count() > max_chars {
+        trimmed.chars().take(max_chars).collect::<String>() + "…"
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn spawn_delete_task(id: String, config: AppConfig) -> Receiver<Result<bool, String>> {
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let result = Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|err| format!("failed to build runtime: {err}"))
+            .and_then(|runtime| {
+                runtime.block_on(async move {
+                    let service = SqliteMemoryService::open_default(&config)
+                        .await
+                        .map_err(|err| format!("failed to open memory service: {err}"))?;
+                    service
+                        .delete(&id)
+                        .await
+                        .map_err(|err| format!("delete operation failed: {err}"))
+                })
+            });
+        let _ = tx.send(result);
+    });
+    rx
+}
+
 fn summary_chip(ui: &mut egui::Ui, label: &str, value: String) {
     egui::Frame::group(ui.style()).show(ui, |ui| {
         ui.vertical(|ui| {
@@ -1295,6 +1598,16 @@ fn priority_label(record: &MemoryRecord) -> &'static str {
     read_long_term_priority(record)
         .map(|priority| priority.as_str())
         .unwrap_or("-")
+}
+
+fn summary_label(record: &MemoryRecord) -> &'static str {
+    if is_summary_record(record) {
+        "summary"
+    } else if read_string_field(&record.metadata, "archived_by_summary").is_some() {
+        "source"
+    } else {
+        "-"
+    }
 }
 
 fn governance_summary(record: &MemoryRecord) -> String {
@@ -1386,9 +1699,10 @@ fn spawn_archive_run_task(config: LongTermArchiveConfig) -> Receiver<Result<Stri
                     let memory_db = open_default_memory_db()
                         .await
                         .map_err(|err| format!("failed to open memory db: {err}"))?;
-                    let outcome = archive_stale_long_term_memories(std::sync::Arc::new(memory_db), config)
-                        .await
-                        .map_err(|err| format!("archive operation failed: {err}"))?;
+                    let outcome =
+                        archive_stale_long_term_memories(std::sync::Arc::new(memory_db), config)
+                            .await
+                            .map_err(|err| format!("archive operation failed: {err}"))?;
                     Ok(format!(
                         "Archive complete: {} archived, {} summaries updated, {} skipped",
                         outcome.archived_records,
@@ -1799,5 +2113,95 @@ mod tests {
         let options = aggregate_session_key_options(&sessions);
 
         assert_eq!(options, vec!["base-1", "active-1", "base-2"]);
+    }
+
+    #[test]
+    fn content_preview_truncates_ascii_at_max_chars() {
+        let long_text = "This is a fairly long ASCII sentence that exceeds the limit.";
+        let preview = content_preview(long_text, 20);
+        assert_eq!(preview, "This is a fairly lon…");
+        assert!(preview.chars().count() == 21); // 20 chars + ellipsis
+    }
+
+    #[test]
+    fn content_preview_truncates_cjk_without_panicking_on_multibyte_boundary() {
+        // The bug: byte-index slicing inside a 3-byte Chinese char caused panic.
+        // "王" is bytes 58..61 in the original crash string; max_len=60 sliced at byte 60.
+        let cjk_text = "朱霸天陛下吹得舒舒服服，擅长拍马溜须，彩虹屁王者在此";
+        let preview = content_preview(cjk_text, 8);
+        // Should truncate at a char boundary, not crash.
+        assert!(preview.ends_with('…'));
+        assert!(preview.chars().count() == 9); // 8 chars + ellipsis
+        assert_eq!(preview, "朱霸天陛下吹得舒…");
+    }
+
+    #[test]
+    fn content_preview_returns_full_text_when_shorter_than_limit() {
+        let short_text = "Hello";
+        let preview = content_preview(short_text, 60);
+        assert_eq!(preview, "Hello");
+        assert!(!preview.contains('…'));
+    }
+
+    #[test]
+    fn content_preview_uses_first_line_only() {
+        let multiline = "first line\nsecond line\nthird line";
+        let preview = content_preview(multiline, 60);
+        assert_eq!(preview, "first line");
+    }
+
+    #[test]
+    fn summary_label_identifies_summary_record() {
+        let record = MemoryRecord {
+            id: "summary-1".to_string(),
+            scope: "long_term".to_string(),
+            content: "Consolidated summary".to_string(),
+            metadata: serde_json::json!({
+                "summary": true,
+                "source_ids": ["old-1", "old-2"],
+            }),
+            pinned: false,
+            created_at_ms: 1,
+            updated_at_ms: 1,
+        };
+
+        assert_eq!(summary_label(&record), "summary");
+    }
+
+    #[test]
+    fn summary_label_identifies_source_record_archived_by_summary() {
+        let record = MemoryRecord {
+            id: "old-1".to_string(),
+            scope: "long_term".to_string(),
+            content: "Original fact".to_string(),
+            metadata: serde_json::json!({
+                "kind": "fact",
+                "status": "archived",
+                "archived_by_summary": "summary-1",
+            }),
+            pinned: false,
+            created_at_ms: 1,
+            updated_at_ms: 1,
+        };
+
+        assert_eq!(summary_label(&record), "source");
+    }
+
+    #[test]
+    fn summary_label_returns_dash_for_normal_record() {
+        let record = MemoryRecord {
+            id: "1".to_string(),
+            scope: "long_term".to_string(),
+            content: "Just a regular fact".to_string(),
+            metadata: serde_json::json!({
+                "kind": "fact",
+                "status": "active",
+            }),
+            pinned: false,
+            created_at_ms: 1,
+            updated_at_ms: 1,
+        };
+
+        assert_eq!(summary_label(&record), "-");
     }
 }

--- a/klaw-gui/src/panels/memory.rs
+++ b/klaw-gui/src/panels/memory.rs
@@ -6,7 +6,8 @@ use egui_phosphor::regular;
 use klaw_config::{AppConfig, ConfigError, ConfigSnapshot, ConfigStore, EmbeddingConfig};
 use klaw_memory::{
     LongTermMemoryKind, LongTermMemoryPromptOptions, LongTermMemoryStatus, MemoryError,
-    MemoryRecord, MemoryStats, SqliteMemoryStatsService, read_long_term_kind,
+    MemoryRecord, MemoryStats, SqliteMemoryStatsService, is_summary_record,
+    read_long_term_archived_at, read_long_term_kind, read_long_term_priority,
     read_long_term_status, read_long_term_topic, render_long_term_memory_section,
 };
 use klaw_storage::{ChatRecord, SessionStorage, open_default_store};
@@ -766,11 +767,15 @@ impl MemoryPanel {
         match selected_long_term_record(&filtered, self.selected_long_term_id.as_deref()) {
             Some(record) => {
                 ui.small(format!(
-                    "ID: {} | kind: {} | status: {} | topic: {} | updated: {}",
+                    "ID: {} | kind: {} | priority: {} | status: {} | topic: {} | archived_at: {} | updated: {}",
                     record.id,
                     kind_label(record),
+                    priority_label(record),
                     status_label(record),
                     read_long_term_topic(record).unwrap_or_else(|| "-".to_string()),
+                    read_long_term_archived_at(record)
+                        .map(format_timestamp_millis)
+                        .unwrap_or_else(|| "-".to_string()),
                     format_timestamp_millis(record.updated_at_ms)
                 ));
                 let governance = governance_summary(record);
@@ -1220,19 +1225,38 @@ fn status_label(record: &MemoryRecord) -> &'static str {
         .as_str()
 }
 
+fn priority_label(record: &MemoryRecord) -> &'static str {
+    read_long_term_priority(record)
+        .map(|priority| priority.as_str())
+        .unwrap_or("-")
+}
+
 fn governance_summary(record: &MemoryRecord) -> String {
     let supersedes = read_string_list_field(&record.metadata, "supersedes");
     let superseded_by = read_string_field(&record.metadata, "superseded_by");
-    match (supersedes.is_empty(), superseded_by) {
-        (false, Some(superseded_by)) => {
-            format!(
-                "supersedes: {}; superseded_by: {superseded_by}",
-                supersedes.join(", ")
-            )
-        }
-        (false, None) => format!("supersedes: {}", supersedes.join(", ")),
-        (true, Some(superseded_by)) => format!("superseded_by: {superseded_by}"),
-        (true, None) => "-".to_string(),
+    let source_ids = read_string_list_field(&record.metadata, "source_ids");
+    let archived_by_summary = read_string_field(&record.metadata, "archived_by_summary");
+    let archived_at = read_long_term_archived_at(record).map(format_timestamp_millis);
+    let mut parts = Vec::new();
+    if !supersedes.is_empty() {
+        parts.push(format!("supersedes: {}", supersedes.join(", ")));
+    }
+    if let Some(superseded_by) = superseded_by {
+        parts.push(format!("superseded_by: {superseded_by}"));
+    }
+    if is_summary_record(record) && !source_ids.is_empty() {
+        parts.push(format!("summary sources: {}", source_ids.join(", ")));
+    }
+    if let Some(archived_by_summary) = archived_by_summary {
+        parts.push(format!("archived_by_summary: {archived_by_summary}"));
+    }
+    if let Some(archived_at) = archived_at {
+        parts.push(format!("archived_at: {archived_at}"));
+    }
+    if parts.is_empty() {
+        "-".to_string()
+    } else {
+        parts.join("; ")
     }
 }
 
@@ -1621,6 +1645,30 @@ mod tests {
         let summary = governance_summary(&record);
         assert!(summary.contains("old-1"));
         assert!(summary.contains("new-2"));
+    }
+
+    #[test]
+    fn governance_summary_renders_summary_and_archive_metadata() {
+        let record = MemoryRecord {
+            id: "summary-1".to_string(),
+            scope: "long_term".to_string(),
+            content: "Archived summary".to_string(),
+            metadata: serde_json::json!({
+                "summary": true,
+                "source_ids": ["old-1", "old-2"],
+                "archived_at": 1,
+                "archived_by_summary": "summary-1",
+            }),
+            pinned: false,
+            created_at_ms: 1,
+            updated_at_ms: 1,
+        };
+
+        let summary = governance_summary(&record);
+        assert!(summary.contains("summary sources"));
+        assert!(summary.contains("old-1"));
+        assert!(summary.contains("archived_by_summary"));
+        assert!(summary.contains("archived_at"));
     }
 
     #[test]

--- a/klaw-memory/CHANGELOG.md
+++ b/klaw-memory/CHANGELOG.md
@@ -1,5 +1,17 @@
 # CHANGELOG
 
+## 2026-04-23
+
+### Added
+
+- 长期记忆治理新增 `priority` 元数据校验与默认优先级推导，可显式覆盖 prompt 注入顺序
+
+### Changed
+
+- 长期记忆 prompt 渲染现在优先按显式 `priority` 排序，再回退到 `kind` 优先级
+- `SqliteMemoryService::search` 会统一过滤 `long_term` scope 下的 `archived` / `rejected` / `superseded` 记录，避免旧事实继续命中检索
+- 低优先级长期记忆现在支持后台自动归档，并按 `kind + topic` 生成 `summary=true` 的摘要索引记录
+
 ## 2026-03-31
 
 ### Added

--- a/klaw-memory/README.md
+++ b/klaw-memory/README.md
@@ -1,10 +1,13 @@
 # klaw-memory
 
-`klaw-memory` provides memory CRUD, retrieval (FTS/vector), and statistics for Klaw.
+`klaw-memory` provides memory CRUD, retrieval (FTS/vector), long-term memory governance, prompt rendering, and statistics for Klaw.
 
 ## Capabilities
 
 - Memory upsert/search/get/delete/pin (`SqliteMemoryService`)
+- Long-term memory governance (`kind`/`priority`/`status`/`topic` normalization)
+- Low-priority long-term memory archiving with grouped summary rollups
+- Prompt-safe long-term memory rendering with priority-aware ordering
 - Optional embedding provider integration for vector retrieval
 - SQLite-backed statistics aggregation (`SqliteMemoryStatsService`)
 

--- a/klaw-memory/src/governance.rs
+++ b/klaw-memory/src/governance.rs
@@ -53,6 +53,43 @@ impl LongTermMemoryKind {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LongTermMemoryPriority {
+    High,
+    Medium,
+    Low,
+}
+
+impl LongTermMemoryPriority {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::High => "high",
+            Self::Medium => "medium",
+            Self::Low => "low",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.trim() {
+            "high" => Some(Self::High),
+            "medium" => Some(Self::Medium),
+            "low" => Some(Self::Low),
+            _ => None,
+        }
+    }
+
+    #[must_use]
+    pub fn rank(self) -> u8 {
+        match self {
+            Self::High => 2,
+            Self::Medium => 1,
+            Self::Low => 0,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum LongTermMemoryStatus {
@@ -84,6 +121,19 @@ impl LongTermMemoryStatus {
     }
 }
 
+#[must_use]
+pub fn default_priority_for_kind(kind: LongTermMemoryKind) -> LongTermMemoryPriority {
+    match kind {
+        LongTermMemoryKind::Identity | LongTermMemoryKind::ProjectRule => {
+            LongTermMemoryPriority::High
+        }
+        LongTermMemoryKind::Preference
+        | LongTermMemoryKind::Workflow
+        | LongTermMemoryKind::Constraint => LongTermMemoryPriority::Medium,
+        LongTermMemoryKind::Fact => LongTermMemoryPriority::Low,
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct GovernedLongTermWrite {
     pub primary: UpsertMemoryInput,
@@ -95,6 +145,7 @@ pub struct GovernedLongTermWrite {
 
 fn is_active_long_term_with_kind(record: &MemoryRecord, kind: LongTermMemoryKind) -> bool {
     record.scope == "long_term"
+        && !is_summary_record(record)
         && read_status(record).unwrap_or(LongTermMemoryStatus::Active)
             == LongTermMemoryStatus::Active
         && read_kind(record).unwrap_or(LongTermMemoryKind::Fact) == kind
@@ -125,6 +176,7 @@ pub fn govern_long_term_write(
     let mut normalized_metadata = metadata.clone();
     let kind = normalize_kind(&normalized_metadata)?;
     normalize_incoming_status(&normalized_metadata)?;
+    let priority = normalize_priority(&normalized_metadata, kind)?;
     let topic = normalize_optional_string_field(&mut normalized_metadata, "topic");
     let mut supersedes = normalize_supersedes_field(&mut normalized_metadata)?;
     normalized_metadata.remove("superseded_by");
@@ -156,6 +208,7 @@ pub fn govern_long_term_write(
     let supersedes = dedupe_strings(supersedes);
 
     normalized_metadata.insert("kind".to_string(), json!(kind.as_str()));
+    normalized_metadata.insert("priority".to_string(), json!(priority.as_str()));
     normalized_metadata.insert(
         "status".to_string(),
         json!(LongTermMemoryStatus::Active.as_str()),
@@ -229,6 +282,47 @@ pub fn read_topic(record: &MemoryRecord) -> Option<String> {
         .map(ToString::to_string)
 }
 
+pub fn read_priority(record: &MemoryRecord) -> Option<LongTermMemoryPriority> {
+    record
+        .metadata
+        .get("priority")
+        .and_then(Value::as_str)
+        .and_then(LongTermMemoryPriority::parse)
+}
+
+pub fn read_archived_at(record: &MemoryRecord) -> Option<i64> {
+    record.metadata.get("archived_at").and_then(Value::as_i64)
+}
+
+#[must_use]
+pub fn is_summary_record(record: &MemoryRecord) -> bool {
+    record
+        .metadata
+        .get("summary")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
+#[must_use]
+pub fn effective_priority(record: &MemoryRecord) -> LongTermMemoryPriority {
+    read_priority(record).unwrap_or_else(|| {
+        default_priority_for_kind(read_kind(record).unwrap_or(LongTermMemoryKind::Fact))
+    })
+}
+
+#[must_use]
+pub fn is_inactive_long_term_record(record: &MemoryRecord) -> bool {
+    record.scope == "long_term"
+        && matches!(
+            read_status(record),
+            Some(
+                LongTermMemoryStatus::Archived
+                    | LongTermMemoryStatus::Rejected
+                    | LongTermMemoryStatus::Superseded
+            )
+        )
+}
+
 pub fn normalize_content(content: &str) -> String {
     content.split_whitespace().collect::<Vec<_>>().join(" ")
 }
@@ -260,6 +354,20 @@ fn normalize_incoming_status(metadata: &Map<String, Value>) -> Result<(), Memory
         ));
     }
     Ok(())
+}
+
+fn normalize_priority(
+    metadata: &Map<String, Value>,
+    kind: LongTermMemoryKind,
+) -> Result<LongTermMemoryPriority, MemoryError> {
+    match metadata.get("priority").and_then(Value::as_str) {
+        Some(raw) => LongTermMemoryPriority::parse(raw).ok_or_else(|| {
+            MemoryError::InvalidQuery(format!(
+                "invalid memory metadata.priority `{raw}`; expected one of high/medium/low"
+            ))
+        }),
+        None => Ok(default_priority_for_kind(kind)),
+    }
 }
 
 fn normalize_supersedes_field(
@@ -456,5 +564,54 @@ mod tests {
         .expect_err("non-active status should be rejected");
 
         assert!(err.to_string().contains("system-managed"));
+    }
+
+    #[test]
+    fn govern_long_term_write_rejects_invalid_priority() {
+        let err = govern_long_term_write(
+            &[],
+            UpsertMemoryInput {
+                id: None,
+                scope: "long_term".to_string(),
+                content: "Keep my replies concise.".to_string(),
+                metadata: json!({"priority": "urgent"}),
+                pinned: false,
+            },
+        )
+        .expect_err("invalid priority should be rejected");
+
+        assert!(err.to_string().contains("invalid memory metadata.priority"));
+    }
+
+    #[test]
+    fn govern_long_term_write_ignores_archive_summary_records_when_detecting_conflicts() {
+        let existing = vec![record(
+            "summary-1",
+            "Archived summary for reply_language.",
+            json!({
+                "kind": "preference",
+                "topic": "reply_language",
+                "status": "active",
+                "summary": true,
+                "source_ids": ["old-1"],
+            }),
+            false,
+        )];
+
+        let plan = govern_long_term_write(
+            &existing,
+            UpsertMemoryInput {
+                id: Some("new-1".to_string()),
+                scope: "long_term".to_string(),
+                content: "Default language is Chinese.".to_string(),
+                metadata: json!({"kind": "preference", "topic": "reply_language"}),
+                pinned: false,
+            },
+        )
+        .expect("governance should ignore summaries");
+
+        assert!(plan.superseded_updates.is_empty());
+        assert_eq!(plan.primary.metadata["topic"], "reply_language");
+        assert_eq!(plan.primary.metadata["status"], "active");
     }
 }

--- a/klaw-memory/src/lib.rs
+++ b/klaw-memory/src/lib.rs
@@ -1,5 +1,6 @@
 mod error;
 mod governance;
+mod maintenance;
 mod prompt;
 mod provider;
 mod service;
@@ -9,9 +10,16 @@ mod util;
 
 pub use error::MemoryError;
 pub use governance::{
-    GovernedLongTermWrite, LongTermMemoryKind, LongTermMemoryStatus, govern_long_term_write,
+    GovernedLongTermWrite, LongTermMemoryKind, LongTermMemoryPriority, LongTermMemoryStatus,
+    default_priority_for_kind, effective_priority as effective_long_term_priority,
+    govern_long_term_write, is_inactive_long_term_record, is_summary_record,
     normalize_content as normalize_long_term_content, read_kind as read_long_term_kind,
-    read_status as read_long_term_status, read_topic as read_long_term_topic,
+    read_archived_at as read_long_term_archived_at,
+    read_priority as read_long_term_priority, read_status as read_long_term_status,
+    read_topic as read_long_term_topic,
+};
+pub use maintenance::{
+    LongTermArchiveConfig, LongTermArchiveOutcome, archive_stale_long_term_memories,
 };
 pub use prompt::{LongTermMemoryPromptOptions, render_long_term_memory_section};
 pub use provider::{OpenAiEmbeddingProvider, build_embedding_provider_from_config};

--- a/klaw-memory/src/maintenance.rs
+++ b/klaw-memory/src/maintenance.rs
@@ -1,0 +1,256 @@
+use crate::{
+    LongTermMemoryKind, LongTermMemoryPriority, MemoryError, MemoryRecord, MemoryService,
+    SqliteMemoryService,
+    SqliteMemoryStatsService, UpsertMemoryInput, effective_long_term_priority,
+    is_inactive_long_term_record, is_summary_record, normalize_long_term_content, read_long_term_kind,
+    read_long_term_topic,
+};
+use klaw_storage::MemoryDb;
+use serde_json::{Map, Value, json};
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::util::now_ms;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LongTermArchiveConfig {
+    pub max_age_days: i64,
+    pub summary_max_sources: usize,
+}
+
+impl Default for LongTermArchiveConfig {
+    fn default() -> Self {
+        Self {
+            max_age_days: 30,
+            summary_max_sources: 8,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct LongTermArchiveOutcome {
+    pub archived_records: usize,
+    pub summary_records_upserted: usize,
+    pub skipped_records: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct ArchiveGroupKey {
+    kind: LongTermMemoryKind,
+    topic: Option<String>,
+}
+
+pub async fn archive_stale_long_term_memories(
+    db: Arc<dyn MemoryDb>,
+    config: LongTermArchiveConfig,
+) -> Result<LongTermArchiveOutcome, MemoryError> {
+    if config.max_age_days <= 0 {
+        return Err(MemoryError::InvalidQuery(
+            "archive max_age_days must be greater than 0".to_string(),
+        ));
+    }
+    if config.summary_max_sources == 0 {
+        return Err(MemoryError::InvalidQuery(
+            "archive summary_max_sources must be greater than 0".to_string(),
+        ));
+    }
+
+    let stats = SqliteMemoryStatsService::new(db.clone());
+    let service = SqliteMemoryService::new(db, None).await?;
+    let records = stats.list_scope_records("long_term").await?;
+    let now = now_ms();
+    let cutoff_ms = now.saturating_sub(config.max_age_days.saturating_mul(24 * 60 * 60 * 1000));
+
+    let mut summaries_by_group = BTreeMap::new();
+    let mut source_records_by_id = BTreeMap::new();
+    let mut candidate_groups: BTreeMap<ArchiveGroupKey, Vec<MemoryRecord>> = BTreeMap::new();
+    let mut outcome = LongTermArchiveOutcome::default();
+
+    for record in &records {
+        source_records_by_id.insert(record.id.clone(), record.clone());
+        if is_summary_record(record)
+            && !is_inactive_long_term_record(record)
+            && record.scope == "long_term"
+        {
+            summaries_by_group.insert(group_key(record), record.clone());
+        }
+    }
+
+    for record in &records {
+        if should_archive_record(record, cutoff_ms) {
+            candidate_groups
+                .entry(group_key(record))
+                .or_default()
+                .push(record.clone());
+        } else if record.scope == "long_term"
+            && !is_summary_record(record)
+            && !is_inactive_long_term_record(record)
+            && effective_long_term_priority(record) == LongTermMemoryPriority::Low
+        {
+            outcome.skipped_records += 1;
+        }
+    }
+
+    for (group, mut candidates) in candidate_groups {
+        candidates.sort_by(|a, b| {
+            a.updated_at_ms
+                .cmp(&b.updated_at_ms)
+                .then_with(|| a.created_at_ms.cmp(&b.created_at_ms))
+                .then_with(|| a.id.cmp(&b.id))
+        });
+
+        let existing_summary = summaries_by_group.get(&group).cloned();
+        let summary_id = existing_summary
+            .as_ref()
+            .map(|record| record.id.clone())
+            .unwrap_or_else(|| Uuid::new_v4().to_string());
+
+        let source_ids = merged_source_ids(existing_summary.as_ref(), &candidates);
+        let source_records = source_ids
+            .iter()
+            .filter_map(|id| source_records_by_id.get(id))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        let summary_metadata = build_summary_metadata(&group, &source_ids, now, existing_summary.as_ref());
+        let summary_content =
+            build_summary_content(&group, &source_records, config.summary_max_sources);
+
+        service
+            .upsert(UpsertMemoryInput {
+                id: Some(summary_id.clone()),
+                scope: "long_term".to_string(),
+                content: summary_content,
+                metadata: Value::Object(summary_metadata),
+                pinned: false,
+            })
+            .await?;
+        outcome.summary_records_upserted += 1;
+
+        for record in candidates {
+            let metadata = archive_metadata(&record, now, &summary_id);
+            service
+                .upsert(UpsertMemoryInput {
+                    id: Some(record.id.clone()),
+                    scope: record.scope.clone(),
+                    content: record.content.clone(),
+                    metadata: Value::Object(metadata),
+                    pinned: record.pinned,
+                })
+                .await?;
+            outcome.archived_records += 1;
+        }
+    }
+
+    Ok(outcome)
+}
+
+fn should_archive_record(record: &MemoryRecord, cutoff_ms: i64) -> bool {
+    record.scope == "long_term"
+        && !record.pinned
+        && !is_summary_record(record)
+        && !is_inactive_long_term_record(record)
+        && effective_long_term_priority(record) == LongTermMemoryPriority::Low
+        && record
+            .metadata
+            .get("archived_at")
+            .and_then(Value::as_i64)
+            .is_none()
+        && record.updated_at_ms <= cutoff_ms
+}
+
+fn group_key(record: &MemoryRecord) -> ArchiveGroupKey {
+    ArchiveGroupKey {
+        kind: read_long_term_kind(record).unwrap_or(LongTermMemoryKind::Fact),
+        topic: read_long_term_topic(record),
+    }
+}
+
+fn merged_source_ids(existing_summary: Option<&MemoryRecord>, candidates: &[MemoryRecord]) -> Vec<String> {
+    let mut seen = BTreeSet::new();
+    existing_summary
+        .into_iter()
+        .flat_map(read_source_ids)
+        .chain(candidates.iter().map(|record| record.id.clone()))
+        .filter(|id| seen.insert(id.clone()))
+        .collect()
+}
+
+fn read_source_ids(record: &MemoryRecord) -> Vec<String> {
+    match record.metadata.get("source_ids") {
+        Some(Value::String(value)) => vec![value.clone()],
+        Some(Value::Array(values)) => values
+            .iter()
+            .filter_map(Value::as_str)
+            .map(ToString::to_string)
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn build_summary_metadata(
+    group: &ArchiveGroupKey,
+    source_ids: &[String],
+    archived_at_ms: i64,
+    existing_summary: Option<&MemoryRecord>,
+) -> Map<String, Value> {
+    let mut metadata = existing_summary
+        .and_then(|record| record.metadata.as_object().cloned())
+        .unwrap_or_default();
+    metadata.insert("kind".to_string(), json!(group.kind.as_str()));
+    metadata.insert("priority".to_string(), json!(LongTermMemoryPriority::Low.as_str()));
+    metadata.insert("status".to_string(), json!("active"));
+    metadata.insert("summary".to_string(), json!(true));
+    metadata.insert("source_ids".to_string(), json!(source_ids));
+    metadata.insert("archived_at".to_string(), json!(archived_at_ms));
+    metadata.insert("summary_type".to_string(), json!("archive_rollup"));
+    if let Some(topic) = group.topic.as_ref() {
+        metadata.insert("topic".to_string(), json!(topic));
+    } else {
+        metadata.remove("topic");
+    }
+    metadata
+}
+
+fn build_summary_content(
+    group: &ArchiveGroupKey,
+    source_records: &[MemoryRecord],
+    max_sources: usize,
+) -> String {
+    let label = group
+        .topic
+        .as_deref()
+        .map(ToString::to_string)
+        .unwrap_or_else(|| group.kind.as_str().to_string());
+    let mut snippets = source_records
+        .iter()
+        .map(|record| normalize_long_term_content(&record.content))
+        .filter(|content| !content.is_empty())
+        .collect::<Vec<_>>();
+    snippets.sort();
+    snippets.dedup();
+
+    let total = snippets.len();
+    let preview = snippets
+        .into_iter()
+        .take(max_sources)
+        .collect::<Vec<_>>();
+    let more = total.saturating_sub(preview.len());
+    let mut content = format!(
+        "Archived {total} low-priority memories for {label}: {}",
+        preview.join(" | ")
+    );
+    if more > 0 {
+        content.push_str(&format!(" | +{more} more"));
+    }
+    content
+}
+
+fn archive_metadata(record: &MemoryRecord, archived_at_ms: i64, summary_id: &str) -> Map<String, Value> {
+    let mut metadata = record.metadata.as_object().cloned().unwrap_or_default();
+    metadata.insert("status".to_string(), json!("archived"));
+    metadata.insert("archived_at".to_string(), json!(archived_at_ms));
+    metadata.insert("archived_by_summary".to_string(), json!(summary_id));
+    metadata
+}

--- a/klaw-memory/src/prompt.rs
+++ b/klaw-memory/src/prompt.rs
@@ -1,6 +1,7 @@
 use crate::{
-    LongTermMemoryKind, LongTermMemoryStatus, MemoryRecord, normalize_long_term_content,
-    read_long_term_kind, read_long_term_status,
+    LongTermMemoryKind, MemoryRecord, effective_long_term_priority,
+    is_inactive_long_term_record, is_summary_record, normalize_long_term_content,
+    read_long_term_kind,
 };
 use serde_json::Value;
 use std::collections::BTreeSet;
@@ -34,8 +35,10 @@ pub fn render_long_term_memory_section(
                 .unwrap_or(LongTermMemoryKind::Fact)
                 .priority()
         };
+        let prompt_pri = |record: &MemoryRecord| effective_long_term_priority(record).rank();
         b.pinned
             .cmp(&a.pinned)
+            .then_with(|| prompt_pri(b).cmp(&prompt_pri(a)))
             .then_with(|| kind_pri(b).cmp(&kind_pri(a)))
             .then_with(|| b.updated_at_ms.cmp(&a.updated_at_ms))
             .then_with(|| a.id.cmp(&b.id))
@@ -48,7 +51,7 @@ pub fn render_long_term_memory_section(
     let mut used_chars = 0usize;
 
     for record in &ordered_records {
-        if is_inactive(record) {
+        if is_inactive_long_term_record(record) || is_summary_record(record) {
             continue;
         }
         let content = normalize_long_term_content(&record.content);
@@ -82,17 +85,6 @@ pub fn render_long_term_memory_section(
     }
 
     (!lines.is_empty()).then(|| lines.join("\n"))
-}
-
-fn is_inactive(record: &MemoryRecord) -> bool {
-    matches!(
-        read_long_term_status(record),
-        Some(
-            LongTermMemoryStatus::Archived
-                | LongTermMemoryStatus::Rejected
-                | LongTermMemoryStatus::Superseded
-        )
-    )
 }
 
 fn kind_label(metadata: &Value) -> Option<String> {
@@ -211,5 +203,64 @@ mod tests {
         assert!(!rendered.contains("Outdated memory"));
         assert!(rendered.contains("A very long memory item"));
         assert!(rendered.contains("..."));
+    }
+
+    #[test]
+    fn render_long_term_memory_section_prioritizes_explicit_priority_over_kind() {
+        let rendered = render_long_term_memory_section(
+            &[
+                record(
+                    "1",
+                    "Use concise replies.",
+                    json!({"kind": "project_rule", "priority": "low"}),
+                    false,
+                    10,
+                ),
+                record(
+                    "2",
+                    "I live in Shanghai.",
+                    json!({"kind": "fact", "priority": "high"}),
+                    false,
+                    9,
+                ),
+            ],
+            &LongTermMemoryPromptOptions::default(),
+        )
+        .expect("section should render");
+
+        let lines = rendered.lines().collect::<Vec<_>>();
+        assert_eq!(lines[0], "- [fact] I live in Shanghai.");
+        assert_eq!(lines[1], "- [project_rule] Use concise replies.");
+    }
+
+    #[test]
+    fn render_long_term_memory_section_skips_summary_records() {
+        let rendered = render_long_term_memory_section(
+            &[
+                record(
+                    "1",
+                    "Archived summary for reply_language.",
+                    json!({
+                        "kind": "preference",
+                        "status": "active",
+                        "summary": true,
+                    }),
+                    false,
+                    10,
+                ),
+                record(
+                    "2",
+                    "Default language is Chinese.",
+                    json!({"kind": "preference", "status": "active"}),
+                    false,
+                    9,
+                ),
+            ],
+            &LongTermMemoryPromptOptions::default(),
+        )
+        .expect("section should render");
+
+        assert!(!rendered.contains("Archived summary"));
+        assert!(rendered.contains("Default language is Chinese."));
     }
 }

--- a/klaw-memory/src/service.rs
+++ b/klaw-memory/src/service.rs
@@ -1,6 +1,6 @@
 use crate::{
     EmbeddingProvider, MemoryError, MemoryHit, MemoryRecord, MemorySearchQuery, MemoryService,
-    UpsertMemoryInput, build_embedding_provider_from_config,
+    UpsertMemoryInput, build_embedding_provider_from_config, is_inactive_long_term_record,
     util::{db_string, f32_vec_to_blob, now_ms, row_to_record, rrf_score},
 };
 use async_trait::async_trait;
@@ -327,6 +327,7 @@ impl MemoryService for SqliteMemoryService {
             })
             .collect();
 
+        hits.retain(|hit| !is_inactive_long_term_record(&hit.record));
         hits.sort_by(|a, b| {
             b.record
                 .pinned

--- a/klaw-memory/src/tests.rs
+++ b/klaw-memory/src/tests.rs
@@ -485,6 +485,7 @@ fn embedding_provider_build_uses_memory_config() {
                 provider: "openai".to_string(),
                 model: "text-embedding-3-small".to_string(),
             },
+            archive: klaw_config::MemoryArchiveConfig::default(),
         },
         ..Default::default()
     };

--- a/klaw-memory/src/tests.rs
+++ b/klaw-memory/src/tests.rs
@@ -1,6 +1,7 @@
 use crate::{
-    EmbeddingProvider, MemorySearchQuery, MemoryService, SqliteMemoryService,
-    SqliteMemoryStatsService, UpsertMemoryInput, build_embedding_provider_from_config,
+    EmbeddingProvider, LongTermArchiveConfig, MemorySearchQuery, MemoryService,
+    SqliteMemoryService, SqliteMemoryStatsService, UpsertMemoryInput,
+    archive_stale_long_term_memories, build_embedding_provider_from_config,
     util::{now_ms, rrf_score},
 };
 use async_trait::async_trait;
@@ -99,6 +100,239 @@ async fn fts_search_returns_hits_without_vector() {
 
     assert!(!hits.is_empty());
     assert!(hits[0].record.content.contains("E_CONNRESET"));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn search_skips_inactive_long_term_records() {
+    let db = create_db().await;
+    let service = SqliteMemoryService::new(db, Some(Arc::new(MockEmbeddingProvider)))
+        .await
+        .expect("service should init");
+
+    let _ = service
+        .upsert(UpsertMemoryInput {
+            id: Some("m-active".to_string()),
+            scope: "long_term".to_string(),
+            content: "Default reply language is Chinese.".to_string(),
+            metadata: serde_json::json!({
+                "kind": "preference",
+                "status": "active",
+            }),
+            pinned: false,
+        })
+        .await
+        .expect("active upsert should work");
+
+    let _ = service
+        .upsert(UpsertMemoryInput {
+            id: Some("m-archived".to_string()),
+            scope: "long_term".to_string(),
+            content: "Default reply language is Chinese (old).".to_string(),
+            metadata: serde_json::json!({
+                "kind": "preference",
+                "status": "archived",
+            }),
+            pinned: false,
+        })
+        .await
+        .expect("archived upsert should work");
+
+    let hits = service
+        .search(MemorySearchQuery {
+            scope: Some("long_term".to_string()),
+            text: "reply language".to_string(),
+            use_vector: false,
+            limit: 10,
+            ..MemorySearchQuery::default()
+        })
+        .await
+        .expect("search should work");
+
+    let ids = hits
+        .iter()
+        .map(|hit| hit.record.id.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(ids, vec!["m-active"]);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn archive_stale_long_term_memories_archives_low_priority_records_and_creates_summary() {
+    let db = create_db().await;
+    let service = SqliteMemoryService::new(db.clone(), Some(Arc::new(MockEmbeddingProvider)))
+        .await
+        .expect("service should init");
+    let now = now_ms();
+    let forty_days_ms = 40_i64 * 24 * 60 * 60 * 1000;
+
+    let _ = service
+        .upsert(UpsertMemoryInput {
+            id: Some("old-1".to_string()),
+            scope: "long_term".to_string(),
+            content: "Worked from Beijing office.".to_string(),
+            metadata: serde_json::json!({
+                "kind": "fact",
+                "priority": "low",
+                "topic": "work_city",
+                "status": "active",
+            }),
+            pinned: false,
+        })
+        .await
+        .expect("first record should upsert");
+    let _ = service
+        .upsert(UpsertMemoryInput {
+            id: Some("old-2".to_string()),
+            scope: "long_term".to_string(),
+            content: "Moved to Shenzhen for work.".to_string(),
+            metadata: serde_json::json!({
+                "kind": "fact",
+                "priority": "low",
+                "topic": "work_city",
+                "status": "active",
+            }),
+            pinned: false,
+        })
+        .await
+        .expect("second record should upsert");
+
+    for id in ["old-1", "old-2"] {
+        let _ = db
+            .execute(
+                "UPDATE memories SET updated_at_ms = ?1, created_at_ms = ?1 WHERE id = ?2",
+                &[
+                    klaw_storage::DbValue::Integer(now - forty_days_ms),
+                    klaw_storage::DbValue::Text(id.to_string()),
+                ],
+            )
+            .await
+            .expect("timestamps should update");
+    }
+
+    let outcome = archive_stale_long_term_memories(
+        db.clone(),
+        LongTermArchiveConfig {
+            max_age_days: 30,
+            summary_max_sources: 8,
+        },
+    )
+    .await
+    .expect("archive should succeed");
+
+    assert_eq!(outcome.archived_records, 2);
+    assert_eq!(outcome.summary_records_upserted, 1);
+
+    let records = SqliteMemoryStatsService::new(db)
+        .list_scope_records("long_term")
+        .await
+        .expect("records should load");
+
+    let archived = records
+        .iter()
+        .filter(|record| {
+            matches!(
+                record.metadata.get("status").and_then(serde_json::Value::as_str),
+                Some("archived")
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(archived.len(), 2);
+    assert!(archived.iter().all(|record| {
+        record
+            .metadata
+            .get("archived_at")
+            .and_then(serde_json::Value::as_i64)
+            .is_some()
+    }));
+    let summary = records
+        .iter()
+        .find(|record| {
+            record
+                .metadata
+                .get("summary")
+                .and_then(serde_json::Value::as_bool)
+                == Some(true)
+        })
+        .expect("summary record should exist");
+    assert_eq!(summary.metadata["status"], "active");
+    assert_eq!(summary.metadata["priority"], "low");
+    assert_eq!(summary.metadata["topic"], "work_city");
+    assert_eq!(summary.metadata["source_ids"], serde_json::json!(["old-1", "old-2"]));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn archive_stale_long_term_memories_reuses_existing_summary_for_same_topic() {
+    let db = create_db().await;
+    let service = SqliteMemoryService::new(db.clone(), Some(Arc::new(MockEmbeddingProvider)))
+        .await
+        .expect("service should init");
+    let now = now_ms();
+    let forty_days_ms = 40_i64 * 24 * 60 * 60 * 1000;
+
+    let _ = service
+        .upsert(UpsertMemoryInput {
+            id: Some("summary-1".to_string()),
+            scope: "long_term".to_string(),
+            content: "Archived summary for work_city.".to_string(),
+            metadata: serde_json::json!({
+                "kind": "fact",
+                "priority": "low",
+                "topic": "work_city",
+                "status": "active",
+                "summary": true,
+                "source_ids": ["old-1"],
+            }),
+            pinned: false,
+        })
+        .await
+        .expect("summary should upsert");
+    let _ = service
+        .upsert(UpsertMemoryInput {
+            id: Some("old-2".to_string()),
+            scope: "long_term".to_string(),
+            content: "Moved to Shenzhen for work.".to_string(),
+            metadata: serde_json::json!({
+                "kind": "fact",
+                "priority": "low",
+                "topic": "work_city",
+                "status": "active",
+            }),
+            pinned: false,
+        })
+        .await
+        .expect("record should upsert");
+    let _ = db
+        .execute(
+            "UPDATE memories SET updated_at_ms = ?1, created_at_ms = ?1 WHERE id = ?2",
+            &[
+                klaw_storage::DbValue::Integer(now - forty_days_ms),
+                klaw_storage::DbValue::Text("old-2".to_string()),
+            ],
+        )
+        .await
+        .expect("timestamps should update");
+
+    let outcome = archive_stale_long_term_memories(
+        db.clone(),
+        LongTermArchiveConfig {
+            max_age_days: 30,
+            summary_max_sources: 8,
+        },
+    )
+    .await
+    .expect("archive should succeed");
+
+    assert_eq!(outcome.archived_records, 1);
+    assert_eq!(outcome.summary_records_upserted, 1);
+
+    let summary = service
+        .get("summary-1")
+        .await
+        .expect("summary lookup should work")
+        .expect("summary should exist");
+    assert_eq!(
+        summary.metadata["source_ids"],
+        serde_json::json!(["old-1", "old-2"])
+    );
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/klaw-runtime/src/lib.rs
+++ b/klaw-runtime/src/lib.rs
@@ -233,7 +233,9 @@ impl ChannelRuntime for SharedChannelRuntime {
     }
 
     async fn on_cron_tick(&self) {
-        self.background.on_cron_tick().await;
+        if self.background.on_cron_tick().await {
+            refresh_runtime_system_prompt(self.runtime.as_ref()).await;
+        }
     }
 
     async fn on_runtime_tick(&self) {

--- a/klaw-runtime/src/service_loop.rs
+++ b/klaw-runtime/src/service_loop.rs
@@ -10,15 +10,17 @@ use klaw_core::{
     DeliveryMode, Envelope, InMemoryTransport, InboundMessage, MessageTransport, OutboundMessage,
     Subscription, TransportAckHandle, TransportError,
 };
-use klaw_cron::{CronWorker, CronWorkerConfig, MissedRunPolicy};
+use klaw_cron::{CronScheduleKind, CronWorker, CronWorkerConfig, MissedRunPolicy, ScheduleSpec};
 use klaw_gateway::{GatewayWebsocketServerFrame, OutboundEvent};
 use klaw_heartbeat::{HeartbeatWorker, HeartbeatWorkerConfig, should_suppress_output};
-use klaw_storage::{ChatRecord, DefaultSessionStore, SessionStorage};
+use klaw_memory::{LongTermArchiveConfig, archive_stale_long_term_memories};
+use klaw_storage::{ChatRecord, DefaultSessionStore, MemoryDb, SessionStorage};
+use klaw_util::system_timezone_name;
 use serde_json::Value;
 use std::{
     collections::BTreeMap,
     io,
-    sync::{Mutex, mpsc},
+    sync::{Arc, Mutex, mpsc},
     thread,
     time::Duration,
     time::SystemTime,
@@ -29,6 +31,8 @@ use tracing::{debug, warn};
 type StdioCronWorker = CronWorker<DefaultSessionStore, FilteringInboundTransport>;
 type StdioHeartbeatWorker = HeartbeatWorker<DefaultSessionStore, FilteringInboundTransport>;
 const OUTBOUND_DISPATCH_TIMEOUT: Duration = Duration::from_secs(10);
+const MEMORY_ARCHIVE_SCHEDULE: &str = "0 0 2 * * *";
+const MEMORY_ARCHIVE_LOOKBACK_MS: i64 = 24 * 60 * 60 * 1000;
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct ChannelAvailability {
@@ -226,6 +230,7 @@ impl MessageTransport<InboundMessage> for FilteringInboundTransport {
 pub struct BackgroundServices {
     cron_worker: StdioCronWorker,
     heartbeat_worker: StdioHeartbeatWorker,
+    memory_archive_worker: Option<MemoryArchiveWorker>,
     config: BackgroundServiceConfig,
     runtime_drain_error: Mutex<Option<String>>,
     dispatched_outbound_count: Mutex<usize>,
@@ -263,6 +268,10 @@ impl BackgroundServices {
         Self {
             cron_worker,
             heartbeat_worker,
+            memory_archive_worker: runtime
+                .memory_db
+                .clone()
+                .map(MemoryArchiveWorker::new),
             config,
             runtime_drain_error: Mutex::new(None),
             dispatched_outbound_count: Mutex::new(0),
@@ -278,13 +287,25 @@ impl BackgroundServices {
         self.config.runtime_tick_interval
     }
 
-    pub async fn on_cron_tick(&self) {
+    pub async fn on_cron_tick(&self) -> bool {
+        let mut memory_changed = false;
         if let Err(err) = self.cron_worker.run_tick().await {
             warn!(error = %err, "cron tick failed");
         }
         if let Err(err) = self.heartbeat_worker.run_tick().await {
             warn!(error = %err, "heartbeat tick failed");
         }
+        if let Some(worker) = &self.memory_archive_worker {
+            match worker.run_tick().await {
+                Ok(changed) => {
+                    memory_changed = changed;
+                }
+                Err(err) => {
+                    warn!(error = %err, "memory archive tick failed");
+                }
+            }
+        }
+        memory_changed
     }
 
     pub async fn run_cron_now(&self, cron_id: &str) -> Result<String, String> {
@@ -352,6 +373,80 @@ impl BackgroundServices {
         *guard = messages.len();
         Ok(())
     }
+}
+
+struct MemoryArchiveWorker {
+    memory_db: Arc<dyn MemoryDb>,
+    schedule: ScheduleSpec,
+    timezone: String,
+    last_scheduled_run_ms: Mutex<Option<i64>>,
+    archive_config: LongTermArchiveConfig,
+}
+
+impl MemoryArchiveWorker {
+    fn new(memory_db: Arc<dyn MemoryDb>) -> Self {
+        Self {
+            memory_db,
+            schedule: ScheduleSpec::from_kind_expr(CronScheduleKind::Cron, MEMORY_ARCHIVE_SCHEDULE)
+                .expect("memory archive schedule should be valid"),
+            timezone: system_timezone_name(),
+            last_scheduled_run_ms: Mutex::new(None),
+            archive_config: LongTermArchiveConfig::default(),
+        }
+    }
+
+    async fn run_tick(&self) -> Result<bool, String> {
+        let now_ms = current_time_ms();
+        let scheduled_run_ms = {
+            let mut last_scheduled = self
+                .last_scheduled_run_ms
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let Some(next_due) = next_memory_archive_due_ms(
+                &self.schedule,
+                &self.timezone,
+                *last_scheduled,
+                now_ms,
+            )
+            .map_err(|err| err.to_string())?
+            else {
+                return Ok(false);
+            };
+            *last_scheduled = Some(next_due);
+            next_due
+        };
+
+        let outcome = archive_stale_long_term_memories(self.memory_db.clone(), self.archive_config)
+            .await
+            .map_err(|err| err.to_string())?;
+        debug!(
+            scheduled_run_ms,
+            archived_records = outcome.archived_records,
+            summary_records_upserted = outcome.summary_records_upserted,
+            skipped_records = outcome.skipped_records,
+            "memory archive tick completed"
+        );
+        Ok(outcome.archived_records > 0 || outcome.summary_records_upserted > 0)
+    }
+}
+
+fn next_memory_archive_due_ms(
+    schedule: &ScheduleSpec,
+    timezone: &str,
+    last_scheduled_run_ms: Option<i64>,
+    now_ms: i64,
+) -> Result<Option<i64>, klaw_cron::CronError> {
+    let anchor_ms =
+        last_scheduled_run_ms.unwrap_or_else(|| now_ms.saturating_sub(MEMORY_ARCHIVE_LOOKBACK_MS));
+    let next_due_ms = schedule.next_run_after_ms_in_timezone(anchor_ms, timezone)?;
+    Ok((now_ms >= next_due_ms).then_some(next_due_ms))
+}
+
+fn current_time_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64
 }
 
 fn spawn_outbound_dispatcher(
@@ -781,7 +876,8 @@ fn render_outbound_markdown(output: &OutboundMessage) -> String {
 mod tests {
     use super::{
         BackgroundDingtalkAccountConfig, BackgroundServiceConfig, ChannelAvailability,
-        FilteringInboundTransport, dispatch_outbound_message, resolve_outbound_account_id,
+        FilteringInboundTransport, MEMORY_ARCHIVE_SCHEDULE, dispatch_outbound_message,
+        next_memory_archive_due_ms, resolve_outbound_account_id,
     };
     use klaw_channel::dingtalk::is_session_webhook_session_not_found_error;
     use klaw_config::{AppConfig, DingtalkConfig};
@@ -789,6 +885,7 @@ mod tests {
         Envelope, EnvelopeHeader, InMemoryTransport, InboundMessage, MessageTopic,
         MessageTransport, OutboundMessage,
     };
+    use klaw_cron::{CronScheduleKind, ScheduleSpec};
     use klaw_gateway::GatewayWebsocketBroadcaster;
     use klaw_session::{SessionManager, SqliteSessionManager};
     use klaw_storage::{DefaultSessionStore, StoragePaths};
@@ -885,6 +982,46 @@ mod tests {
         );
 
         assert_eq!(resolve_outbound_account_id(&msg, "telegram"), None);
+    }
+
+    #[test]
+    fn memory_archive_due_ms_claims_today_run_after_starting_late() {
+        let schedule = ScheduleSpec::from_kind_expr(CronScheduleKind::Cron, MEMORY_ARCHIVE_SCHEDULE)
+            .expect("schedule should parse");
+
+        let due = next_memory_archive_due_ms(
+            &schedule,
+            "Asia/Shanghai",
+            None,
+            68_400_000,
+        )
+        .expect("due calculation should succeed");
+
+        assert_eq!(due, Some(64_800_000));
+    }
+
+    #[test]
+    fn memory_archive_due_ms_only_runs_once_per_day() {
+        let schedule = ScheduleSpec::from_kind_expr(CronScheduleKind::Cron, MEMORY_ARCHIVE_SCHEDULE)
+            .expect("schedule should parse");
+
+        let first_due = next_memory_archive_due_ms(
+            &schedule,
+            "Asia/Shanghai",
+            None,
+            68_400_000,
+        )
+        .expect("first due calculation should succeed");
+        assert_eq!(first_due, Some(64_800_000));
+
+        let second_due = next_memory_archive_due_ms(
+            &schedule,
+            "Asia/Shanghai",
+            first_due,
+            72_000_000,
+        )
+        .expect("second due calculation should succeed");
+        assert_eq!(second_due, None);
     }
 
     #[test]

--- a/klaw-runtime/src/service_loop.rs
+++ b/klaw-runtime/src/service_loop.rs
@@ -31,7 +31,6 @@ use tracing::{debug, warn};
 type StdioCronWorker = CronWorker<DefaultSessionStore, FilteringInboundTransport>;
 type StdioHeartbeatWorker = HeartbeatWorker<DefaultSessionStore, FilteringInboundTransport>;
 const OUTBOUND_DISPATCH_TIMEOUT: Duration = Duration::from_secs(10);
-const MEMORY_ARCHIVE_SCHEDULE: &str = "0 0 2 * * *";
 const MEMORY_ARCHIVE_LOOKBACK_MS: i64 = 24 * 60 * 60 * 1000;
 
 #[derive(Debug, Clone, Default)]
@@ -102,6 +101,10 @@ pub struct BackgroundServiceConfig {
     pub runtime_drain_batch: usize,
     pub cron_batch_limit: i64,
     pub cron_missed_run_policy: MissedRunPolicy,
+    pub memory_archive_enabled: bool,
+    pub memory_archive_schedule: String,
+    pub memory_archive_max_age_days: i64,
+    pub memory_archive_summary_max_sources: usize,
     channel_availability: ChannelAvailability,
     pub dingtalk_accounts: BTreeMap<String, BackgroundDingtalkAccountConfig>,
     pub telegram_configs: BTreeMap<String, klaw_config::TelegramConfig>,
@@ -118,6 +121,10 @@ impl BackgroundServiceConfig {
                 CronMissedRunPolicy::Skip => MissedRunPolicy::Skip,
                 CronMissedRunPolicy::CatchUp => MissedRunPolicy::CatchUp,
             },
+            memory_archive_enabled: config.memory.archive.enabled,
+            memory_archive_schedule: config.memory.archive.schedule.clone(),
+            memory_archive_max_age_days: config.memory.archive.max_age_days,
+            memory_archive_summary_max_sources: config.memory.archive.summary_max_sources,
             channel_availability: ChannelAvailability::from_app_config(config),
             dingtalk_accounts: config
                 .channels
@@ -156,6 +163,10 @@ impl Default for BackgroundServiceConfig {
             runtime_drain_batch: 8,
             cron_batch_limit: 64,
             cron_missed_run_policy: MissedRunPolicy::Skip,
+            memory_archive_enabled: true,
+            memory_archive_schedule: "0 0 2 * * *".to_string(),
+            memory_archive_max_age_days: 30,
+            memory_archive_summary_max_sources: 8,
             channel_availability: ChannelAvailability::default(),
             dingtalk_accounts: BTreeMap::new(),
             telegram_configs: BTreeMap::new(),
@@ -268,10 +279,14 @@ impl BackgroundServices {
         Self {
             cron_worker,
             heartbeat_worker,
-            memory_archive_worker: runtime
-                .memory_db
-                .clone()
-                .map(MemoryArchiveWorker::new),
+            memory_archive_worker: if config.memory_archive_enabled {
+                runtime
+                    .memory_db
+                    .clone()
+                    .and_then(|memory_db| MemoryArchiveWorker::new(memory_db, &config).ok())
+            } else {
+                None
+            },
             config,
             runtime_drain_error: Mutex::new(None),
             dispatched_outbound_count: Mutex::new(0),
@@ -384,15 +399,21 @@ struct MemoryArchiveWorker {
 }
 
 impl MemoryArchiveWorker {
-    fn new(memory_db: Arc<dyn MemoryDb>) -> Self {
-        Self {
+    fn new(memory_db: Arc<dyn MemoryDb>, config: &BackgroundServiceConfig) -> Result<Self, String> {
+        Ok(Self {
             memory_db,
-            schedule: ScheduleSpec::from_kind_expr(CronScheduleKind::Cron, MEMORY_ARCHIVE_SCHEDULE)
-                .expect("memory archive schedule should be valid"),
+            schedule: ScheduleSpec::from_kind_expr(
+                CronScheduleKind::Cron,
+                &config.memory_archive_schedule,
+            )
+            .map_err(|err| err.to_string())?,
             timezone: system_timezone_name(),
             last_scheduled_run_ms: Mutex::new(None),
-            archive_config: LongTermArchiveConfig::default(),
-        }
+            archive_config: LongTermArchiveConfig {
+                max_age_days: config.memory_archive_max_age_days,
+                summary_max_sources: config.memory_archive_summary_max_sources,
+            },
+        })
     }
 
     async fn run_tick(&self) -> Result<bool, String> {
@@ -876,7 +897,7 @@ fn render_outbound_markdown(output: &OutboundMessage) -> String {
 mod tests {
     use super::{
         BackgroundDingtalkAccountConfig, BackgroundServiceConfig, ChannelAvailability,
-        FilteringInboundTransport, MEMORY_ARCHIVE_SCHEDULE, dispatch_outbound_message,
+        FilteringInboundTransport, dispatch_outbound_message,
         next_memory_archive_due_ms, resolve_outbound_account_id,
     };
     use klaw_channel::dingtalk::is_session_webhook_session_not_found_error;
@@ -986,7 +1007,7 @@ mod tests {
 
     #[test]
     fn memory_archive_due_ms_claims_today_run_after_starting_late() {
-        let schedule = ScheduleSpec::from_kind_expr(CronScheduleKind::Cron, MEMORY_ARCHIVE_SCHEDULE)
+        let schedule = ScheduleSpec::from_kind_expr(CronScheduleKind::Cron, "0 0 2 * * *")
             .expect("schedule should parse");
 
         let due = next_memory_archive_due_ms(
@@ -1002,7 +1023,7 @@ mod tests {
 
     #[test]
     fn memory_archive_due_ms_only_runs_once_per_day() {
-        let schedule = ScheduleSpec::from_kind_expr(CronScheduleKind::Cron, MEMORY_ARCHIVE_SCHEDULE)
+        let schedule = ScheduleSpec::from_kind_expr(CronScheduleKind::Cron, "0 0 2 * * *")
             .expect("schedule should parse");
 
         let first_due = next_memory_archive_due_ms(
@@ -1056,6 +1077,22 @@ mod tests {
                 },
             })
         );
+    }
+
+    #[test]
+    fn background_service_config_collects_memory_archive_settings() {
+        let mut app_config = AppConfig::default();
+        app_config.memory.archive.enabled = true;
+        app_config.memory.archive.schedule = "0 15 3 * * *".to_string();
+        app_config.memory.archive.max_age_days = 45;
+        app_config.memory.archive.summary_max_sources = 16;
+
+        let config = BackgroundServiceConfig::from_app_config(&app_config);
+
+        assert!(config.memory_archive_enabled);
+        assert_eq!(config.memory_archive_schedule, "0 15 3 * * *");
+        assert_eq!(config.memory_archive_max_age_days, 45);
+        assert_eq!(config.memory_archive_summary_max_sources, 16);
     }
 
     #[test]

--- a/klaw-tool/src/memory.rs
+++ b/klaw-tool/src/memory.rs
@@ -338,7 +338,7 @@ impl Tool for MemoryTool {
                         },
                         "metadata": {
                             "type": "object",
-                            "description": "Optional structured metadata for this memory. Supported governance fields: `kind` (`identity|preference|project_rule|workflow|fact|constraint`), optional `topic` for conflict replacement, and optional `supersedes` (string or string array). `status` is system-managed and only `active` is accepted on new writes.",
+                            "description": "Optional structured metadata for this memory. Supported governance fields: `kind` (`identity|preference|project_rule|workflow|fact|constraint`), optional `priority` (`high|medium|low`) to override prompt injection order, optional `topic` for conflict replacement, and optional `supersedes` (string or string array). `status` is system-managed and only `active` is accepted on new writes.",
                             "additionalProperties": true
                         },
                         "pinned": {


### PR DESCRIPTION
## Summary
- add priority-aware long-term memory lifecycle handling with automatic archiving and grouped summary rollups
- refresh runtime memory prompts after scheduled maintenance and keep retrieval/prompt visibility aligned for archived and superseded records
- update GUI and docs so summary, archive, and priority metadata are visible and documented end-to-end

## Test plan
- [x] `cargo test -p klaw-memory`
- [x] `cargo test -p klaw-runtime memory_archive_due_ms`
- [x] `cargo test -p klaw-gui governance_summary_renders_summary_and_archive_metadata`
- [x] `cargo check -p klaw-tool -p klaw-runtime -p klaw-gui`

Closes #221

Made with [Cursor](https://cursor.com)