### PR TITLE
perf(gui): add puffin profiling around gui and runtime hotspots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4214,6 +4214,7 @@ dependencies = [
  "klaw-llm",
  "klaw-tool",
  "klaw-util",
+ "puffin",
  "serde",
  "serde_json",
  "strum 0.27.2",

--- a/klaw-core/Cargo.toml
+++ b/klaw-core/Cargo.toml
@@ -13,6 +13,7 @@ tokio = { workspace = true }
 uuid = { workspace = true }
 tracing = { workspace = true }
 strum = { workspace = true }
+puffin = { workspace = true }
 klaw-llm = { workspace = true }
 klaw-tool = { workspace = true }
 klaw-agent = { workspace = true }

--- a/klaw-core/src/agent_loop.rs
+++ b/klaw-core/src/agent_loop.rs
@@ -151,6 +151,7 @@ struct RegistryToolExecutor<'a> {
 #[async_trait]
 impl ToolExecutor for RegistryToolExecutor<'_> {
     fn definitions(&self) -> Vec<ToolDefinition> {
+        puffin::profile_function!();
         self.tools
             .list()
             .into_iter()
@@ -814,13 +815,22 @@ impl AgentLoop {
         state = self.transition(state, StateTransitionEvent::ValidationPassed);
         state = self.transition(state, StateTransitionEvent::ContextPrepared);
 
-        let conversation_history = extract_conversation_history(&msg.payload.metadata);
-        let user_media = extract_user_media(&msg.payload);
-        let current_attachments = current_attachment_contexts(&msg.payload.media_references);
-        let user_content = augment_user_content_with_attachment_context(
-            &msg.payload.content,
-            &current_attachments,
-        );
+        let (conversation_history, user_media, current_attachments, user_content) = {
+            puffin::profile_scope!("prepare_execution_input");
+            let conversation_history = extract_conversation_history(&msg.payload.metadata);
+            let user_media = extract_user_media(&msg.payload);
+            let current_attachments = current_attachment_contexts(&msg.payload.media_references);
+            let user_content = augment_user_content_with_attachment_context(
+                &msg.payload.content,
+                &current_attachments,
+            );
+            (
+                conversation_history,
+                user_media,
+                current_attachments,
+                user_content,
+            )
+        };
         if !msg.payload.media_references.is_empty() {
             info!(
                 message_id = %msg.header.message_id,
@@ -905,29 +915,33 @@ impl AgentLoop {
 
         match result {
             Ok(output) => {
-                let request_audits = output
-                    .request_audits
-                    .into_iter()
-                    .map(|record| klaw_agent::AgentRequestAudit {
-                        request_seq: record.request_seq,
-                        payload: normalize_audit_payload_provider(
-                            record.payload,
-                            &resolved_provider_id,
-                        ),
-                    })
-                    .collect::<Vec<_>>();
-                let request_count = request_audits.len().max(output.request_usages.len());
-                let tool_iterations = request_audits
-                    .iter()
-                    .filter(|record| {
-                        record
-                            .payload
-                            .response_body
-                            .as_ref()
-                            .and_then(extract_tool_call_count)
-                            .is_some_and(|count| count > 0)
-                    })
-                    .count();
+                let (request_audits, request_count, tool_iterations) = {
+                    puffin::profile_scope!("normalize_execution_output");
+                    let request_audits = output
+                        .request_audits
+                        .into_iter()
+                        .map(|record| klaw_agent::AgentRequestAudit {
+                            request_seq: record.request_seq,
+                            payload: normalize_audit_payload_provider(
+                                record.payload,
+                                &resolved_provider_id,
+                            ),
+                        })
+                        .collect::<Vec<_>>();
+                    let request_count = request_audits.len().max(output.request_usages.len());
+                    let tool_iterations = request_audits
+                        .iter()
+                        .filter(|record| {
+                            record
+                                .payload
+                                .response_body
+                                .as_ref()
+                                .and_then(extract_tool_call_count)
+                                .is_some_and(|count| count > 0)
+                        })
+                        .count();
+                    (request_audits, request_count, tool_iterations)
+                };
                 record_model_requests(
                     self.telemetry.as_ref(),
                     session_key,

--- a/klaw-gui/src/app/mod.rs
+++ b/klaw-gui/src/app/mod.rs
@@ -223,6 +223,7 @@ impl KlawGuiApp {
     }
 
     fn poll_pending_actions(&mut self) {
+        puffin::profile_scope!("poll_pending_runtime_actions");
         let Some(pending) = self.pending_provider_override.as_mut() else {
             return;
         };

--- a/klaw-gui/src/panels/memory.rs
+++ b/klaw-gui/src/panels/memory.rs
@@ -1,28 +1,27 @@
 use crate::notifications::NotificationCenter;
 use crate::panels::{PanelRenderer, RenderCtx};
+use crate::runtime_bridge::{RuntimeRequestHandle, begin_run_memory_archive_now_request};
 use crate::time_format::format_timestamp_millis;
 use egui::{Color32, RichText};
 use egui_extras::{Column, TableBuilder};
 use egui_phosphor::regular;
 use klaw_config::{AppConfig, ConfigError, ConfigSnapshot, ConfigStore, EmbeddingConfig};
 use klaw_memory::{
-    LongTermMemoryKind, LongTermMemoryPromptOptions, LongTermMemoryStatus,
-    MemoryError, MemoryRecord, MemoryService, MemoryStats, SqliteMemoryService,
-    SqliteMemoryStatsService, is_summary_record,
-    read_long_term_archived_at, read_long_term_kind, read_long_term_priority,
+    LongTermMemoryKind, LongTermMemoryPromptOptions, LongTermMemoryStatus, MemoryError,
+    MemoryRecord, MemoryService, MemoryStats, SqliteMemoryService, SqliteMemoryStatsService,
+    is_summary_record, read_long_term_archived_at, read_long_term_kind, read_long_term_priority,
     read_long_term_status, read_long_term_topic, render_long_term_memory_section,
 };
-use crate::runtime_bridge::{begin_run_memory_archive_now_request, RuntimeRequestHandle};
 use klaw_storage::{ChatRecord, SessionStorage, open_default_store};
 use serde_json::Value;
 use std::collections::HashSet;
 use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::{self, Receiver, TryRecvError};
-use tokio::runtime::Builder;
 use std::thread;
 use std::time::Duration as StdDuration;
 use time::{Duration, OffsetDateTime};
+use tokio::runtime::Builder;
 
 const POLL_INTERVAL: StdDuration = StdDuration::from_millis(150);
 
@@ -621,9 +620,8 @@ impl MemoryPanel {
             return;
         }
         self.archive_run_loading = true;
-        let timeout = std::time::Duration::from_secs(
-            self.config.memory.archive.command_timeout_secs.max(30),
-        );
+        let timeout =
+            std::time::Duration::from_secs(self.config.memory.archive.command_timeout_secs.max(30));
         self.archive_run_request = Some(PendingArchiveRun {
             handle: spawn_archive_run_task(timeout),
         });

--- a/klaw-gui/src/runtime_bridge.rs
+++ b/klaw-gui/src/runtime_bridge.rs
@@ -155,7 +155,11 @@ fn recv_response<T>(
     timeout: Duration,
     operation: &str,
 ) -> Result<T, String> {
-    receiver.recv_timeout(timeout).map_err(|err| match err {
+    {
+        puffin::profile_scope!("runtime_recv_wait");
+        receiver.recv_timeout(timeout)
+    }
+    .map_err(|err| match err {
         mpsc::RecvTimeoutError::Timeout => {
             format!("timed out waiting for {operation} response")
         }
@@ -205,6 +209,7 @@ pub fn clear_log_receiver() {
 }
 
 pub fn drain_log_chunks(max_batch: usize) -> Vec<String> {
+    puffin::profile_function!();
     if max_batch == 0 {
         return Vec::new();
     }
@@ -282,7 +287,11 @@ where
 {
     let (tx, rx) = mpsc::channel();
     std::thread::spawn(move || {
-        let _ = tx.send(operation());
+        let result = {
+            puffin::profile_scope!("runtime_spawn_request");
+            operation()
+        };
+        let _ = tx.send(result);
     });
     RuntimeRequestHandle { receiver: Some(rx) }
 }

--- a/klaw-gui/src/ui/shell.rs
+++ b/klaw-gui/src/ui/shell.rs
@@ -478,7 +478,11 @@ enum SyncSupervisorMessage {
 
 impl SyncSupervisor {
     fn tick(&mut self, notifications: &mut NotificationCenter) {
-        self.poll_task_result(notifications);
+        puffin::profile_function!();
+        {
+            puffin::profile_scope!("sync_supervisor_poll_result");
+            self.poll_task_result(notifications);
+        }
 
         if self
             .last_poll_at
@@ -526,6 +530,7 @@ impl SyncSupervisor {
     }
 
     fn spawn_task(&mut self, kind: SyncRuntimeTaskKind, settings: AppSettings) {
+        puffin::profile_function!();
         let label = match kind {
             SyncRuntimeTaskKind::StartupCheck => "Checking remote manifests",
             SyncRuntimeTaskKind::AutoBackup => "Automatic manifest sync",
@@ -540,14 +545,17 @@ impl SyncSupervisor {
         let (tx, rx) = mpsc::channel();
         self.task_rx = Some(rx);
         thread::spawn(move || {
-            let result = match kind {
-                SyncRuntimeTaskKind::StartupCheck => run_startup_check_task(&settings),
-                SyncRuntimeTaskKind::AutoBackup => run_auto_backup_task(&settings),
-                SyncRuntimeTaskKind::ManualBackup
-                | SyncRuntimeTaskKind::RetentionCleanup
-                | SyncRuntimeTaskKind::RefreshRemoteSnapshots
-                | SyncRuntimeTaskKind::RestoreSnapshot => {
-                    Err("unsupported sync supervisor task".to_string())
+            let result = {
+                puffin::profile_scope!("sync_supervisor_worker");
+                match kind {
+                    SyncRuntimeTaskKind::StartupCheck => run_startup_check_task(&settings),
+                    SyncRuntimeTaskKind::AutoBackup => run_auto_backup_task(&settings),
+                    SyncRuntimeTaskKind::ManualBackup
+                    | SyncRuntimeTaskKind::RetentionCleanup
+                    | SyncRuntimeTaskKind::RefreshRemoteSnapshots
+                    | SyncRuntimeTaskKind::RestoreSnapshot => {
+                        Err("unsupported sync supervisor task".to_string())
+                    }
                 }
             };
             let message =
@@ -557,6 +565,7 @@ impl SyncSupervisor {
     }
 
     fn poll_task_result(&mut self, notifications: &mut NotificationCenter) {
+        puffin::profile_function!();
         let Some(rx) = self.task_rx.as_ref() else {
             return;
         };
@@ -673,6 +682,7 @@ fn build_backup_plan(settings: &AppSettings) -> BackupPlan {
 }
 
 fn run_startup_check_task(settings: &AppSettings) -> Result<SyncSupervisorMessage, String> {
+    puffin::profile_function!();
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -698,6 +708,7 @@ fn run_startup_check_task(settings: &AppSettings) -> Result<SyncSupervisorMessag
 }
 
 fn run_auto_backup_task(settings: &AppSettings) -> Result<SyncSupervisorMessage, String> {
+    puffin::profile_function!();
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()

--- a/klaw-gui/src/ui/sidebar.rs
+++ b/klaw-gui/src/ui/sidebar.rs
@@ -10,6 +10,7 @@ fn grouped_menus() -> Vec<(WorkbenchMenuGroup, Vec<WorkbenchMenu>)> {
 }
 
 pub fn show_sidebar(ui: &mut egui::Ui, state: &UiState) -> Vec<UiAction> {
+    puffin::profile_function!();
     let mut actions = Vec::new();
 
     ui.label(
@@ -22,6 +23,7 @@ pub fn show_sidebar(ui: &mut egui::Ui, state: &UiState) -> Vec<UiAction> {
     egui::ScrollArea::vertical()
         .auto_shrink([false, false])
         .show(ui, |ui| {
+            puffin::profile_scope!("sidebar_grouped_menus");
             let groups = grouped_menus();
             for (index, (group, menus)) in groups.iter().enumerate() {
                 if index > 0 {

--- a/klaw-gui/src/ui/workbench.rs
+++ b/klaw-gui/src/ui/workbench.rs
@@ -9,26 +9,30 @@ pub fn show_workbench(
     panels: &mut PanelRegistry,
     notifications: &mut NotificationCenter,
 ) -> Vec<UiAction> {
+    puffin::profile_function!();
     let mut actions = Vec::new();
 
-    egui::ScrollArea::horizontal()
-        .id_salt("workbench-tab-strip")
-        .scroll_bar_visibility(ScrollBarVisibility::AlwaysHidden)
-        .show(ui, |ui| {
-            ui.horizontal(|ui| {
-                for tab in &state.workbench.tabs {
-                    let is_active = state.workbench.active_tab == Some(tab.id);
-                    let tab_button = ui.selectable_label(is_active, tab.title.as_str());
-                    if tab_button.clicked() {
-                        actions.push(UiAction::ActivateTab(tab.id));
+    {
+        puffin::profile_scope!("workbench_tab_strip");
+        egui::ScrollArea::horizontal()
+            .id_salt("workbench-tab-strip")
+            .scroll_bar_visibility(ScrollBarVisibility::AlwaysHidden)
+            .show(ui, |ui| {
+                ui.horizontal(|ui| {
+                    for tab in &state.workbench.tabs {
+                        let is_active = state.workbench.active_tab == Some(tab.id);
+                        let tab_button = ui.selectable_label(is_active, tab.title.as_str());
+                        if tab_button.clicked() {
+                            actions.push(UiAction::ActivateTab(tab.id));
+                        }
+                        if tab.closable && ui.small_button("x").clicked() {
+                            actions.push(UiAction::CloseTab(tab.id));
+                        }
+                        ui.separator();
                     }
-                    if tab.closable && ui.small_button("x").clicked() {
-                        actions.push(UiAction::CloseTab(tab.id));
-                    }
-                    ui.separator();
-                }
+                });
             });
-        });
+    }
 
     ui.separator();
 
@@ -37,6 +41,7 @@ pub fn show_workbench(
             menu: active.menu,
             tab_title: active.title.as_str(),
         };
+        puffin::profile_scope!("workbench_panel_shell");
         panels.render_for(ui, &ctx, notifications);
     } else {
         ui.heading("No open tabs");

--- a/klaw-gui/src/widgets/chat_box.rs
+++ b/klaw-gui/src/widgets/chat_box.rs
@@ -189,6 +189,7 @@ impl ChatBox {
     }
 
     pub fn show(&mut self, ctx: &egui::Context) -> Option<ChatAction> {
+        puffin::profile_function!();
         if !self.open {
             return None;
         }
@@ -235,6 +236,7 @@ impl ChatBox {
     }
 
     fn render_messages(&mut self, ui: &mut egui::Ui, pending_action: &mut Option<ChatAction>) {
+        puffin::profile_scope!("chat_box_messages");
         self.prune_finished_animations();
         let scroll_id = egui::Id::new((&self.title, "chat_messages"));
 

--- a/klaw-gui/src/widgets/markdown.rs
+++ b/klaw-gui/src/widgets/markdown.rs
@@ -5,12 +5,14 @@ use std::sync::Arc;
 pub type MarkdownCache = CommonMarkCache;
 
 pub fn text_layouter(ui: &Ui, text: &dyn TextBuffer, wrap_width: f32) -> Arc<Galley> {
+    puffin::profile_function!();
     let mut job = highlight_job(text.as_str());
     job.wrap.max_width = wrap_width;
     ui.fonts_mut(|fonts| fonts.layout_job(job))
 }
 
 pub fn render(ui: &mut Ui, cache: &mut MarkdownCache, markdown: &str) {
+    puffin::profile_function!();
     ui.style_mut().url_in_tooltip = true;
     CommonMarkViewer::new().show(ui, cache, markdown);
 }

--- a/klaw-memory/src/lib.rs
+++ b/klaw-memory/src/lib.rs
@@ -13,8 +13,8 @@ pub use governance::{
     GovernedLongTermWrite, LongTermMemoryKind, LongTermMemoryPriority, LongTermMemoryStatus,
     default_priority_for_kind, effective_priority as effective_long_term_priority,
     govern_long_term_write, is_inactive_long_term_record, is_summary_record,
-    normalize_content as normalize_long_term_content, read_kind as read_long_term_kind,
-    read_archived_at as read_long_term_archived_at,
+    normalize_content as normalize_long_term_content,
+    read_archived_at as read_long_term_archived_at, read_kind as read_long_term_kind,
     read_priority as read_long_term_priority, read_status as read_long_term_status,
     read_topic as read_long_term_topic,
 };

--- a/klaw-memory/src/maintenance.rs
+++ b/klaw-memory/src/maintenance.rs
@@ -5,13 +5,13 @@ use crate::{
     read_long_term_kind, read_long_term_topic,
 };
 use async_trait::async_trait;
+use futures_util::future::join_all;
 use klaw_storage::MemoryDb;
 use serde_json::{Map, Value, json};
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 use tracing::warn;
 use uuid::Uuid;
-use futures_util::future::join_all;
 
 use crate::util::now_ms;
 

--- a/klaw-memory/src/tests.rs
+++ b/klaw-memory/src/tests.rs
@@ -1,9 +1,8 @@
 use crate::{
     EmbeddingProvider, LongTermArchiveConfig, MemorySearchQuery, MemoryService,
-    SqliteMemoryService, SqliteMemoryStatsService, UpsertMemoryInput,
-    archive_stale_long_term_memories, build_embedding_provider_from_config,
+    SqliteMemoryService, SqliteMemoryStatsService, SummaryGenerator, TemplateSummaryGenerator,
+    UpsertMemoryInput, archive_stale_long_term_memories, build_embedding_provider_from_config,
     util::{now_ms, rrf_score},
-    TemplateSummaryGenerator, SummaryGenerator,
 };
 use async_trait::async_trait;
 use klaw_config::{AppConfig, ModelProviderConfig};
@@ -236,7 +235,10 @@ async fn archive_stale_long_term_memories_archives_low_priority_records_and_crea
         .iter()
         .filter(|record| {
             matches!(
-                record.metadata.get("status").and_then(serde_json::Value::as_str),
+                record
+                    .metadata
+                    .get("status")
+                    .and_then(serde_json::Value::as_str),
                 Some("archived")
             )
         })
@@ -262,7 +264,10 @@ async fn archive_stale_long_term_memories_archives_low_priority_records_and_crea
     assert_eq!(summary.metadata["status"], "active");
     assert_eq!(summary.metadata["priority"], "low");
     assert_eq!(summary.metadata["topic"], "work_city");
-    assert_eq!(summary.metadata["source_ids"], serde_json::json!(["old-1", "old-2"]));
+    assert_eq!(
+        summary.metadata["source_ids"],
+        serde_json::json!(["old-1", "old-2"])
+    );
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/klaw-runtime/src/service_loop.rs
+++ b/klaw-runtime/src/service_loop.rs
@@ -13,8 +13,8 @@ use klaw_core::{
 use klaw_cron::{CronScheduleKind, CronWorker, CronWorkerConfig, MissedRunPolicy, ScheduleSpec};
 use klaw_gateway::{GatewayWebsocketServerFrame, OutboundEvent};
 use klaw_heartbeat::{HeartbeatWorker, HeartbeatWorkerConfig, should_suppress_output};
-use klaw_memory::{LongTermArchiveConfig, SummaryGenerator, archive_stale_long_term_memories};
 use klaw_llm::{ChatOptions, LlmMessage, LlmProvider};
+use klaw_memory::{LongTermArchiveConfig, SummaryGenerator, archive_stale_long_term_memories};
 use klaw_storage::{ChatRecord, DefaultSessionStore, MemoryDb, SessionStorage};
 use klaw_util::system_timezone_name;
 use serde_json::Value;
@@ -33,7 +33,6 @@ type StdioCronWorker = CronWorker<DefaultSessionStore, FilteringInboundTransport
 type StdioHeartbeatWorker = HeartbeatWorker<DefaultSessionStore, FilteringInboundTransport>;
 const OUTBOUND_DISPATCH_TIMEOUT: Duration = Duration::from_secs(10);
 const MEMORY_ARCHIVE_LOOKBACK_MS: i64 = 24 * 60 * 60 * 1000;
-
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct ChannelAvailability {
@@ -289,18 +288,15 @@ impl BackgroundServices {
             heartbeat_worker,
             memory_archive_worker: if config.memory_archive_enabled {
                 let provider_runtime = runtime.runtime.provider_runtime_snapshot();
-                runtime
-                    .memory_db
-                    .clone()
-                    .and_then(|memory_db| {
-                        MemoryArchiveWorker::new(
-                            memory_db,
-                            &config,
-                            provider_runtime.default_provider,
-                            provider_runtime.default_model,
-                        )
-                        .ok()
-                    })
+                runtime.memory_db.clone().and_then(|memory_db| {
+                    MemoryArchiveWorker::new(
+                        memory_db,
+                        &config,
+                        provider_runtime.default_provider,
+                        provider_runtime.default_model,
+                    )
+                    .ok()
+                })
             } else {
                 None
             },
@@ -533,14 +529,12 @@ impl SummaryGenerator for LlmSummaryGenerator {
         )
         .await
         .map_err(|_| {
-            klaw_memory::MemoryError::CapabilityUnavailable(
-                format!(
-                    "LLM summary call timed out after {}s for kind={} topic={}",
-                    self.summary_timeout.as_secs(),
-                    group.kind.as_str(),
-                    group.topic.as_deref().unwrap_or("none"),
-                ),
-            )
+            klaw_memory::MemoryError::CapabilityUnavailable(format!(
+                "LLM summary call timed out after {}s for kind={} topic={}",
+                self.summary_timeout.as_secs(),
+                group.kind.as_str(),
+                group.topic.as_deref().unwrap_or("none"),
+            ))
         })?
         .map_err(|err| {
             klaw_memory::MemoryError::CapabilityUnavailable(format!(
@@ -610,13 +604,9 @@ impl MemoryArchiveWorker {
                 .last_scheduled_run_ms
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
-            let Some(next_due) = next_memory_archive_due_ms(
-                &self.schedule,
-                &self.timezone,
-                *last_scheduled,
-                now_ms,
-            )
-            .map_err(|err| err.to_string())?
+            let Some(next_due) =
+                next_memory_archive_due_ms(&self.schedule, &self.timezone, *last_scheduled, now_ms)
+                    .map_err(|err| err.to_string())?
             else {
                 return Ok(false);
             };
@@ -624,9 +614,13 @@ impl MemoryArchiveWorker {
             next_due
         };
 
-        let outcome = archive_stale_long_term_memories(self.memory_db.clone(), self.archive_config, self.summary_generator.clone())
-            .await
-            .map_err(|err| err.to_string())?;
+        let outcome = archive_stale_long_term_memories(
+            self.memory_db.clone(),
+            self.archive_config,
+            self.summary_generator.clone(),
+        )
+        .await
+        .map_err(|err| err.to_string())?;
         debug!(
             scheduled_run_ms,
             archived_records = outcome.archived_records,
@@ -654,9 +648,7 @@ impl MemoryArchiveWorker {
         );
         Ok(format!(
             "{} archived, {} summaries updated, {} skipped",
-            outcome.archived_records,
-            outcome.summary_records_upserted,
-            outcome.skipped_records
+            outcome.archived_records, outcome.summary_records_upserted, outcome.skipped_records
         ))
     }
 }
@@ -1107,8 +1099,8 @@ fn render_outbound_markdown(output: &OutboundMessage) -> String {
 mod tests {
     use super::{
         BackgroundDingtalkAccountConfig, BackgroundServiceConfig, ChannelAvailability,
-        FilteringInboundTransport, dispatch_outbound_message,
-        next_memory_archive_due_ms, resolve_outbound_account_id,
+        FilteringInboundTransport, dispatch_outbound_message, next_memory_archive_due_ms,
+        resolve_outbound_account_id,
     };
     use klaw_channel::dingtalk::is_session_webhook_session_not_found_error;
     use klaw_config::{AppConfig, DingtalkConfig};
@@ -1220,13 +1212,8 @@ mod tests {
         let schedule = ScheduleSpec::from_kind_expr(CronScheduleKind::Cron, "0 0 2 * * *")
             .expect("schedule should parse");
 
-        let due = next_memory_archive_due_ms(
-            &schedule,
-            "Asia/Shanghai",
-            None,
-            68_400_000,
-        )
-        .expect("due calculation should succeed");
+        let due = next_memory_archive_due_ms(&schedule, "Asia/Shanghai", None, 68_400_000)
+            .expect("due calculation should succeed");
 
         assert_eq!(due, Some(64_800_000));
     }
@@ -1236,22 +1223,13 @@ mod tests {
         let schedule = ScheduleSpec::from_kind_expr(CronScheduleKind::Cron, "0 0 2 * * *")
             .expect("schedule should parse");
 
-        let first_due = next_memory_archive_due_ms(
-            &schedule,
-            "Asia/Shanghai",
-            None,
-            68_400_000,
-        )
-        .expect("first due calculation should succeed");
+        let first_due = next_memory_archive_due_ms(&schedule, "Asia/Shanghai", None, 68_400_000)
+            .expect("first due calculation should succeed");
         assert_eq!(first_due, Some(64_800_000));
 
-        let second_due = next_memory_archive_due_ms(
-            &schedule,
-            "Asia/Shanghai",
-            first_due,
-            72_000_000,
-        )
-        .expect("second due calculation should succeed");
+        let second_due =
+            next_memory_archive_due_ms(&schedule, "Asia/Shanghai", first_due, 72_000_000)
+                .expect("second due calculation should succeed");
         assert_eq!(second_due, None);
     }
 


### PR DESCRIPTION
## Summary
- add puffin instrumentation around high-traffic GUI rendering paths such as chat, markdown, sidebar, workbench, and runtime action polling
- add profiling scopes around runtime bridge waits, sync supervisor work, and synchronous `klaw-core` preprocessing/output normalization paths
- include the formatter-driven follow-up edits that were present in the working tree when this instrumentation pass was committed

## Test Plan
- [x] `cargo fmt --all`
- [x] `cargo check -p klaw-core -p klaw-gui -p klaw-cli`

Made with [Cursor](https://cursor.com)