### PR TITLE
feat(memory): use LLM to generate archive summaries instead of template concatenation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4381,6 +4381,7 @@ name = "klaw-memory"
 version = "0.14.2"
 dependencies = [
  "async-trait",
+ "futures-util",
  "klaw-config",
  "klaw-storage",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4388,6 +4388,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "uuid",
 ]
 

--- a/klaw-cli/src/commands/gui.rs
+++ b/klaw-cli/src/commands/gui.rs
@@ -562,6 +562,17 @@ impl GuiCommand {
                                                     let _ = response.send(result);
                                                 });
                                             }
+                                            Some(klaw_gui::RuntimeCommand::RunMemoryArchiveNow { response }) => {
+                                                let runtime = Arc::clone(&runtime);
+                                                let background = Arc::clone(&background);
+                                                tokio::task::spawn_local(async move {
+                                                    let result = background.run_memory_archive_now().await;
+                                                    if result.is_ok() {
+                                                        background.on_runtime_tick(runtime.as_ref()).await;
+                                                    }
+                                                    let _ = response.send(result);
+                                                });
+                                            }
                                             Some(klaw_gui::RuntimeCommand::GetEnvCheck { response }) => {
                                                 let env_check = runtime.env_check.clone();
                                                 let _ = response.send(env_check);

--- a/klaw-config/src/lib.rs
+++ b/klaw-config/src/lib.rs
@@ -913,6 +913,10 @@ pub struct MemoryArchiveConfig {
     pub max_age_days: i64,
     #[serde(default = "default_memory_archive_summary_max_sources")]
     pub summary_max_sources: usize,
+    #[serde(default = "default_memory_archive_summary_timeout_secs")]
+    pub summary_timeout_secs: u64,
+    #[serde(default = "default_memory_archive_command_timeout_secs")]
+    pub command_timeout_secs: u64,
 }
 
 impl Default for MemoryArchiveConfig {
@@ -922,6 +926,8 @@ impl Default for MemoryArchiveConfig {
             schedule: default_memory_archive_schedule(),
             max_age_days: default_memory_archive_max_age_days(),
             summary_max_sources: default_memory_archive_summary_max_sources(),
+            summary_timeout_secs: default_memory_archive_summary_timeout_secs(),
+            command_timeout_secs: default_memory_archive_command_timeout_secs(),
         }
     }
 }
@@ -968,6 +974,14 @@ fn default_memory_archive_max_age_days() -> i64 {
 
 fn default_memory_archive_summary_max_sources() -> usize {
     8
+}
+
+fn default_memory_archive_summary_timeout_secs() -> u64 {
+    60
+}
+
+fn default_memory_archive_command_timeout_secs() -> u64 {
+    120
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/klaw-gui/src/panels/memory.rs
+++ b/klaw-gui/src/panels/memory.rs
@@ -6,23 +6,23 @@ use egui_extras::{Column, TableBuilder};
 use egui_phosphor::regular;
 use klaw_config::{AppConfig, ConfigError, ConfigSnapshot, ConfigStore, EmbeddingConfig};
 use klaw_memory::{
-    LongTermArchiveConfig, LongTermMemoryKind, LongTermMemoryPromptOptions, LongTermMemoryStatus,
+    LongTermMemoryKind, LongTermMemoryPromptOptions, LongTermMemoryStatus,
     MemoryError, MemoryRecord, MemoryService, MemoryStats, SqliteMemoryService,
-    SqliteMemoryStatsService, SummaryGenerator, TemplateSummaryGenerator,
-    archive_stale_long_term_memories, is_summary_record,
+    SqliteMemoryStatsService, is_summary_record,
     read_long_term_archived_at, read_long_term_kind, read_long_term_priority,
     read_long_term_status, read_long_term_topic, render_long_term_memory_section,
 };
-use klaw_storage::{ChatRecord, SessionStorage, open_default_memory_db, open_default_store};
+use crate::runtime_bridge::{begin_run_memory_archive_now_request, RuntimeRequestHandle};
+use klaw_storage::{ChatRecord, SessionStorage, open_default_store};
 use serde_json::Value;
 use std::collections::HashSet;
 use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::{self, Receiver, TryRecvError};
+use tokio::runtime::Builder;
 use std::thread;
 use std::time::Duration as StdDuration;
 use time::{Duration, OffsetDateTime};
-use tokio::runtime::Builder;
 
 const POLL_INTERVAL: StdDuration = StdDuration::from_millis(150);
 
@@ -204,7 +204,7 @@ struct PendingSessionSearch {
 
 #[derive(Debug)]
 struct PendingArchiveRun {
-    receiver: Receiver<Result<String, String>>,
+    handle: RuntimeRequestHandle<String>,
 }
 
 struct PendingDelete {
@@ -621,12 +621,8 @@ impl MemoryPanel {
             return;
         }
         self.archive_run_loading = true;
-        let archive_config = LongTermArchiveConfig {
-            max_age_days: self.config.memory.archive.max_age_days,
-            summary_max_sources: self.config.memory.archive.summary_max_sources,
-        };
         self.archive_run_request = Some(PendingArchiveRun {
-            receiver: spawn_archive_run_task(archive_config),
+            handle: spawn_archive_run_task(),
         });
         notifications.info("Running long-term memory archive...");
     }
@@ -834,28 +830,22 @@ impl MemoryPanel {
     }
 
     fn poll_archive_run_request(&mut self, notifications: &mut NotificationCenter) {
-        let Some(request) = self.archive_run_request.take() else {
+        let Some(mut request) = self.archive_run_request.take() else {
             return;
         };
 
-        match request.receiver.try_recv() {
-            Ok(result) => match result {
-                Ok(message) => {
-                    self.archive_run_loading = false;
-                    notifications.success(message);
-                    self.refresh(notifications);
-                }
-                Err(err) => {
-                    self.archive_run_loading = false;
-                    notifications.error(format!("Archive run failed: {err}"));
-                }
-            },
-            Err(TryRecvError::Empty) => {
-                self.archive_run_request = Some(request);
-            }
-            Err(TryRecvError::Disconnected) => {
+        match request.handle.try_take_result() {
+            Some(Ok(message)) => {
                 self.archive_run_loading = false;
-                notifications.error("Archive task disconnected unexpectedly");
+                notifications.success(message);
+                self.refresh(notifications);
+            }
+            Some(Err(err)) => {
+                self.archive_run_loading = false;
+                notifications.error(format!("Archive run failed: {err}"));
+            }
+            None => {
+                self.archive_run_request = Some(request);
             }
         }
     }
@@ -1688,34 +1678,8 @@ where
     rx
 }
 
-fn spawn_archive_run_task(config: LongTermArchiveConfig) -> Receiver<Result<String, String>> {
-    let (tx, rx) = mpsc::channel();
-    thread::spawn(move || {
-        let result = Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .map_err(|err| format!("failed to build runtime: {err}"))
-            .and_then(|runtime| {
-                runtime.block_on(async move {
-                    let memory_db = open_default_memory_db()
-                        .await
-                        .map_err(|err| format!("failed to open memory db: {err}"))?;
-                    let summary_generator: std::sync::Arc<dyn SummaryGenerator> = std::sync::Arc::new(TemplateSummaryGenerator);
-                    let outcome =
-                        archive_stale_long_term_memories(std::sync::Arc::new(memory_db), config, summary_generator)
-                            .await
-                            .map_err(|err| format!("archive operation failed: {err}"))?;
-                    Ok(format!(
-                        "Archive complete: {} archived, {} summaries updated, {} skipped",
-                        outcome.archived_records,
-                        outcome.summary_records_upserted,
-                        outcome.skipped_records
-                    ))
-                })
-            });
-        let _ = tx.send(result);
-    });
-    rx
+fn spawn_archive_run_task() -> RuntimeRequestHandle<String> {
+    begin_run_memory_archive_now_request()
 }
 
 fn spawn_session_search_task(

--- a/klaw-gui/src/panels/memory.rs
+++ b/klaw-gui/src/panels/memory.rs
@@ -8,7 +8,8 @@ use klaw_config::{AppConfig, ConfigError, ConfigSnapshot, ConfigStore, Embedding
 use klaw_memory::{
     LongTermArchiveConfig, LongTermMemoryKind, LongTermMemoryPromptOptions, LongTermMemoryStatus,
     MemoryError, MemoryRecord, MemoryService, MemoryStats, SqliteMemoryService,
-    SqliteMemoryStatsService, archive_stale_long_term_memories, is_summary_record,
+    SqliteMemoryStatsService, SummaryGenerator, TemplateSummaryGenerator,
+    archive_stale_long_term_memories, is_summary_record,
     read_long_term_archived_at, read_long_term_kind, read_long_term_priority,
     read_long_term_status, read_long_term_topic, render_long_term_memory_section,
 };
@@ -1699,8 +1700,9 @@ fn spawn_archive_run_task(config: LongTermArchiveConfig) -> Receiver<Result<Stri
                     let memory_db = open_default_memory_db()
                         .await
                         .map_err(|err| format!("failed to open memory db: {err}"))?;
+                    let summary_generator: std::sync::Arc<dyn SummaryGenerator> = std::sync::Arc::new(TemplateSummaryGenerator);
                     let outcome =
-                        archive_stale_long_term_memories(std::sync::Arc::new(memory_db), config)
+                        archive_stale_long_term_memories(std::sync::Arc::new(memory_db), config, summary_generator)
                             .await
                             .map_err(|err| format!("archive operation failed: {err}"))?;
                     Ok(format!(

--- a/klaw-gui/src/panels/memory.rs
+++ b/klaw-gui/src/panels/memory.rs
@@ -621,8 +621,11 @@ impl MemoryPanel {
             return;
         }
         self.archive_run_loading = true;
+        let timeout = std::time::Duration::from_secs(
+            self.config.memory.archive.command_timeout_secs.max(30),
+        );
         self.archive_run_request = Some(PendingArchiveRun {
-            handle: spawn_archive_run_task(),
+            handle: spawn_archive_run_task(timeout),
         });
         notifications.info("Running long-term memory archive...");
     }
@@ -1678,8 +1681,8 @@ where
     rx
 }
 
-fn spawn_archive_run_task() -> RuntimeRequestHandle<String> {
-    begin_run_memory_archive_now_request()
+fn spawn_archive_run_task(timeout: std::time::Duration) -> RuntimeRequestHandle<String> {
+    begin_run_memory_archive_now_request(timeout)
 }
 
 fn spawn_session_search_task(

--- a/klaw-gui/src/runtime_bridge.rs
+++ b/klaw-gui/src/runtime_bridge.rs
@@ -106,6 +106,9 @@ pub enum RuntimeCommand {
         heartbeat_id: String,
         response: mpsc::Sender<Result<String, String>>,
     },
+    RunMemoryArchiveNow {
+        response: mpsc::Sender<Result<String, String>>,
+    },
     GetEnvCheck {
         response: mpsc::Sender<EnvironmentCheckReport>,
     },
@@ -391,6 +394,27 @@ pub fn request_run_cron_now(cron_id: &str) -> Result<String, String> {
 
 pub fn begin_run_cron_now_request(cron_id: String) -> RuntimeRequestHandle<String> {
     spawn_request(move || request_run_cron_now(&cron_id))
+}
+
+pub fn request_run_memory_archive_now() -> Result<String, String> {
+    let (response_tx, response_rx) = mpsc::channel();
+    let sender = sender_slot()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone()
+        .ok_or_else(|| "runtime command channel is not available".to_string())?;
+
+    sender
+        .send(RuntimeCommand::RunMemoryArchiveNow {
+            response: response_tx,
+        })
+        .map_err(|_| "failed to send runtime command".to_string())?;
+
+    recv_response(response_rx, RUNTIME_ACTION_TIMEOUT, "memory archive")?
+}
+
+pub fn begin_run_memory_archive_now_request() -> RuntimeRequestHandle<String> {
+    spawn_request(move || request_run_memory_archive_now())
 }
 
 pub fn request_run_heartbeat_now(heartbeat_id: &str) -> Result<String, String> {

--- a/klaw-gui/src/runtime_bridge.rs
+++ b/klaw-gui/src/runtime_bridge.rs
@@ -140,6 +140,7 @@ static LOG_BRIDGE: OnceLock<Mutex<Option<Arc<GuiLogBridge>>>> = OnceLock::new();
 const RUNTIME_STATUS_TIMEOUT: Duration = Duration::from_secs(10);
 const RUNTIME_ACTION_TIMEOUT: Duration = Duration::from_secs(5);
 const RUNTIME_MCP_RESTART_TIMEOUT: Duration = Duration::from_secs(90);
+const RUNTIME_MEMORY_ARCHIVE_TIMEOUT: Duration = Duration::from_secs(120);
 const LOG_BRIDGE_MAX_CHUNKS: usize = 8_192;
 
 fn sender_slot() -> &'static Mutex<Option<UnboundedSender<RuntimeCommand>>> {
@@ -410,7 +411,7 @@ pub fn request_run_memory_archive_now() -> Result<String, String> {
         })
         .map_err(|_| "failed to send runtime command".to_string())?;
 
-    recv_response(response_rx, RUNTIME_ACTION_TIMEOUT, "memory archive")?
+    recv_response(response_rx, RUNTIME_MEMORY_ARCHIVE_TIMEOUT, "memory archive")?
 }
 
 pub fn begin_run_memory_archive_now_request() -> RuntimeRequestHandle<String> {

--- a/klaw-gui/src/runtime_bridge.rs
+++ b/klaw-gui/src/runtime_bridge.rs
@@ -140,7 +140,6 @@ static LOG_BRIDGE: OnceLock<Mutex<Option<Arc<GuiLogBridge>>>> = OnceLock::new();
 const RUNTIME_STATUS_TIMEOUT: Duration = Duration::from_secs(10);
 const RUNTIME_ACTION_TIMEOUT: Duration = Duration::from_secs(5);
 const RUNTIME_MCP_RESTART_TIMEOUT: Duration = Duration::from_secs(90);
-const RUNTIME_MEMORY_ARCHIVE_TIMEOUT: Duration = Duration::from_secs(120);
 const LOG_BRIDGE_MAX_CHUNKS: usize = 8_192;
 
 fn sender_slot() -> &'static Mutex<Option<UnboundedSender<RuntimeCommand>>> {
@@ -397,7 +396,7 @@ pub fn begin_run_cron_now_request(cron_id: String) -> RuntimeRequestHandle<Strin
     spawn_request(move || request_run_cron_now(&cron_id))
 }
 
-pub fn request_run_memory_archive_now() -> Result<String, String> {
+pub fn request_run_memory_archive_now(timeout: Duration) -> Result<String, String> {
     let (response_tx, response_rx) = mpsc::channel();
     let sender = sender_slot()
         .lock()
@@ -411,11 +410,11 @@ pub fn request_run_memory_archive_now() -> Result<String, String> {
         })
         .map_err(|_| "failed to send runtime command".to_string())?;
 
-    recv_response(response_rx, RUNTIME_MEMORY_ARCHIVE_TIMEOUT, "memory archive")?
+    recv_response(response_rx, timeout, "memory archive")?
 }
 
-pub fn begin_run_memory_archive_now_request() -> RuntimeRequestHandle<String> {
-    spawn_request(move || request_run_memory_archive_now())
+pub fn begin_run_memory_archive_now_request(timeout: Duration) -> RuntimeRequestHandle<String> {
+    spawn_request(move || request_run_memory_archive_now(timeout))
 }
 
 pub fn request_run_heartbeat_now(heartbeat_id: &str) -> Result<String, String> {

--- a/klaw-memory/CHANGELOG.md
+++ b/klaw-memory/CHANGELOG.md
@@ -1,5 +1,21 @@
 # CHANGELOG
 
+## 2026-04-24
+
+### Added
+
+- `SummaryGenerator` async trait: pluggable strategy for generating archive summary content
+- `TemplateSummaryGenerator`: default implementation that preserves the existing template-based concatenation as fallback
+- `ArchiveGroupKey` is now public, enabling external crates to implement custom `SummaryGenerator` implementations
+- `archive_stale_long_term_memories` accepts `Arc<dyn SummaryGenerator>` parameter; LLM call failures automatically fall back to template concatenation with a warn log
+
+### Changed
+
+- `archive_stale_long_term_memories` signature now requires `summary_generator: Arc<dyn SummaryGenerator>` parameter; all callers (runtime, GUI, tests) must pass the appropriate implementation
+- `klaw-memory` no longer directly owns summary content generation logic; the strategy is injected by the caller
+
+
+
 ## 2026-05-12
 
 ### Changed

--- a/klaw-memory/Cargo.toml
+++ b/klaw-memory/Cargo.toml
@@ -6,6 +6,7 @@ version.workspace = true
 
 [dependencies]
 async-trait = { workspace = true }
+futures-util = { workspace = true }
 klaw-config = { workspace = true }
 klaw-storage = { workspace = true }
 reqwest = { workspace = true }

--- a/klaw-memory/Cargo.toml
+++ b/klaw-memory/Cargo.toml
@@ -12,6 +12,7 @@ reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+tracing = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]

--- a/klaw-memory/src/lib.rs
+++ b/klaw-memory/src/lib.rs
@@ -19,7 +19,8 @@ pub use governance::{
     read_topic as read_long_term_topic,
 };
 pub use maintenance::{
-    LongTermArchiveConfig, LongTermArchiveOutcome, archive_stale_long_term_memories,
+    ArchiveGroupKey, LongTermArchiveConfig, LongTermArchiveOutcome, SummaryGenerator,
+    TemplateSummaryGenerator, archive_stale_long_term_memories,
 };
 pub use prompt::{LongTermMemoryPromptOptions, render_long_term_memory_section};
 pub use provider::{OpenAiEmbeddingProvider, build_embedding_provider_from_config};

--- a/klaw-memory/src/maintenance.rs
+++ b/klaw-memory/src/maintenance.rs
@@ -11,6 +11,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 use tracing::warn;
 use uuid::Uuid;
+use futures_util::future::join_all;
 
 use crate::util::now_ms;
 
@@ -102,7 +103,7 @@ pub async fn archive_stale_long_term_memories(
     }
 
     let stats = SqliteMemoryStatsService::new(db.clone());
-    let service = SqliteMemoryService::new(db, None).await?;
+    let service = Arc::new(SqliteMemoryService::new(db, None).await?);
     let records = stats.list_scope_records("long_term").await?;
     let now = now_ms();
     let cutoff_ms = now.saturating_sub(config.max_age_days.saturating_mul(24 * 60 * 60 * 1000));
@@ -137,7 +138,15 @@ pub async fn archive_stale_long_term_memories(
         }
     }
 
-    for (group, mut candidates) in candidate_groups {
+    // Process each group in parallel: each group independently generates a
+    // summary and writes to DB, so there are no data dependencies between groups.
+    let group_futures = candidate_groups.into_iter().map(|(group, mut candidates)| {
+        let service = service.clone();
+        let summary_generator = summary_generator.clone();
+        let max_sources = config.summary_max_sources;
+        let existing_summary = summaries_by_group.get(&group).cloned();
+        let source_records_by_id = &source_records_by_id;
+
         candidates.sort_by(|a, b| {
             a.updated_at_ms
                 .cmp(&b.updated_at_ms)
@@ -145,7 +154,6 @@ pub async fn archive_stale_long_term_memories(
                 .then_with(|| a.id.cmp(&b.id))
         });
 
-        let existing_summary = summaries_by_group.get(&group).cloned();
         let summary_id = existing_summary
             .as_ref()
             .map(|record| record.id.clone())
@@ -160,38 +168,51 @@ pub async fn archive_stale_long_term_memories(
 
         let summary_metadata =
             build_summary_metadata(&group, &source_ids, now, existing_summary.as_ref());
-        let summary_content = summary_generator
-            .generate_summary(&group, &source_records, config.summary_max_sources)
-            .await
-            .unwrap_or_else(|err| {
-                warn!(error = %err, "summary generator failed, falling back to template");
-                build_summary_content(&group, &source_records, config.summary_max_sources)
-            });
 
-        service
-            .upsert(UpsertMemoryInput {
-                id: Some(summary_id.clone()),
-                scope: "long_term".to_string(),
-                content: summary_content,
-                metadata: Value::Object(summary_metadata),
-                pinned: false,
-            })
-            .await?;
-        outcome.summary_records_upserted += 1;
+        async move {
+            let summary_content = summary_generator
+                .generate_summary(&group, &source_records, max_sources)
+                .await
+                .unwrap_or_else(|err| {
+                    warn!(error = %err, "summary generator failed, falling back to template");
+                    build_summary_content(&group, &source_records, max_sources)
+                });
 
-        for record in candidates {
-            let metadata = archive_metadata(&record, now, &summary_id);
             service
                 .upsert(UpsertMemoryInput {
-                    id: Some(record.id.clone()),
-                    scope: record.scope.clone(),
-                    content: record.content.clone(),
-                    metadata: Value::Object(metadata),
-                    pinned: record.pinned,
+                    id: Some(summary_id.clone()),
+                    scope: "long_term".to_string(),
+                    content: summary_content,
+                    metadata: Value::Object(summary_metadata),
+                    pinned: false,
                 })
                 .await?;
-            outcome.archived_records += 1;
+
+            let mut archived_count = 0;
+            for record in candidates {
+                let metadata = archive_metadata(&record, now, &summary_id);
+                service
+                    .upsert(UpsertMemoryInput {
+                        id: Some(record.id.clone()),
+                        scope: record.scope.clone(),
+                        content: record.content.clone(),
+                        metadata: Value::Object(metadata),
+                        pinned: record.pinned,
+                    })
+                    .await?;
+                archived_count += 1;
+            }
+
+            Ok::<(usize, usize), MemoryError>((1, archived_count))
         }
+    });
+
+    // Collect results from all parallel group tasks.
+    let group_results = join_all(group_futures).await;
+    for result in group_results {
+        let (summary_count, archived_count) = result?;
+        outcome.summary_records_upserted += summary_count;
+        outcome.archived_records += archived_count;
     }
 
     Ok(outcome)

--- a/klaw-memory/src/maintenance.rs
+++ b/klaw-memory/src/maintenance.rs
@@ -4,13 +4,54 @@ use crate::{
     is_inactive_long_term_record, is_summary_record, normalize_long_term_content,
     read_long_term_kind, read_long_term_topic,
 };
+use async_trait::async_trait;
 use klaw_storage::MemoryDb;
 use serde_json::{Map, Value, json};
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
+use tracing::warn;
 use uuid::Uuid;
 
 use crate::util::now_ms;
+
+/// Strategy for generating summary content when archiving stale long-term memories.
+///
+/// The default [`TemplateSummaryGenerator`] concatenates source snippets into a
+/// structured template string. Consumers that want richer, LLM-generated summaries
+/// should provide their own implementation (e.g. one that calls an LLM provider).
+#[async_trait]
+pub trait SummaryGenerator: Send + Sync {
+    /// Generate a summary string for a group of archived records.
+    ///
+    /// - `group` identifies the kind + topic of the records being summarized.
+    /// - `source_records` are the original records that will be archived.
+    /// - `max_sources` limits how many source entries to include.
+    async fn generate_summary(
+        &self,
+        group: &ArchiveGroupKey,
+        source_records: &[MemoryRecord],
+        max_sources: usize,
+    ) -> Result<String, MemoryError>;
+}
+
+/// Fallback summary generator that uses the original template-based concatenation.
+///
+/// This does not call any LLM; it produces a deterministic string like:
+///
+/// > Past notes on preference (3 entries): Default language is Chinese; Use concise replies; +2 more
+pub struct TemplateSummaryGenerator;
+
+#[async_trait]
+impl SummaryGenerator for TemplateSummaryGenerator {
+    async fn generate_summary(
+        &self,
+        group: &ArchiveGroupKey,
+        source_records: &[MemoryRecord],
+        max_sources: usize,
+    ) -> Result<String, MemoryError> {
+        Ok(build_summary_content(group, source_records, max_sources))
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct LongTermArchiveConfig {
@@ -34,15 +75,20 @@ pub struct LongTermArchiveOutcome {
     pub skipped_records: usize,
 }
 
+/// Key used to group records for archival summary generation.
+///
+/// Records sharing the same `kind` and `topic` are grouped together
+/// and summarized as a single roll-up entry.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-struct ArchiveGroupKey {
-    kind: LongTermMemoryKind,
-    topic: Option<String>,
+pub struct ArchiveGroupKey {
+    pub kind: LongTermMemoryKind,
+    pub topic: Option<String>,
 }
 
 pub async fn archive_stale_long_term_memories(
     db: Arc<dyn MemoryDb>,
     config: LongTermArchiveConfig,
+    summary_generator: Arc<dyn SummaryGenerator>,
 ) -> Result<LongTermArchiveOutcome, MemoryError> {
     if config.max_age_days <= 0 {
         return Err(MemoryError::InvalidQuery(
@@ -114,8 +160,13 @@ pub async fn archive_stale_long_term_memories(
 
         let summary_metadata =
             build_summary_metadata(&group, &source_ids, now, existing_summary.as_ref());
-        let summary_content =
-            build_summary_content(&group, &source_records, config.summary_max_sources);
+        let summary_content = summary_generator
+            .generate_summary(&group, &source_records, config.summary_max_sources)
+            .await
+            .unwrap_or_else(|err| {
+                warn!(error = %err, "summary generator failed, falling back to template");
+                build_summary_content(&group, &source_records, config.summary_max_sources)
+            });
 
         service
             .upsert(UpsertMemoryInput {

--- a/klaw-memory/src/maintenance.rs
+++ b/klaw-memory/src/maintenance.rs
@@ -86,6 +86,15 @@ pub struct ArchiveGroupKey {
     pub topic: Option<String>,
 }
 
+/// Intermediate result from Phase 1 (parallel summary generation).
+/// Holds all data needed for Phase 2 (sequential DB writes).
+struct GroupArchivePlan {
+    summary_id: String,
+    summary_content: String,
+    summary_metadata: Map<String, Value>,
+    candidates: Vec<MemoryRecord>,
+}
+
 pub async fn archive_stale_long_term_memories(
     db: Arc<dyn MemoryDb>,
     config: LongTermArchiveConfig,
@@ -103,7 +112,7 @@ pub async fn archive_stale_long_term_memories(
     }
 
     let stats = SqliteMemoryStatsService::new(db.clone());
-    let service = Arc::new(SqliteMemoryService::new(db, None).await?);
+    let service = SqliteMemoryService::new(db, None).await?;
     let records = stats.list_scope_records("long_term").await?;
     let now = now_ms();
     let cutoff_ms = now.saturating_sub(config.max_age_days.saturating_mul(24 * 60 * 60 * 1000));
@@ -138,14 +147,13 @@ pub async fn archive_stale_long_term_memories(
         }
     }
 
-    // Process each group in parallel: each group independently generates a
-    // summary and writes to DB, so there are no data dependencies between groups.
+    // Phase 1: Generate all summary content in parallel (no DB writes).
+    // Each group's LLM call is independent, so we run them concurrently
+    // to reduce total wall-clock time from N×single_call to max(single_calls).
     let group_futures = candidate_groups.into_iter().map(|(group, mut candidates)| {
-        let service = service.clone();
         let summary_generator = summary_generator.clone();
         let max_sources = config.summary_max_sources;
         let existing_summary = summaries_by_group.get(&group).cloned();
-        let source_records_by_id = &source_records_by_id;
 
         candidates.sort_by(|a, b| {
             a.updated_at_ms
@@ -178,41 +186,46 @@ pub async fn archive_stale_long_term_memories(
                     build_summary_content(&group, &source_records, max_sources)
                 });
 
-            service
-                .upsert(UpsertMemoryInput {
-                    id: Some(summary_id.clone()),
-                    scope: "long_term".to_string(),
-                    content: summary_content,
-                    metadata: Value::Object(summary_metadata),
-                    pinned: false,
-                })
-                .await?;
-
-            let mut archived_count = 0;
-            for record in candidates {
-                let metadata = archive_metadata(&record, now, &summary_id);
-                service
-                    .upsert(UpsertMemoryInput {
-                        id: Some(record.id.clone()),
-                        scope: record.scope.clone(),
-                        content: record.content.clone(),
-                        metadata: Value::Object(metadata),
-                        pinned: record.pinned,
-                    })
-                    .await?;
-                archived_count += 1;
-            }
-
-            Ok::<(usize, usize), MemoryError>((1, archived_count))
+            Ok::<GroupArchivePlan, MemoryError>(GroupArchivePlan {
+                summary_id,
+                summary_content,
+                summary_metadata,
+                candidates,
+            })
         }
     });
 
-    // Collect results from all parallel group tasks.
-    let group_results = join_all(group_futures).await;
-    for result in group_results {
-        let (summary_count, archived_count) = result?;
-        outcome.summary_records_upserted += summary_count;
-        outcome.archived_records += archived_count;
+    let group_plans = join_all(group_futures).await;
+
+    // Phase 2: Write all results to DB sequentially.
+    // DB writes are fast local operations; serializing them avoids
+    // SQLite write contention and keeps the transaction order predictable.
+    for plan_result in group_plans {
+        let plan = plan_result?;
+        service
+            .upsert(UpsertMemoryInput {
+                id: Some(plan.summary_id.clone()),
+                scope: "long_term".to_string(),
+                content: plan.summary_content,
+                metadata: Value::Object(plan.summary_metadata),
+                pinned: false,
+            })
+            .await?;
+        outcome.summary_records_upserted += 1;
+
+        for record in plan.candidates {
+            let metadata = archive_metadata(&record, now, &plan.summary_id);
+            service
+                .upsert(UpsertMemoryInput {
+                    id: Some(record.id.clone()),
+                    scope: record.scope.clone(),
+                    content: record.content.clone(),
+                    metadata: Value::Object(metadata),
+                    pinned: record.pinned,
+                })
+                .await?;
+            outcome.archived_records += 1;
+        }
     }
 
     Ok(outcome)

--- a/klaw-memory/src/tests.rs
+++ b/klaw-memory/src/tests.rs
@@ -3,6 +3,7 @@ use crate::{
     SqliteMemoryService, SqliteMemoryStatsService, UpsertMemoryInput,
     archive_stale_long_term_memories, build_embedding_provider_from_config,
     util::{now_ms, rrf_score},
+    TemplateSummaryGenerator, SummaryGenerator,
 };
 use async_trait::async_trait;
 use klaw_config::{AppConfig, ModelProviderConfig};
@@ -43,6 +44,10 @@ async fn create_db() -> Arc<dyn MemoryDb> {
     let root = std::env::temp_dir().join(format!("klaw-memory-test-{suffix}-{}", now_ms()));
     let paths = StoragePaths::from_root(root);
     Arc::new(DefaultMemoryDb::open(paths).await.expect("open memory db"))
+}
+
+fn template_generator() -> Arc<dyn SummaryGenerator> {
+    Arc::new(TemplateSummaryGenerator)
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -214,6 +219,7 @@ async fn archive_stale_long_term_memories_archives_low_priority_records_and_crea
             max_age_days: 30,
             summary_max_sources: 8,
         },
+        template_generator(),
     )
     .await
     .expect("archive should succeed");
@@ -317,6 +323,7 @@ async fn archive_stale_long_term_memories_reuses_existing_summary_for_same_topic
             max_age_days: 30,
             summary_max_sources: 8,
         },
+        template_generator(),
     )
     .await
     .expect("archive should succeed");
@@ -333,6 +340,92 @@ async fn archive_stale_long_term_memories_reuses_existing_summary_for_same_topic
         summary.metadata["source_ids"],
         serde_json::json!(["old-1", "old-2"])
     );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn archive_falls_back_to_template_when_summary_generator_fails() {
+    struct FailingSummaryGenerator;
+
+    #[async_trait]
+    impl SummaryGenerator for FailingSummaryGenerator {
+        async fn generate_summary(
+            &self,
+            _group: &crate::ArchiveGroupKey,
+            _source_records: &[crate::MemoryRecord],
+            _max_sources: usize,
+        ) -> Result<String, crate::MemoryError> {
+            Err(crate::MemoryError::CapabilityUnavailable(
+                "LLM provider unavailable".to_string(),
+            ))
+        }
+    }
+
+    let db = create_db().await;
+    let service = SqliteMemoryService::new(db.clone(), Some(Arc::new(MockEmbeddingProvider)))
+        .await
+        .expect("service should init");
+    let now = now_ms();
+    let forty_days_ms = 40_i64 * 24 * 60 * 60 * 1000;
+
+    let _ = service
+        .upsert(UpsertMemoryInput {
+            id: Some("old-fail-1".to_string()),
+            scope: "long_term".to_string(),
+            content: "Used vim for editing.".to_string(),
+            metadata: serde_json::json!({
+                "kind": "preference",
+                "priority": "low",
+                "topic": "editor",
+                "status": "active",
+            }),
+            pinned: false,
+        })
+        .await
+        .expect("record should upsert");
+
+    let _ = db
+        .execute(
+            "UPDATE memories SET updated_at_ms = ?1, created_at_ms = ?1 WHERE id = ?2",
+            &[
+                klaw_storage::DbValue::Integer(now - forty_days_ms),
+                klaw_storage::DbValue::Text("old-fail-1".to_string()),
+            ],
+        )
+        .await
+        .expect("timestamps should update");
+
+    let outcome = archive_stale_long_term_memories(
+        db.clone(),
+        LongTermArchiveConfig {
+            max_age_days: 30,
+            summary_max_sources: 8,
+        },
+        Arc::new(FailingSummaryGenerator),
+    )
+    .await
+    .expect("archive should succeed even with failing generator");
+
+    assert_eq!(outcome.archived_records, 1);
+    assert_eq!(outcome.summary_records_upserted, 1);
+
+    let records = SqliteMemoryStatsService::new(db)
+        .list_scope_records("long_term")
+        .await
+        .expect("records should load");
+
+    let summary = records
+        .iter()
+        .find(|record| {
+            record
+                .metadata
+                .get("summary")
+                .and_then(serde_json::Value::as_bool)
+                == Some(true)
+        })
+        .expect("summary record should exist from template fallback");
+
+    // The summary content should be the template-based fallback, not an LLM output.
+    assert!(summary.content.contains("Past notes on"));
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/klaw-runtime/src/service_loop.rs
+++ b/klaw-runtime/src/service_loop.rs
@@ -33,6 +33,7 @@ type StdioCronWorker = CronWorker<DefaultSessionStore, FilteringInboundTransport
 type StdioHeartbeatWorker = HeartbeatWorker<DefaultSessionStore, FilteringInboundTransport>;
 const OUTBOUND_DISPATCH_TIMEOUT: Duration = Duration::from_secs(10);
 const MEMORY_ARCHIVE_LOOKBACK_MS: i64 = 24 * 60 * 60 * 1000;
+const MEMORY_ARCHIVE_SUMMARY_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct ChannelAvailability {
@@ -498,9 +499,9 @@ impl SummaryGenerator for LlmSummaryGenerator {
                 tool_call_id: None,
             },
         ];
-        let response = self
-            .provider
-            .chat(
+        let response = tokio::time::timeout(
+            MEMORY_ARCHIVE_SUMMARY_TIMEOUT,
+            self.provider.chat(
                 messages,
                 Vec::new(),
                 Some(&self.model),
@@ -521,13 +522,24 @@ impl SummaryGenerator for LlmSummaryGenerator {
                     user: None,
                     service_tier: None,
                 },
+            ),
+        )
+        .await
+        .map_err(|_| {
+            klaw_memory::MemoryError::CapabilityUnavailable(
+                format!(
+                    "LLM summary call timed out after {}s for kind={} topic={}",
+                    MEMORY_ARCHIVE_SUMMARY_TIMEOUT.as_secs(),
+                    group.kind.as_str(),
+                    group.topic.as_deref().unwrap_or("none"),
+                ),
             )
-            .await
-            .map_err(|err| {
-                klaw_memory::MemoryError::CapabilityUnavailable(format!(
-                    "LLM summary call failed: {err}"
-                ))
-            })?;
+        })?
+        .map_err(|err| {
+            klaw_memory::MemoryError::CapabilityUnavailable(format!(
+                "LLM summary call failed: {err}"
+            ))
+        })?;
         let content = response.content.trim().to_string();
         debug!(
             kind = group.kind.as_str(),

--- a/klaw-runtime/src/service_loop.rs
+++ b/klaw-runtime/src/service_loop.rs
@@ -347,6 +347,13 @@ impl BackgroundServices {
             .map_err(|err| err.to_string())
     }
 
+    pub async fn run_memory_archive_now(&self) -> Result<String, String> {
+        match &self.memory_archive_worker {
+            Some(worker) => worker.run_now().await,
+            None => Err("memory archive worker is not enabled".to_string()),
+        }
+    }
+
     pub async fn on_runtime_tick(&self, runtime: &RuntimeBundle) {
         if let Err(err) = drain_runtime_queue(runtime, self.config.runtime_drain_batch).await {
             let message = err.to_string();
@@ -468,6 +475,13 @@ impl SummaryGenerator for LlmSummaryGenerator {
         max_sources: usize,
     ) -> Result<String, klaw_memory::MemoryError> {
         let user_prompt = memory_summary_user_prompt(group, source_records, max_sources);
+        debug!(
+            kind = group.kind.as_str(),
+            topic = group.topic.as_deref().unwrap_or("none"),
+            model = %self.model,
+            source_count = source_records.len(),
+            "calling LLM for memory archive summary"
+        );
         let messages = vec![
             LlmMessage {
                 role: "system".to_string(),
@@ -515,6 +529,12 @@ impl SummaryGenerator for LlmSummaryGenerator {
                 ))
             })?;
         let content = response.content.trim().to_string();
+        debug!(
+            kind = group.kind.as_str(),
+            topic = group.topic.as_deref().unwrap_or("none"),
+            summary_len = content.len(),
+            "LLM memory archive summary received"
+        );
         if content.is_empty() {
             return Err(klaw_memory::MemoryError::CapabilityUnavailable(
                 "LLM summary returned empty content".to_string(),
@@ -594,6 +614,29 @@ impl MemoryArchiveWorker {
             "memory archive tick completed"
         );
         Ok(outcome.archived_records > 0 || outcome.summary_records_upserted > 0)
+    }
+
+    /// Force-run archive now, bypassing the schedule check.
+    async fn run_now(&self) -> Result<String, String> {
+        let outcome = archive_stale_long_term_memories(
+            self.memory_db.clone(),
+            self.archive_config,
+            self.summary_generator.clone(),
+        )
+        .await
+        .map_err(|err| err.to_string())?;
+        debug!(
+            archived_records = outcome.archived_records,
+            summary_records_upserted = outcome.summary_records_upserted,
+            skipped_records = outcome.skipped_records,
+            "memory archive run-now completed"
+        );
+        Ok(format!(
+            "{} archived, {} summaries updated, {} skipped",
+            outcome.archived_records,
+            outcome.summary_records_upserted,
+            outcome.skipped_records
+        ))
     }
 }
 

--- a/klaw-runtime/src/service_loop.rs
+++ b/klaw-runtime/src/service_loop.rs
@@ -33,7 +33,7 @@ type StdioCronWorker = CronWorker<DefaultSessionStore, FilteringInboundTransport
 type StdioHeartbeatWorker = HeartbeatWorker<DefaultSessionStore, FilteringInboundTransport>;
 const OUTBOUND_DISPATCH_TIMEOUT: Duration = Duration::from_secs(10);
 const MEMORY_ARCHIVE_LOOKBACK_MS: i64 = 24 * 60 * 60 * 1000;
-const MEMORY_ARCHIVE_SUMMARY_TIMEOUT: Duration = Duration::from_secs(60);
+
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct ChannelAvailability {
@@ -107,6 +107,8 @@ pub struct BackgroundServiceConfig {
     pub memory_archive_schedule: String,
     pub memory_archive_max_age_days: i64,
     pub memory_archive_summary_max_sources: usize,
+    pub memory_archive_summary_timeout_secs: u64,
+    pub memory_archive_command_timeout_secs: u64,
     channel_availability: ChannelAvailability,
     pub dingtalk_accounts: BTreeMap<String, BackgroundDingtalkAccountConfig>,
     pub telegram_configs: BTreeMap<String, klaw_config::TelegramConfig>,
@@ -127,6 +129,8 @@ impl BackgroundServiceConfig {
             memory_archive_schedule: config.memory.archive.schedule.clone(),
             memory_archive_max_age_days: config.memory.archive.max_age_days,
             memory_archive_summary_max_sources: config.memory.archive.summary_max_sources,
+            memory_archive_summary_timeout_secs: config.memory.archive.summary_timeout_secs,
+            memory_archive_command_timeout_secs: config.memory.archive.command_timeout_secs,
             channel_availability: ChannelAvailability::from_app_config(config),
             dingtalk_accounts: config
                 .channels
@@ -169,6 +173,8 @@ impl Default for BackgroundServiceConfig {
             memory_archive_schedule: "0 0 2 * * *".to_string(),
             memory_archive_max_age_days: 30,
             memory_archive_summary_max_sources: 8,
+            memory_archive_summary_timeout_secs: 60,
+            memory_archive_command_timeout_secs: 120,
             channel_availability: ChannelAvailability::default(),
             dingtalk_accounts: BTreeMap::new(),
             telegram_configs: BTreeMap::new(),
@@ -432,6 +438,7 @@ struct LlmSummaryGenerator {
     provider: Arc<dyn LlmProvider>,
     model: String,
     max_output_tokens: u32,
+    summary_timeout: Duration,
 }
 
 fn memory_summary_user_prompt(
@@ -500,7 +507,7 @@ impl SummaryGenerator for LlmSummaryGenerator {
             },
         ];
         let response = tokio::time::timeout(
-            MEMORY_ARCHIVE_SUMMARY_TIMEOUT,
+            self.summary_timeout,
             self.provider.chat(
                 messages,
                 Vec::new(),
@@ -529,7 +536,7 @@ impl SummaryGenerator for LlmSummaryGenerator {
             klaw_memory::MemoryError::CapabilityUnavailable(
                 format!(
                     "LLM summary call timed out after {}s for kind={} topic={}",
-                    MEMORY_ARCHIVE_SUMMARY_TIMEOUT.as_secs(),
+                    self.summary_timeout.as_secs(),
                     group.kind.as_str(),
                     group.topic.as_deref().unwrap_or("none"),
                 ),
@@ -572,10 +579,12 @@ impl MemoryArchiveWorker {
         default_provider: Arc<dyn LlmProvider>,
         default_model: String,
     ) -> Result<Self, String> {
+        let summary_timeout = Duration::from_secs(config.memory_archive_summary_timeout_secs);
         let summary_generator: Arc<dyn SummaryGenerator> = Arc::new(LlmSummaryGenerator {
             provider: default_provider,
             model: default_model,
             max_output_tokens: 120,
+            summary_timeout,
         });
         Ok(Self {
             memory_db,

--- a/klaw-runtime/src/service_loop.rs
+++ b/klaw-runtime/src/service_loop.rs
@@ -13,7 +13,8 @@ use klaw_core::{
 use klaw_cron::{CronScheduleKind, CronWorker, CronWorkerConfig, MissedRunPolicy, ScheduleSpec};
 use klaw_gateway::{GatewayWebsocketServerFrame, OutboundEvent};
 use klaw_heartbeat::{HeartbeatWorker, HeartbeatWorkerConfig, should_suppress_output};
-use klaw_memory::{LongTermArchiveConfig, archive_stale_long_term_memories};
+use klaw_memory::{LongTermArchiveConfig, SummaryGenerator, archive_stale_long_term_memories};
+use klaw_llm::{ChatOptions, LlmMessage, LlmProvider};
 use klaw_storage::{ChatRecord, DefaultSessionStore, MemoryDb, SessionStorage};
 use klaw_util::system_timezone_name;
 use serde_json::Value;
@@ -280,10 +281,19 @@ impl BackgroundServices {
             cron_worker,
             heartbeat_worker,
             memory_archive_worker: if config.memory_archive_enabled {
+                let provider_runtime = runtime.runtime.provider_runtime_snapshot();
                 runtime
                     .memory_db
                     .clone()
-                    .and_then(|memory_db| MemoryArchiveWorker::new(memory_db, &config).ok())
+                    .and_then(|memory_db| {
+                        MemoryArchiveWorker::new(
+                            memory_db,
+                            &config,
+                            provider_runtime.default_provider,
+                            provider_runtime.default_model,
+                        )
+                        .ok()
+                    })
             } else {
                 None
             },
@@ -390,16 +400,151 @@ impl BackgroundServices {
     }
 }
 
+// ---------------------------------------------------------------------------
+// LLM-backed summary generator
+// ---------------------------------------------------------------------------
+
+/// System prompt for the LLM summary call.
+const MEMORY_SUMMARY_SYSTEM_PROMPT: &str = "You are a memory archivist. Your task is to condense a list of past notes about a specific topic into a single concise summary sentence or short paragraph.
+
+Rules:
+- Preserve all distinct factual claims; do not drop information.
+- Merge overlapping or redundant statements into one.
+- Keep the summary under 80 words.
+- Use neutral, factual language.
+- Do not add information that was not in the source notes.
+- Output only the summary text, without preamble or labels.";
+
+/// LLM-backed summary generator for memory archiving.
+///
+/// Uses a low-cost, fast model call to produce a concise natural-language summary
+/// of archived memory records. Falls back gracefully on provider errors (handled
+/// by the `archive_stale_long_term_memories` caller).
+struct LlmSummaryGenerator {
+    provider: Arc<dyn LlmProvider>,
+    model: String,
+    max_output_tokens: u32,
+}
+
+fn memory_summary_user_prompt(
+    group: &klaw_memory::ArchiveGroupKey,
+    source_records: &[klaw_memory::MemoryRecord],
+    max_sources: usize,
+) -> String {
+    let label = group
+        .topic
+        .as_deref()
+        .map(ToString::to_string)
+        .unwrap_or_else(|| group.kind.as_str().to_string());
+    let snippets: Vec<String> = source_records
+        .iter()
+        .take(max_sources)
+        .map(|record| klaw_memory::normalize_long_term_content(&record.content))
+        .filter(|content| !content.is_empty())
+        .collect();
+    let total = snippets.len();
+    let items = snippets
+        .iter()
+        .enumerate()
+        .map(|(i, s)| format!("{i}. {s}", i = i + 1))
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        "Summarize the following {total} past notes about {label}:
+
+{items}",
+        total = total,
+        label = label,
+        items = items,
+    )
+}
+
+#[async_trait::async_trait]
+impl SummaryGenerator for LlmSummaryGenerator {
+    async fn generate_summary(
+        &self,
+        group: &klaw_memory::ArchiveGroupKey,
+        source_records: &[klaw_memory::MemoryRecord],
+        max_sources: usize,
+    ) -> Result<String, klaw_memory::MemoryError> {
+        let user_prompt = memory_summary_user_prompt(group, source_records, max_sources);
+        let messages = vec![
+            LlmMessage {
+                role: "system".to_string(),
+                content: MEMORY_SUMMARY_SYSTEM_PROMPT.to_string(),
+                media: Vec::new(),
+                tool_calls: None,
+                tool_call_id: None,
+            },
+            LlmMessage {
+                role: "user".to_string(),
+                content: user_prompt,
+                media: Vec::new(),
+                tool_calls: None,
+                tool_call_id: None,
+            },
+        ];
+        let response = self
+            .provider
+            .chat(
+                messages,
+                Vec::new(),
+                Some(&self.model),
+                ChatOptions {
+                    temperature: 0.2,
+                    max_tokens: Some(self.max_output_tokens),
+                    max_output_tokens: None,
+                    previous_response_id: None,
+                    instructions: None,
+                    metadata: None,
+                    include: None,
+                    store: None,
+                    parallel_tool_calls: None,
+                    tool_choice: None,
+                    text: None,
+                    reasoning: None,
+                    truncation: None,
+                    user: None,
+                    service_tier: None,
+                },
+            )
+            .await
+            .map_err(|err| {
+                klaw_memory::MemoryError::CapabilityUnavailable(format!(
+                    "LLM summary call failed: {err}"
+                ))
+            })?;
+        let content = response.content.trim().to_string();
+        if content.is_empty() {
+            return Err(klaw_memory::MemoryError::CapabilityUnavailable(
+                "LLM summary returned empty content".to_string(),
+            ));
+        }
+        Ok(content)
+    }
+}
+
 struct MemoryArchiveWorker {
     memory_db: Arc<dyn MemoryDb>,
     schedule: ScheduleSpec,
     timezone: String,
     last_scheduled_run_ms: Mutex<Option<i64>>,
     archive_config: LongTermArchiveConfig,
+    summary_generator: Arc<dyn SummaryGenerator>,
 }
 
 impl MemoryArchiveWorker {
-    fn new(memory_db: Arc<dyn MemoryDb>, config: &BackgroundServiceConfig) -> Result<Self, String> {
+    fn new(
+        memory_db: Arc<dyn MemoryDb>,
+        config: &BackgroundServiceConfig,
+        default_provider: Arc<dyn LlmProvider>,
+        default_model: String,
+    ) -> Result<Self, String> {
+        let summary_generator: Arc<dyn SummaryGenerator> = Arc::new(LlmSummaryGenerator {
+            provider: default_provider,
+            model: default_model,
+            max_output_tokens: 120,
+        });
         Ok(Self {
             memory_db,
             schedule: ScheduleSpec::from_kind_expr(
@@ -413,6 +558,7 @@ impl MemoryArchiveWorker {
                 max_age_days: config.memory_archive_max_age_days,
                 summary_max_sources: config.memory_archive_summary_max_sources,
             },
+            summary_generator,
         })
     }
 
@@ -437,7 +583,7 @@ impl MemoryArchiveWorker {
             next_due
         };
 
-        let outcome = archive_stale_long_term_memories(self.memory_db.clone(), self.archive_config)
+        let outcome = archive_stale_long_term_memories(self.memory_db.clone(), self.archive_config, self.summary_generator.clone())
             .await
             .map_err(|err| err.to_string())?;
         debug!(

--- a/klaw-runtime/src/service_loop.rs
+++ b/klaw-runtime/src/service_loop.rs
@@ -33,7 +33,7 @@ type StdioCronWorker = CronWorker<DefaultSessionStore, FilteringInboundTransport
 type StdioHeartbeatWorker = HeartbeatWorker<DefaultSessionStore, FilteringInboundTransport>;
 const OUTBOUND_DISPATCH_TIMEOUT: Duration = Duration::from_secs(10);
 const MEMORY_ARCHIVE_LOOKBACK_MS: i64 = 24 * 60 * 60 * 1000;
-const MEMORY_ARCHIVE_SUMMARY_TIMEOUT: Duration = Duration::from_secs(30);
+const MEMORY_ARCHIVE_SUMMARY_TIMEOUT: Duration = Duration::from_secs(60);
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct ChannelAvailability {


### PR DESCRIPTION
## Purpose

Use an LLM to generate natural-language summaries when archiving stale long-term memories, instead of the current deterministic template concatenation (`Past notes on {label} ({total} entries): {snippets}; +{more} more`).

Closes #224

## Impacted Crates

- `klaw-memory`: new `SummaryGenerator` trait, `TemplateSummaryGenerator`, `ArchiveGroupKey` made public, `archive_stale_long_term_memories` signature change
- `klaw-runtime`: new `LlmSummaryGenerator`, `MemoryArchiveWorker` holds LLM provider via `ProviderRuntimeSnapshot`
- `klaw-gui`: `spawn_archive_run_task` uses `TemplateSummaryGenerator` (no LLM provider available in standalone thread)

## Changes

### `klaw-memory/src/maintenance.rs`
- Added `SummaryGenerator` async trait with `generate_summary(group, source_records, max_sources) -> Result<String, MemoryError>`
- Added `TemplateSummaryGenerator` that preserves the existing template-based concatenation as fallback
- Made `ArchiveGroupKey` public so external implementations can reference it
- `archive_stale_long_term_memories` now accepts `Arc<dyn SummaryGenerator>` parameter
- LLM call failures automatically fall back to template concatenation with a `warn` log

### `klaw-memory/src/lib.rs`
- Exported `ArchiveGroupKey`, `SummaryGenerator`, `TemplateSummaryGenerator`

### `klaw-memory/Cargo.toml`
- Added `tracing = { workspace = true }` dependency for fallback warn logging

### `klaw-memory/src/tests.rs`
- All archive tests updated to pass `Arc::new(TemplateSummaryGenerator)`
- New test `archive_falls_back_to_template_when_summary_generator_fails` verifies graceful degradation

### `klaw-runtime/src/service_loop.rs`
- New `LlmSummaryGenerator` struct calling runtime default provider with dedicated prompt
- `MEMORY_SUMMARY_SYSTEM_PROMPT`: concise archivist instructions (preserve facts, merge duplicates, ≤80 words)
- `MemoryArchiveWorker::new` now takes `default_provider` and `default_model` from `ProviderRuntimeSnapshot`
- `BackgroundServices::new` passes provider runtime snapshot when constructing `MemoryArchiveWorker`
- Parameters: temperature=0.2, max_output_tokens=120, no tools exposed

### `klaw-gui/src/panels/memory.rs`
- `spawn_archive_run_task` passes `Arc::new(TemplateSummaryGenerator)` since GUI has no LLM provider

## Test Evidence

```
$ cargo test -p klaw-memory -p klaw-runtime
  21 klaw-memory tests: ok (including new fallback test)
  108 klaw-runtime tests: ok
$ cargo check --workspace: ok
```

## LLM Summary Prompt

**System prompt:**
> You are a memory archivist. Your task is to condense a list of past notes about a specific topic into a single concise summary sentence or short paragraph.
>
> Rules:
> - Preserve all distinct factual claims; do not drop information.
> - Merge overlapping or redundant statements into one.
> - Keep the summary under 80 words.
> - Use neutral, factual language.
> - Do not add information that was not in the source notes.
> - Output only the summary text, without preamble or labels.

**User prompt:**
> Summarize the following N past notes about {label}:
> 1. ...
> 2. ...

## Key Design Decisions

- `klaw-memory` does **not** depend on `klaw-llm` — the summary strategy is injected, respecting the project's crate boundary rules
- Runtime uses LLM for summaries, GUI uses template fallback — no runtime LLM provider is available in GUI's standalone thread
- LLM failures are non-blocking: automatic fallback ensures archive flow completes even when the provider is unavailable