### PR TITLE
feat(core): add PromptExtension trait with Handlebars template rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3373,6 +3373,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "handlebars"
+version = "6.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b3f9296c208515b87bd915a2f5d1163d4b3f863ba83337d7713cf478055948e"
+dependencies = [
+ "derive_builder",
+ "log",
+ "num-order",
+ "pest",
+ "pest_derive",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4269,6 +4285,7 @@ name = "klaw-core"
 version = "0.15.0"
 dependencies = [
  "async-trait",
+ "handlebars",
  "klaw-agent",
  "klaw-llm",
  "klaw-tool",
@@ -5519,6 +5536,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-modular"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17bb261bf36fa7d83f4c294f834e91256769097b3cb505d44831e0a179ac647f"
+
+[[package]]
+name = "num-order"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537b596b97c40fcf8056d153049eb22f481c17ebce72a513ec9286e4986d1bb6"
+dependencies = [
+ "num-modular",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6266,6 +6298,49 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "phf"
@@ -9131,6 +9206,12 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uds_windows"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4427,6 +4427,7 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,6 +123,7 @@ objc2-foundation = "0.2.2"
 objc2 = "0.5.2"
 objc2-core-location = "0.2.2"
 
+handlebars = "6"
 humantime = "2"
 strum = { version = "0.27", features = ["derive"] }
 url = "2"

--- a/docs/src/tools/built-in/knowledge.md
+++ b/docs/src/tools/built-in/knowledge.md
@@ -4,7 +4,7 @@
 
 ## 当前定位
 
-`knowledge` 是一个只读的外部知识检索工具。
+`knowledge` 是一个面向外部知识库的检索工具，当前也支持受限写回到 Obsidian vault。
 
 它面向：
 
@@ -24,7 +24,7 @@
 
 - `memory.add` 写入 agent 自身长期记忆
 - `memory.search` 检索 session 记忆视图
-- `knowledge` 只读取外部知识源，不写 `memory.db`
+- `knowledge` 可显式写回用户知识库，但不写 `memory.db`
 - `knowledge` 不进入 runtime 的长期记忆 prompt 注入链路
 
 ### `knowledge` vs `local_search`
@@ -39,12 +39,13 @@
 
 ## 当前动作
 
-`knowledge` 当前暴露四个动作：
+`knowledge` 当前暴露五个动作：
 
 - `list_sources`
 - `search`
 - `get`
 - `context`
+- `create_note`
 
 ### `list_sources`
 
@@ -75,6 +76,23 @@
 - `query`
 - `limit`
 - `budget_chars`
+
+### `create_note`
+
+按 vault 内相对路径创建一篇新的 Markdown 笔记，并在写入后立即做单文件增量索引。
+
+支持参数：
+
+- `path`
+- `content`
+- `source`
+
+首期约束：
+
+- 仅支持 Obsidian provider
+- `path` 必须是 vault 内相对路径，且以 `.md` 结尾
+- 不允许绝对路径或 `..`
+- 若目标笔记已存在，调用失败，不覆盖、不追加
 
 ## 配置
 
@@ -152,5 +170,6 @@ include_explain = true
 - semantic / FTS / graph / temporal / rerank 五路检索与 weighted RRF fusion
 - 可选本地 orchestrator query expansion + intent classification（由 `klaw-model` 驱动）
 - `ContextBundle` 组装
+- `create_note` 受限写回：原子创建 Markdown 笔记并立即索引，供后续 `search/get/context` 消费
 
 本期仍保持为内部 runtime/tool 能力，不暴露 HTTP/REST 或外部 MCP 服务。

--- a/klaw-core/Cargo.toml
+++ b/klaw-core/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 async-trait = { workspace = true }
+handlebars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/klaw-core/src/lib.rs
+++ b/klaw-core/src/lib.rs
@@ -74,10 +74,12 @@ pub use media::{MediaReference, MediaSourceKind};
 pub use mock::{InMemoryIdempotencyStore, InMemorySessionScheduler, InMemoryTransport};
 pub use observability::{AgentTelemetry, HealthStatus};
 pub use prompt::{
-    PromptError, PromptTemplateWriteReport, RuntimePromptInput, SkillPromptEntry,
-    build_runtime_system_prompt, compose_runtime_prompt, ensure_workspace_prompt_templates,
-    ensure_workspace_prompt_templates_in_dir, format_skills_for_prompt,
-    format_workspace_docs_for_prompt, get_default_template_content, skills_lazy_load_instructions,
+    PromptError, PromptExtension, PromptTemplateWriteReport, RtkPromptExtension,
+    RuntimePromptInput, SkillPromptEntry, build_runtime_system_prompt,
+    build_runtime_system_prompt_with_extensions, compose_runtime_prompt, default_prompt_extensions,
+    ensure_workspace_prompt_templates, ensure_workspace_prompt_templates_in_dir,
+    format_skills_for_prompt, format_workspace_docs_for_prompt, get_default_template_content,
+    skills_lazy_load_instructions,
 };
 pub use protocol::{Envelope, EnvelopeHeader, ErrorCode, MessageTopic, SchemaVersion};
 pub use reliability::{

--- a/klaw-core/src/prompt.rs
+++ b/klaw-core/src/prompt.rs
@@ -1,11 +1,15 @@
 use std::{
     io,
     path::{Path, PathBuf},
+    sync::Arc,
 };
 
+use handlebars::Handlebars;
 use klaw_util::{default_data_dir, workspace_dir};
+use serde_json::{Map, Value};
 use thiserror::Error;
 use tokio::fs;
+use tracing::warn;
 
 const SKILLS_LAZY_LOAD_INSTRUCTIONS: &str = r#"When a task may require a skill, consult the available skills list first.
 Before using a skill, read the SKILL.md file at the listed path.
@@ -66,6 +70,132 @@ const AUTO_CREATE_PROMPT_TEMPLATE_FILES: [(&str, &str); 5] = [
     ("TOOLS.md", include_str!("../templates/prompt/TOOLS.md")),
     ("USER.md", include_str!("../templates/prompt/USER.md")),
 ];
+
+// ---------------------------------------------------------------------------
+// Prompt Extension trait & built-in extensions
+// ---------------------------------------------------------------------------
+
+/// A prompt extension that conditionally includes template sections based on
+/// runtime environment conditions.
+///
+/// Template files use Handlebars `{{#if}}` blocks to denote extension sections:
+///
+/// ```handlebars
+/// {{#if rtk}}
+/// ## Extension Agent: rtk Command Proxy
+/// ...content...
+/// {{/if}}
+/// ```
+///
+/// When an extension's `is_active()` returns `true`, the Handlebars context
+/// includes its name as `true` and the `{{#if name}}` block is rendered.
+/// When `is_active()` returns `false`, the entire block is omitted.
+///
+/// The condition check (`is_active()`) is implemented in code — e.g., probing
+/// the system for a command, checking a config flag, or testing network
+/// reachability. It is **not** left to the LLM to decide.
+pub trait PromptExtension: Send + Sync {
+    /// Unique identifier matching the key used in `{{#if name}}` blocks.
+    fn name(&self) -> &str;
+
+    /// Evaluate whether this extension should be active.
+    /// Implemented in code — e.g., probing the system for a command, checking a
+    /// config flag, or testing network reachability.
+    fn is_active(&self) -> bool;
+
+    /// Return the prompt section content when `is_active()` is true.
+    /// Used as a standalone fallback for dynamic injection outside of
+    /// Handlebars template files (e.g., when a template lacks the `{{#if}}`
+    /// block for this extension).
+    fn prompt_section(&self) -> String;
+}
+
+/// Built-in extension: checks whether the `rtk` command-proxy exists on the
+/// system. When active, all shell-tool commands must be prefixed with `rtk`
+/// so that auditing, sandboxing, and policy enforcement are applied.
+pub struct RtkPromptExtension;
+
+impl PromptExtension for RtkPromptExtension {
+    fn name(&self) -> &str {
+        "rtk"
+    }
+
+    fn is_active(&self) -> bool {
+        is_command_available("rtk")
+    }
+
+    fn prompt_section(&self) -> String {
+        RTK_PROMPT_SECTION.to_string()
+    }
+}
+
+const RTK_PROMPT_SECTION: &str = r#"## Extension Agent: rtk Command Proxy
+
+The `rtk` command is available on this system and acts as a proxy/wrapper for shell operations. It provides auditing, sandboxing, and policy enforcement for all command execution.
+
+**Rule:** When using the shell tool to execute commands, **always prefix the command with `rtk`**. Examples:
+- Instead of `git status` → run `rtk git status`
+- Instead of `npm install` → run `rtk npm install`
+- Instead of `cargo build` → run `rtk cargo build`
+- Instead of `ls -la` → run `rtk ls -la`
+
+This applies to **every** shell command — no exceptions. `rtk` intercepts the command, applies runtime policies, logs the execution, and forwards it to the real binary. Skipping the `rtk` prefix bypasses safety controls."#;
+
+/// Return the default set of built-in prompt extensions.
+/// Callers may append additional extensions before passing the list into
+/// `build_runtime_system_prompt_with_extensions`.
+pub fn default_prompt_extensions() -> Vec<Arc<dyn PromptExtension>> {
+    vec![Arc::new(RtkPromptExtension)]
+}
+
+/// Check whether a command is available on the system by searching PATH.
+/// Uses `which` on Unix-like systems and `where` on Windows.
+fn is_command_available(name: &str) -> bool {
+    let checker = if cfg!(target_family = "unix") {
+        "which"
+    } else {
+        "where"
+    };
+    std::process::Command::new(checker)
+        .arg(name)
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
+/// Render a Handlebars template string, injecting extension activity flags
+/// into the template context.
+///
+/// Each extension contributes a boolean key (`name` → `is_active()`) to the
+/// context. Template sections wrapped in `{{#if name}}` / `{{/if}}` are
+/// included when the extension is active and omitted when it is not.
+///
+/// Falls back to the raw content on rendering errors (e.g., malformed
+/// Handlebars syntax in a user-edited file), ensuring the prompt is always
+/// available even if template processing fails.
+fn render_template_with_extensions(
+    content: &str,
+    extensions: &[Arc<dyn PromptExtension>],
+) -> String {
+    let mut hb = Handlebars::new();
+    // Non-strict mode: unknown `{{variables}}` render as empty string instead
+    // of raising an error. This is safer for user-edited markdown files that
+    // may inadvertently contain `{{…}}` patterns unrelated to extensions.
+    hb.set_strict_mode(false);
+
+    let mut ctx = Map::new();
+    for ext in extensions {
+        ctx.insert(ext.name().to_string(), Value::Bool(ext.is_active()));
+    }
+
+    match hb.render_template(content, &Value::Object(ctx)) {
+        Ok(rendered) => rendered,
+        Err(e) => {
+            warn!("Handlebars template rendering failed, using raw content: {e}");
+            content.to_string()
+        }
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PromptTemplateWriteReport {
@@ -272,19 +402,32 @@ fn compose_runtime_prompt_with_descriptor(
 }
 
 pub fn build_runtime_system_prompt(skills: Vec<SkillPromptEntry>) -> Option<String> {
+    build_runtime_system_prompt_with_extensions(skills, default_prompt_extensions())
+}
+
+/// Build the full runtime system prompt with explicit prompt extensions.
+/// Extensions are evaluated to build a Handlebars context; template files
+/// containing `{{#if name}}` / `{{/if}}` blocks are rendered so that active
+/// extension sections are included and inactive ones are omitted.
+pub fn build_runtime_system_prompt_with_extensions(
+    skills: Vec<SkillPromptEntry>,
+    extensions: Vec<Arc<dyn PromptExtension>>,
+) -> Option<String> {
     let data_dir = resolve_default_data_dir().ok()?;
-    build_runtime_system_prompt_in_dir(&data_dir, skills)
+    build_runtime_system_prompt_in_dir(&data_dir, skills, &extensions)
 }
 
 fn build_runtime_system_prompt_in_dir(
     data_dir: &Path,
     skills: Vec<SkillPromptEntry>,
+    extensions: &[Arc<dyn PromptExtension>],
 ) -> Option<String> {
     compose_runtime_prompt_with_descriptor(
         RuntimePromptInput {
-            workspace_context: format_inlined_workspace_context_for_prompt_in_dir(&workspace_dir(
-                data_dir,
-            )),
+            workspace_context: format_inlined_workspace_context_for_prompt_in_dir(
+                &workspace_dir(data_dir),
+                extensions,
+            ),
             runtime_metadata: None,
             rules: Some(RUNTIME_PROMPT_RULES.to_string()),
             local_docs: Some(format_workspace_docs_for_prompt_in_dir(data_dir)),
@@ -309,7 +452,10 @@ fn format_workspace_descriptor_for_prompt_in_dir(data_dir: &Path) -> String {
     )
 }
 
-fn format_inlined_workspace_context_for_prompt_in_dir(workspace_dir: &Path) -> Option<String> {
+fn format_inlined_workspace_context_for_prompt_in_dir(
+    workspace_dir: &Path,
+    extensions: &[Arc<dyn PromptExtension>],
+) -> Option<String> {
     let mut sections = Vec::new();
 
     for file_name in INLINED_WORKSPACE_PROMPT_DOC_FILES {
@@ -317,7 +463,7 @@ fn format_inlined_workspace_context_for_prompt_in_dir(workspace_dir: &Path) -> O
         let Ok(content) = std::fs::read_to_string(path) else {
             continue;
         };
-        let content = content.trim().to_string();
+        let content = render_template_with_extensions(content.trim(), extensions);
         if content.is_empty() {
             continue;
         }
@@ -550,6 +696,7 @@ mod tests {
                 description: "interact with GitHub repositories".to_string(),
                 source: "workspace".to_string(),
             }],
+            &default_prompt_extensions(),
         )
         .expect("runtime prompt expected");
 
@@ -615,8 +762,11 @@ mod tests {
             .await
             .expect("tools should be written");
 
-        let prompt = format_inlined_workspace_context_for_prompt_in_dir(&workspace)
-            .expect("workspace context should be composed");
+        let prompt = format_inlined_workspace_context_for_prompt_in_dir(
+            &workspace,
+            &default_prompt_extensions(),
+        )
+        .expect("workspace context should be composed");
 
         assert!(prompt.contains("# AGENTS.md\n\nagents body"));
         assert!(prompt.contains("# SOUL.md\n\nsoul body"));
@@ -659,5 +809,250 @@ mod tests {
         assert!(rules_pos < instructions_pos);
         assert!(prompt.contains("## Local Docs\n\ndocs-a"));
         assert!(prompt.contains("## Additional Instructions\n\nextra-a"));
+    }
+
+    // ---- Prompt Extension tests ----
+
+    /// A simple mock extension for testing Handlebars rendering without
+    /// depending on the actual system environment.
+    struct MockExtension {
+        name: &'static str,
+        active: bool,
+    }
+
+    impl PromptExtension for MockExtension {
+        fn name(&self) -> &str {
+            self.name
+        }
+        fn is_active(&self) -> bool {
+            self.active
+        }
+        fn prompt_section(&self) -> String {
+            format!("## Extension: {}", self.name)
+        }
+    }
+
+    #[test]
+    fn render_template_keeps_active_if_block() {
+        let input = "# AGENTS.md\n\n## Every Session\n\nDo stuff.\n\n{{#if rtk}}\n## Extension Agent: rtk\n\nPrefix with rtk.\n{{/if}}\n\n## Make It Yours\n";
+        let extensions: Vec<Arc<dyn PromptExtension>> = vec![Arc::new(MockExtension {
+            name: "rtk",
+            active: true,
+        })];
+        let result = render_template_with_extensions(input, &extensions);
+
+        assert!(result.contains("## Extension Agent: rtk"));
+        assert!(result.contains("Prefix with rtk."));
+        assert!(!result.contains("{{#if rtk}}"));
+        assert!(!result.contains("{{/if}}"));
+        assert!(result.contains("## Every Session"));
+        assert!(result.contains("## Make It Yours"));
+    }
+
+    #[test]
+    fn render_template_strips_inactive_if_block() {
+        let input = "# AGENTS.md\n\n## Every Session\n\nDo stuff.\n\n{{#if rtk}}\n## Extension Agent: rtk\n\nPrefix with rtk.\n{{/if}}\n\n## Make It Yours\n";
+        let extensions: Vec<Arc<dyn PromptExtension>> = vec![Arc::new(MockExtension {
+            name: "rtk",
+            active: false,
+        })];
+        let result = render_template_with_extensions(input, &extensions);
+
+        assert!(!result.contains("## Extension Agent: rtk"));
+        assert!(!result.contains("Prefix with rtk."));
+        assert!(!result.contains("{{#if rtk}}"));
+        assert!(!result.contains("{{/if}}"));
+        assert!(result.contains("## Every Session"));
+        assert!(result.contains("## Make It Yours"));
+    }
+
+    #[test]
+    fn render_template_preserves_content_without_handlebars_syntax() {
+        let input = "# AGENTS.md\n\n## Every Session\n\nDo stuff.\n\n## Make It Yours\n";
+        let extensions: Vec<Arc<dyn PromptExtension>> = vec![Arc::new(MockExtension {
+            name: "rtk",
+            active: true,
+        })];
+        let result = render_template_with_extensions(input, &extensions);
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn render_template_handles_multiple_extensions() {
+        let input = "# AGENTS.md\n\n{{#if rtk}}\n## rtk\n\nrtk content\n{{/if}}\n\n{{#if docker}}\n## docker\n\ndocker content\n{{/if}}\n\n## End\n";
+        let extensions: Vec<Arc<dyn PromptExtension>> = vec![
+            Arc::new(MockExtension {
+                name: "rtk",
+                active: true,
+            }),
+            Arc::new(MockExtension {
+                name: "docker",
+                active: false,
+            }),
+        ];
+        let result = render_template_with_extensions(input, &extensions);
+
+        assert!(result.contains("## rtk"));
+        assert!(result.contains("rtk content"));
+        assert!(!result.contains("## docker"));
+        assert!(!result.contains("docker content"));
+        assert!(!result.contains("{{#if"));
+        assert!(!result.contains("{{/if}}"));
+        assert!(result.contains("## End"));
+    }
+
+    #[test]
+    fn render_template_if_else_block_works() {
+        let input = "{{#if rtk}}\nrtk is active\n{{else}}\nrtk is not available\n{{/if}}\n";
+        let active_exts: Vec<Arc<dyn PromptExtension>> = vec![Arc::new(MockExtension {
+            name: "rtk",
+            active: true,
+        })];
+        let active_result = render_template_with_extensions(input, &active_exts);
+        assert!(active_result.contains("rtk is active"));
+        assert!(!active_result.contains("rtk is not available"));
+
+        let inactive_exts: Vec<Arc<dyn PromptExtension>> = vec![Arc::new(MockExtension {
+            name: "rtk",
+            active: false,
+        })];
+        let inactive_result = render_template_with_extensions(input, &inactive_exts);
+        assert!(!inactive_result.contains("rtk is active"));
+        assert!(inactive_result.contains("rtk is not available"));
+    }
+
+    #[test]
+    fn render_template_falls_back_on_invalid_syntax() {
+        // Malformed Handlebars syntax should fall back to raw content.
+        let input = "{{#if}}\nbroken block\n{{/if}}\n";
+        let extensions: Vec<Arc<dyn PromptExtension>> = vec![Arc::new(MockExtension {
+            name: "rtk",
+            active: true,
+        })];
+        let result = render_template_with_extensions(input, &extensions);
+        // Fallback returns raw content unchanged.
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn rtk_prompt_extension_has_correct_name() {
+        let ext = RtkPromptExtension;
+        assert_eq!(ext.name(), "rtk");
+    }
+
+    #[test]
+    fn rtk_prompt_extension_section_contains_shell_prefix_rule() {
+        let ext = RtkPromptExtension;
+        let section = ext.prompt_section();
+        assert!(section.contains("## Extension Agent: rtk Command Proxy"));
+        assert!(section.contains("always prefix the command with `rtk`"));
+        assert!(section.contains("rtk git status"));
+    }
+
+    #[test]
+    fn is_command_available_returns_false_for_nonexistent_command() {
+        // A command that almost certainly does not exist on any system.
+        assert!(!is_command_available("klaw_nonexistent_test_command_xyz"));
+    }
+
+    #[test]
+    fn default_prompt_extensions_includes_rtk() {
+        let exts = default_prompt_extensions();
+        assert!(exts.iter().any(|e| e.name() == "rtk"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn format_inlined_workspace_context_strips_inactive_extension_from_template() {
+        // Write the actual AGENTS.md template content (which contains
+        // {{#if rtk}} Handlebars blocks) into a temp workspace and verify
+        // that inactive extensions are stripped.
+        let workspace =
+            std::env::temp_dir().join(format!("klaw-prompt-ext-test-{}", Uuid::new_v4()));
+        fs::create_dir_all(&workspace)
+            .await
+            .expect("workspace dir should be created");
+
+        let agents_content =
+            get_default_template_content("AGENTS.md").expect("AGENTS.md template should exist");
+        assert!(
+            agents_content.contains("{{#if rtk}}"),
+            "template should contain rtk Handlebars block"
+        );
+
+        fs::write(workspace.join("AGENTS.md"), agents_content)
+            .await
+            .expect("agents should be written");
+        fs::write(workspace.join("SOUL.md"), "# SOUL.md\n\nsoul body")
+            .await
+            .expect("soul should be written");
+        fs::write(
+            workspace.join("IDENTITY.md"),
+            "# IDENTITY.md\n\nidentity body",
+        )
+        .await
+        .expect("identity should be written");
+        fs::write(workspace.join("TOOLS.md"), "# TOOLS.md\n\ntools body")
+            .await
+            .expect("tools should be written");
+
+        // Use a mock rtk extension that is inactive to simulate a system without rtk.
+        let inactive_exts: Vec<Arc<dyn PromptExtension>> = vec![Arc::new(MockExtension {
+            name: "rtk",
+            active: false,
+        })];
+
+        let prompt = format_inlined_workspace_context_for_prompt_in_dir(&workspace, &inactive_exts)
+            .expect("workspace context should be composed");
+
+        assert!(!prompt.contains("{{#if rtk}}"));
+        assert!(!prompt.contains("{{/if}}"));
+        assert!(!prompt.contains("Extension Agent: rtk Command Proxy"));
+        assert!(!prompt.contains("always prefix the command with `rtk`"));
+        assert!(prompt.contains("# AGENTS.md"));
+        assert!(prompt.contains("## Make It Yours"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn format_inlined_workspace_context_keeps_active_extension_from_template() {
+        let workspace =
+            std::env::temp_dir().join(format!("klaw-prompt-ext-active-{}", Uuid::new_v4()));
+        fs::create_dir_all(&workspace)
+            .await
+            .expect("workspace dir should be created");
+
+        let agents_content =
+            get_default_template_content("AGENTS.md").expect("AGENTS.md template should exist");
+
+        fs::write(workspace.join("AGENTS.md"), agents_content)
+            .await
+            .expect("agents should be written");
+        fs::write(workspace.join("SOUL.md"), "# SOUL.md\n\nsoul body")
+            .await
+            .expect("soul should be written");
+        fs::write(
+            workspace.join("IDENTITY.md"),
+            "# IDENTITY.md\n\nidentity body",
+        )
+        .await
+        .expect("identity should be written");
+        fs::write(workspace.join("TOOLS.md"), "# TOOLS.md\n\ntools body")
+            .await
+            .expect("tools should be written");
+
+        // Use a mock rtk extension that is active to simulate a system with rtk.
+        let active_exts: Vec<Arc<dyn PromptExtension>> = vec![Arc::new(MockExtension {
+            name: "rtk",
+            active: true,
+        })];
+
+        let prompt = format_inlined_workspace_context_for_prompt_in_dir(&workspace, &active_exts)
+            .expect("workspace context should be composed");
+
+        assert!(!prompt.contains("{{#if rtk}}"));
+        assert!(!prompt.contains("{{/if}}"));
+        assert!(prompt.contains("Extension Agent: rtk Command Proxy"));
+        assert!(prompt.contains("always prefix the command with `rtk`"));
+        assert!(prompt.contains("# AGENTS.md"));
+        assert!(prompt.contains("## Make It Yours"));
     }
 }

--- a/klaw-core/src/prompt.rs
+++ b/klaw-core/src/prompt.rs
@@ -170,6 +170,12 @@ fn is_command_available(name: &str) -> bool {
 /// context. Template sections wrapped in `{{#if name}}` / `{{/if}}` are
 /// included when the extension is active and omitted when it is not.
 ///
+/// Built-in extension content is injected by code in
+/// `format_inlined_workspace_context_for_prompt_in_dir`, not embedded in
+/// template files, so that AGENTS.md stays pure markdown without visible
+/// Handlebars syntax. This function is still applied to on-disk content as
+/// a safety net for user-edited files that may add `{{#if}}` blocks.
+///
 /// Falls back to the raw content on rendering errors (e.g., malformed
 /// Handlebars syntax in a user-edited file), ensuring the prompt is always
 /// available even if template processing fails.
@@ -406,9 +412,11 @@ pub fn build_runtime_system_prompt(skills: Vec<SkillPromptEntry>) -> Option<Stri
 }
 
 /// Build the full runtime system prompt with explicit prompt extensions.
-/// Extensions are evaluated to build a Handlebars context; template files
-/// containing `{{#if name}}` / `{{/if}}` blocks are rendered so that active
-/// extension sections are included and inactive ones are omitted.
+/// Active extensions inject their `prompt_section()` content after the
+/// inlined workspace context. Inactive extensions are omitted entirely.
+/// Template files may optionally use Handlebars `{{#if name}}` / `{{/if}}`
+/// blocks for advanced conditional rendering, but built-in extension
+/// sections are injected by code — not embedded in template files.
 pub fn build_runtime_system_prompt_with_extensions(
     skills: Vec<SkillPromptEntry>,
     extensions: Vec<Arc<dyn PromptExtension>>,
@@ -468,6 +476,19 @@ fn format_inlined_workspace_context_for_prompt_in_dir(
             continue;
         }
         sections.push(content);
+    }
+
+    // Inject active extension prompt sections after the inlined file content.
+    // Extension content is defined in code (via `prompt_section()`), not
+    // embedded in template files, so that AGENTS.md stays pure markdown
+    // without visible Handlebars syntax in GUI previews.
+    for ext in extensions {
+        if ext.is_active() {
+            let section = ext.prompt_section().trim().to_string();
+            if !section.is_empty() {
+                sections.push(section);
+            }
+        }
     }
 
     if sections.is_empty() {
@@ -962,10 +983,10 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn format_inlined_workspace_context_strips_inactive_extension_from_template() {
-        // Write the actual AGENTS.md template content (which contains
-        // {{#if rtk}} Handlebars blocks) into a temp workspace and verify
-        // that inactive extensions are stripped.
+    async fn format_inlined_workspace_context_omits_inactive_extension_section() {
+        // Extension content is injected by code via prompt_section(), not
+        // embedded in template files. Verify that inactive extensions do not
+        // appear in the inlined workspace context.
         let workspace =
             std::env::temp_dir().join(format!("klaw-prompt-ext-test-{}", Uuid::new_v4()));
         fs::create_dir_all(&workspace)
@@ -974,10 +995,6 @@ mod tests {
 
         let agents_content =
             get_default_template_content("AGENTS.md").expect("AGENTS.md template should exist");
-        assert!(
-            agents_content.contains("{{#if rtk}}"),
-            "template should contain rtk Handlebars block"
-        );
 
         fs::write(workspace.join("AGENTS.md"), agents_content)
             .await
@@ -1006,14 +1023,16 @@ mod tests {
 
         assert!(!prompt.contains("{{#if rtk}}"));
         assert!(!prompt.contains("{{/if}}"));
-        assert!(!prompt.contains("Extension Agent: rtk Command Proxy"));
-        assert!(!prompt.contains("always prefix the command with `rtk`"));
+        assert!(!prompt.contains("## Extension: rtk"));
         assert!(prompt.contains("# AGENTS.md"));
         assert!(prompt.contains("## Make It Yours"));
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn format_inlined_workspace_context_keeps_active_extension_from_template() {
+    async fn format_inlined_workspace_context_injects_active_extension_section() {
+        // Extension content is injected by code via prompt_section(), not
+        // embedded in template files. Verify that active extensions appear
+        // in the inlined workspace context.
         let workspace =
             std::env::temp_dir().join(format!("klaw-prompt-ext-active-{}", Uuid::new_v4()));
         fs::create_dir_all(&workspace)
@@ -1040,6 +1059,7 @@ mod tests {
             .expect("tools should be written");
 
         // Use a mock rtk extension that is active to simulate a system with rtk.
+        // MockExtension.prompt_section() returns "## Extension: rtk".
         let active_exts: Vec<Arc<dyn PromptExtension>> = vec![Arc::new(MockExtension {
             name: "rtk",
             active: true,
@@ -1050,8 +1070,7 @@ mod tests {
 
         assert!(!prompt.contains("{{#if rtk}}"));
         assert!(!prompt.contains("{{/if}}"));
-        assert!(prompt.contains("Extension Agent: rtk Command Proxy"));
-        assert!(prompt.contains("always prefix the command with `rtk`"));
+        assert!(prompt.contains("## Extension: rtk"));
         assert!(prompt.contains("# AGENTS.md"));
         assert!(prompt.contains("## Make It Yours"));
     }

--- a/klaw-core/templates/prompt/AGENTS.md
+++ b/klaw-core/templates/prompt/AGENTS.md
@@ -255,20 +255,6 @@ Think of it like a human reviewing their journal and updating their mental model
 
 The goal: Be helpful without being annoying. Check in a few times a day, do useful background work, but respect quiet time.
 
-{{#if rtk}}
-## Extension Agent: rtk Command Proxy
-
-The `rtk` command is available on this system and acts as a proxy/wrapper for shell operations. It provides auditing, sandboxing, and policy enforcement for all command execution.
-
-**Rule:** When using the shell tool to execute commands, **always prefix the command with `rtk`**. Examples:
-- Instead of `git status` → run `rtk git status`
-- Instead of `npm install` → run `rtk npm install`
-- Instead of `cargo build` → run `rtk cargo build`
-- Instead of `ls -la` → run `rtk ls -la`
-
-This applies to **every** shell command — no exceptions. `rtk` intercepts the command, applies runtime policies, logs the execution, and forwards it to the real binary. Skipping the `rtk` prefix bypasses safety controls.
-{{/if}}
-
 ## Make It Yours
 
 This is a starting point. Add your own conventions, style, and rules as you figure out what works.

--- a/klaw-core/templates/prompt/AGENTS.md
+++ b/klaw-core/templates/prompt/AGENTS.md
@@ -255,6 +255,20 @@ Think of it like a human reviewing their journal and updating their mental model
 
 The goal: Be helpful without being annoying. Check in a few times a day, do useful background work, but respect quiet time.
 
+{{#if rtk}}
+## Extension Agent: rtk Command Proxy
+
+The `rtk` command is available on this system and acts as a proxy/wrapper for shell operations. It provides auditing, sandboxing, and policy enforcement for all command execution.
+
+**Rule:** When using the shell tool to execute commands, **always prefix the command with `rtk`**. Examples:
+- Instead of `git status` → run `rtk git status`
+- Instead of `npm install` → run `rtk npm install`
+- Instead of `cargo build` → run `rtk cargo build`
+- Instead of `ls -la` → run `rtk ls -la`
+
+This applies to **every** shell command — no exceptions. `rtk` intercepts the command, applies runtime policies, logs the execution, and forwards it to the real binary. Skipping the `rtk` prefix bypasses safety controls.
+{{/if}}
+
 ## Make It Yours
 
 This is a starting point. Add your own conventions, style, and rules as you figure out what works.

--- a/klaw-core/templates/prompt/AGENTS.md
+++ b/klaw-core/templates/prompt/AGENTS.md
@@ -44,6 +44,19 @@ Capture what matters: decisions, context, preferences, and lessons. Skip secrets
 - When you make a mistake → document it so future-you doesn't repeat it
 - **Persistent memory > brain** 📝
 
+## Knowledge
+
+Your human may maintain an external knowledge base (Obsidian vault, research notes, project docs). `memory` is _your_ diary; `knowledge` is _their_ library. Don't write user knowledge into `memory`, and don't use `knowledge` for facts only you need to recall.
+
+**Browse proactively — don't wait to be told:**
+
+- When a task touches a domain your human curates notes on
+- When the user references something indirectly ("that paper I read", "my notes on X")
+- When you need context before answering a nuanced question
+- During heartbeat downtime — `search` topics you know they care about to stay familiar
+
+A well-timed knowledge lookup beats a confident wrong answer. If a topic smells like it lives in the knowledge base, go look.
+
 ## Safety
 
 - Don't exfiltrate private data. Ever.

--- a/klaw-gui/src/panels/system.rs
+++ b/klaw-gui/src/panels/system.rs
@@ -251,6 +251,7 @@ enum DirKind {
     Logs,
     Skills,
     SkillsRegistry,
+    Models,
 }
 
 impl DirKind {
@@ -263,6 +264,7 @@ impl DirKind {
             DirKind::Logs => "Logs",
             DirKind::Skills => "Skills",
             DirKind::SkillsRegistry => "Skills Registry",
+            DirKind::Models => "Models",
         }
     }
 
@@ -275,6 +277,7 @@ impl DirKind {
             DirKind::Logs => "logs",
             DirKind::Skills => "skills",
             DirKind::SkillsRegistry => "skills-registry",
+            DirKind::Models => "models",
         }
     }
 
@@ -287,6 +290,7 @@ impl DirKind {
             DirKind::Logs => paths.logs_dir.clone(),
             DirKind::Skills => paths.skills_dir.clone(),
             DirKind::SkillsRegistry => paths.skills_registry_dir.clone(),
+            DirKind::Models => paths.models_dir.clone(),
         }
     }
 }
@@ -337,6 +341,7 @@ impl SystemPanel {
             DirKind::Logs => 4,
             DirKind::Skills => 5,
             DirKind::SkillsRegistry => 6,
+            DirKind::Models => 7,
         }
     }
 
@@ -409,6 +414,7 @@ impl SystemPanel {
             DirKind::Logs,
             DirKind::Skills,
             DirKind::SkillsRegistry,
+            DirKind::Models,
         ] {
             let dir = self.get_dir(kind);
             if dir.usage_bytes.is_none() && dir.usage_rx.is_none() {
@@ -948,6 +954,8 @@ impl PanelRenderer for SystemPanel {
                     self.render_section(ui, DirKind::Skills, notifications);
                     ui.separator();
                     self.render_section(ui, DirKind::SkillsRegistry, notifications);
+                    ui.separator();
+                    self.render_section(ui, DirKind::Models, notifications);
                 }
                 SystemView::Environment => {
                     self.render_env_check_section(ui);

--- a/klaw-knowledge/CHANGELOG.md
+++ b/klaw-knowledge/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+## 2026-04-27
+
+### Added
+
+- 新增 `CreateKnowledgeNoteInput` 与 `KnowledgeProvider::create_note`，支持在 configured Obsidian vault 中创建新的 Markdown 笔记
+- Obsidian provider 现在会对新建笔记执行路径校验、原子写入，并在写入成功后立即做单文件增量索引
+
+### Fixed
+
+- 新建笔记命中已存在路径时现在会显式报冲突，避免覆盖用户已有 vault 内容
+
 ## 2026-04-26
 
 ### Added

--- a/klaw-knowledge/Cargo.toml
+++ b/klaw-knowledge/Cargo.toml
@@ -12,7 +12,8 @@ thiserror = { workspace = true }
 time = { workspace = true, features = ["parsing"] }
 regex = { workspace = true }
 strsim = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt"] }
+tokio = { workspace = true, features = ["fs", "macros", "rt"] }
+uuid = { workspace = true }
 ignore = { workspace = true }
 notify = { workspace = true }
 notify-debouncer-full = { workspace = true }

--- a/klaw-knowledge/README.md
+++ b/klaw-knowledge/README.md
@@ -1,16 +1,18 @@
 # klaw-knowledge
 
-`klaw-knowledge` provides read-only retrieval over external knowledge sources for Klaw.
+`klaw-knowledge` provides retrieval-first access to external knowledge sources for Klaw, including constrained write-back for Obsidian notes.
 
 ## Knowledge vs Memory
 
 - `klaw-memory` stores agent-produced long-term facts and session recall.
 - `klaw-knowledge` retrieves external knowledge owned outside the agent, such as an Obsidian vault.
+- `klaw-knowledge` can explicitly create new Obsidian notes in the configured vault, but it remains separate from agent memory storage.
 - `klaw-knowledge` does not write user knowledge back into `memory.db` or the runtime `Memory` prompt section.
 
 ## Capabilities
 
 - Provider-based knowledge retrieval via `KnowledgeProvider`
+- Constrained note creation for Obsidian vaults with immediate single-note reindexing
 - Obsidian markdown parsing, scored semantic chunking, and indexing helpers
 - Obsidian link discovery for explicit wikilinks plus exact name, alias, fuzzy Levenshtein, and unique first-name matches without rewriting vault files
 - Structured search result types (`KnowledgeHit`, `KnowledgeEntry`, `ContextBundle`)

--- a/klaw-knowledge/src/error.rs
+++ b/klaw-knowledge/src/error.rs
@@ -4,6 +4,10 @@ pub enum KnowledgeError {
     InvalidConfig(String),
     #[error("invalid query: {0}")]
     InvalidQuery(String),
+    #[error("invalid note path: {0}")]
+    InvalidNotePath(String),
+    #[error("note already exists: {0}")]
+    NoteAlreadyExists(String),
     #[error("provider error: {0}")]
     Provider(String),
     #[error("source unavailable: {0}")]

--- a/klaw-knowledge/src/lib.rs
+++ b/klaw-knowledge/src/lib.rs
@@ -17,9 +17,10 @@ pub use models::{build_local_embedding_model, build_local_orchestrator, build_lo
 pub use obsidian::provider::ObsidianKnowledgeProvider;
 pub use provider_router::KnowledgeProviderRouter;
 pub use types::{
-    KnowledgeAutoIndexHandle, KnowledgeEntry, KnowledgeHit, KnowledgeProvider,
-    KnowledgeRuntimeSnapshot, KnowledgeRuntimeState, KnowledgeSearchQuery, KnowledgeSourceInfo,
-    KnowledgeStatus, KnowledgeSyncProgress, KnowledgeSyncProgressStage, KnowledgeSyncResult,
+    CreateKnowledgeNoteInput, KnowledgeAutoIndexHandle, KnowledgeEntry, KnowledgeHit,
+    KnowledgeProvider, KnowledgeRuntimeSnapshot, KnowledgeRuntimeState, KnowledgeSearchQuery,
+    KnowledgeSourceInfo, KnowledgeStatus, KnowledgeSyncProgress, KnowledgeSyncProgressStage,
+    KnowledgeSyncResult,
 };
 
 pub async fn open_configured_obsidian_provider(

--- a/klaw-knowledge/src/obsidian/provider.rs
+++ b/klaw-knowledge/src/obsidian/provider.rs
@@ -9,10 +9,11 @@ use async_trait::async_trait;
 use klaw_model::QueryIntent;
 use klaw_storage::{DatabaseExecutor, DbRow, DbValue};
 use serde_json::{Value, json};
+use uuid::Uuid;
 
 use crate::{
-    KnowledgeEntry, KnowledgeError, KnowledgeHit, KnowledgeProvider, KnowledgeSearchQuery,
-    KnowledgeSourceInfo, KnowledgeStatus, KnowledgeSyncProgress,
+    CreateKnowledgeNoteInput, KnowledgeEntry, KnowledgeError, KnowledgeHit, KnowledgeProvider,
+    KnowledgeSearchQuery, KnowledgeSourceInfo, KnowledgeStatus, KnowledgeSyncProgress,
     models::{EmbeddingModel, KnowledgeOrchestration, OrchestratorModel, RerankModel},
     obsidian::indexer::{
         KNOWLEDGE_VECTOR_INDEX_NAME, embed_missing_chunks, embed_missing_chunks_with_progress,
@@ -129,6 +130,46 @@ impl ObsidianKnowledgeProvider {
 
     pub fn start_auto_index_watcher(&self) -> Result<AutoIndexWatcher, KnowledgeError> {
         start_auto_index_watcher(self.clone())
+    }
+
+    pub async fn create_note(
+        &self,
+        input: CreateKnowledgeNoteInput,
+    ) -> Result<KnowledgeEntry, KnowledgeError> {
+        let relative_path = normalize_note_path(&input.path)?;
+        let absolute_path = self.vault_root.join(&relative_path);
+        if absolute_path.exists() {
+            return Err(KnowledgeError::NoteAlreadyExists(relative_path));
+        }
+
+        let parent = absolute_path.parent().ok_or_else(|| {
+            KnowledgeError::InvalidNotePath("note path must include a file name".to_string())
+        })?;
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|err| KnowledgeError::Provider(format!("create note parent failed: {err}")))?;
+
+        let temp_path = temp_note_path(&absolute_path);
+        tokio::fs::write(&temp_path, input.content)
+            .await
+            .map_err(|err| KnowledgeError::Provider(format!("write note failed: {err}")))?;
+        if let Err(err) = tokio::fs::rename(&temp_path, &absolute_path).await {
+            let _ = tokio::fs::remove_file(&temp_path).await;
+            return Err(KnowledgeError::Provider(format!("finalize note failed: {err}")));
+        }
+
+        if let Err(err) = self.index_path(&absolute_path).await {
+            let _ = tokio::fs::remove_file(&absolute_path).await;
+            return Err(KnowledgeError::Provider(format!(
+                "reindex after note creation failed: {err}"
+            )));
+        }
+
+        self.get(&relative_path).await?.ok_or_else(|| {
+            KnowledgeError::Provider(format!(
+                "created note missing from knowledge index: {relative_path}"
+            ))
+        })
     }
 
     pub async fn reindex_with_progress<F>(&self, progress: F) -> Result<usize, KnowledgeError>
@@ -614,6 +655,13 @@ impl KnowledgeProvider for ObsidianKnowledgeProvider {
             entry_count: self.entry_count().await?,
         }])
     }
+
+    async fn create_note(
+        &self,
+        input: CreateKnowledgeNoteInput,
+    ) -> Result<KnowledgeEntry, KnowledgeError> {
+        ObsidianKnowledgeProvider::create_note(self, input).await
+    }
 }
 
 impl ObsidianKnowledgeProvider {
@@ -773,6 +821,59 @@ fn is_vector_query_capability_error(message: &str) -> bool {
         || normalized.contains("libsql_vector_idx")
         || normalized.contains("no such function")
         || normalized.contains("no such module")
+}
+
+fn normalize_note_path(path: &str) -> Result<String, KnowledgeError> {
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        return Err(KnowledgeError::InvalidNotePath(
+            "note path cannot be empty".to_string(),
+        ));
+    }
+    if trimmed.starts_with('/') || Path::new(trimmed).is_absolute() {
+        return Err(KnowledgeError::InvalidNotePath(
+            "note path must be relative to the vault root".to_string(),
+        ));
+    }
+    if !trimmed.ends_with(".md") {
+        return Err(KnowledgeError::InvalidNotePath(
+            "note path must end with `.md`".to_string(),
+        ));
+    }
+
+    let mut normalized = PathBuf::new();
+    for component in Path::new(trimmed).components() {
+        match component {
+            std::path::Component::Normal(part) => normalized.push(part),
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                return Err(KnowledgeError::InvalidNotePath(
+                    "note path cannot escape the vault root".to_string(),
+                ));
+            }
+            _ => {
+                return Err(KnowledgeError::InvalidNotePath(
+                    "note path contains unsupported components".to_string(),
+                ));
+            }
+        }
+    }
+
+    let normalized = normalized.to_string_lossy().replace('\\', "/");
+    if normalized.is_empty() {
+        return Err(KnowledgeError::InvalidNotePath(
+            "note path must include a file name".to_string(),
+        ));
+    }
+    Ok(normalized)
+}
+
+fn temp_note_path(absolute_path: &Path) -> PathBuf {
+    let file_name = absolute_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("note.md");
+    absolute_path.with_file_name(format!("{file_name}.{}.tmp", Uuid::new_v4()))
 }
 
 fn dedup_ranked_hits<F>(rows: Vec<DbRow>, map: F) -> Vec<RankedHit>
@@ -1453,5 +1554,73 @@ mod tests {
                 .and_then(Value::as_array)
                 .is_some_and(|lanes| lanes.iter().any(|lane| lane == "rerank"))
         }));
+    }
+
+    #[test]
+    fn normalize_note_path_rejects_invalid_paths() {
+        assert!(matches!(
+            normalize_note_path("/tmp/note.md"),
+            Err(KnowledgeError::InvalidNotePath(_))
+        ));
+        assert!(matches!(
+            normalize_note_path("../note.md"),
+            Err(KnowledgeError::InvalidNotePath(_))
+        ));
+        assert!(matches!(
+            normalize_note_path("notes/note.txt"),
+            Err(KnowledgeError::InvalidNotePath(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn create_note_writes_indexes_and_returns_entry() {
+        let provider = test_provider_unindexed().await;
+        let entry = provider
+            .create_note(CreateKnowledgeNoteInput {
+                path: "notes/new.md".to_string(),
+                content: "# New\n\nFresh knowledge for the vault.".to_string(),
+            })
+            .await
+            .expect("create note should succeed");
+
+        assert_eq!(entry.id, "notes/new.md");
+        assert_eq!(entry.uri, "notes/new.md");
+        assert!(provider.vault_root().join("notes/new.md").exists());
+
+        let indexed = provider
+            .get("notes/new.md")
+            .await
+            .expect("get should succeed")
+            .expect("entry should be indexed");
+        assert!(indexed.content.contains("Fresh knowledge"));
+
+        let hits = provider
+            .search(KnowledgeSearchQuery {
+                text: "fresh knowledge".to_string(),
+                ..Default::default()
+            })
+            .await
+            .expect("search should succeed");
+        assert!(hits.iter().any(|hit| hit.id == "notes/new.md"));
+    }
+
+    #[tokio::test]
+    async fn create_note_rejects_existing_paths_without_overwriting() {
+        let provider = test_provider_unindexed().await;
+        let original = std::fs::read_to_string(provider.vault_root().join("auth.md"))
+            .expect("existing note should be readable");
+
+        let err = provider
+            .create_note(CreateKnowledgeNoteInput {
+                path: "auth.md".to_string(),
+                content: "# Replacement".to_string(),
+            })
+            .await
+            .expect_err("existing path should fail");
+
+        assert!(matches!(err, KnowledgeError::NoteAlreadyExists(_)));
+        let current = std::fs::read_to_string(provider.vault_root().join("auth.md"))
+            .expect("existing note should remain readable");
+        assert_eq!(current, original);
     }
 }

--- a/klaw-knowledge/src/provider_router.rs
+++ b/klaw-knowledge/src/provider_router.rs
@@ -1,8 +1,8 @@
 use std::{collections::BTreeMap, sync::Arc};
 
 use crate::{
-    KnowledgeEntry, KnowledgeError, KnowledgeHit, KnowledgeProvider, KnowledgeSearchQuery,
-    KnowledgeSourceInfo,
+    CreateKnowledgeNoteInput, KnowledgeEntry, KnowledgeError, KnowledgeHit, KnowledgeProvider,
+    KnowledgeSearchQuery, KnowledgeSourceInfo,
 };
 
 #[derive(Default, Clone)]
@@ -57,6 +57,17 @@ impl KnowledgeProviderRouter {
             .get(provider_name)
             .ok_or_else(|| KnowledgeError::SourceUnavailable(provider_name.to_string()))?;
         provider.list_sources().await
+    }
+
+    pub async fn create_note(
+        &self,
+        provider_name: &str,
+        input: CreateKnowledgeNoteInput,
+    ) -> Result<KnowledgeEntry, KnowledgeError> {
+        let provider = self
+            .get(provider_name)
+            .ok_or_else(|| KnowledgeError::SourceUnavailable(provider_name.to_string()))?;
+        provider.create_note(input).await
     }
 }
 
@@ -114,6 +125,23 @@ mod tests {
                 entry_count: 1,
             }])
         }
+
+        async fn create_note(
+            &self,
+            input: CreateKnowledgeNoteInput,
+        ) -> Result<KnowledgeEntry, KnowledgeError> {
+            Ok(KnowledgeEntry {
+                id: input.path.clone(),
+                title: "Created".to_string(),
+                content: input.content,
+                tags: vec![],
+                uri: input.path,
+                source: "mock".to_string(),
+                metadata: json!({}),
+                created_at_ms: 1,
+                updated_at_ms: 1,
+            })
+        }
     }
 
     #[tokio::test]
@@ -138,6 +166,18 @@ mod tests {
             .await
             .expect("get should succeed");
         assert_eq!(entry.expect("entry").content, "full content");
+
+        let created = router
+            .create_note(
+                "mock",
+                CreateKnowledgeNoteInput {
+                    path: "notes/new.md".to_string(),
+                    content: "# New".to_string(),
+                },
+            )
+            .await
+            .expect("create should succeed");
+        assert_eq!(created.uri, "notes/new.md");
     }
 
     #[tokio::test]

--- a/klaw-knowledge/src/types.rs
+++ b/klaw-knowledge/src/types.rs
@@ -29,6 +29,12 @@ pub struct KnowledgeEntry {
     pub updated_at_ms: i64,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CreateKnowledgeNoteInput {
+    pub path: String,
+    pub content: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct KnowledgeSourceInfo {
     pub provider: String,
@@ -120,6 +126,11 @@ pub trait KnowledgeProvider: Send + Sync {
     async fn get(&self, id: &str) -> Result<Option<KnowledgeEntry>, KnowledgeError>;
 
     async fn list_sources(&self) -> Result<Vec<KnowledgeSourceInfo>, KnowledgeError>;
+
+    async fn create_note(
+        &self,
+        input: CreateKnowledgeNoteInput,
+    ) -> Result<KnowledgeEntry, KnowledgeError>;
 }
 
 #[async_trait]

--- a/klaw-runtime/src/knowledge_runtime.rs
+++ b/klaw-runtime/src/knowledge_runtime.rs
@@ -6,10 +6,10 @@ use std::sync::{
 use async_trait::async_trait;
 use klaw_config::AppConfig;
 use klaw_knowledge::{
-    KnowledgeAutoIndexHandle, KnowledgeEntry, KnowledgeError, KnowledgeHit, KnowledgeProvider,
-    KnowledgeRuntimeSnapshot, KnowledgeRuntimeState, KnowledgeSearchQuery, KnowledgeSourceInfo,
-    KnowledgeStatus, KnowledgeSyncProgress, KnowledgeSyncResult, ObsidianKnowledgeProvider,
-    open_configured_obsidian_provider,
+    CreateKnowledgeNoteInput, KnowledgeAutoIndexHandle, KnowledgeEntry, KnowledgeError,
+    KnowledgeHit, KnowledgeProvider, KnowledgeRuntimeSnapshot, KnowledgeRuntimeState,
+    KnowledgeSearchQuery, KnowledgeSourceInfo, KnowledgeStatus, KnowledgeSyncProgress,
+    KnowledgeSyncResult, ObsidianKnowledgeProvider, open_configured_obsidian_provider,
 };
 use tokio::sync::{Mutex, Notify, mpsc};
 
@@ -337,6 +337,13 @@ impl KnowledgeProvider for KnowledgeRuntimeService {
     async fn list_sources(&self) -> Result<Vec<KnowledgeSourceInfo>, KnowledgeError> {
         self.ready_provider().await?.list_sources().await
     }
+
+    async fn create_note(
+        &self,
+        input: CreateKnowledgeNoteInput,
+    ) -> Result<KnowledgeEntry, KnowledgeError> {
+        self.ready_provider().await?.create_note(input).await
+    }
 }
 
 fn initial_snapshot(config: &AppConfig) -> KnowledgeRuntimeSnapshot {
@@ -378,9 +385,9 @@ mod tests {
     use async_trait::async_trait;
     use klaw_config::AppConfig;
     use klaw_knowledge::{
-        KnowledgeAutoIndexHandle, KnowledgeEntry, KnowledgeError, KnowledgeHit, KnowledgeProvider,
-        KnowledgeRuntimeState, KnowledgeSearchQuery, KnowledgeSourceInfo, KnowledgeStatus,
-        KnowledgeSyncProgress, KnowledgeSyncResult,
+        CreateKnowledgeNoteInput, KnowledgeAutoIndexHandle, KnowledgeEntry, KnowledgeError,
+        KnowledgeHit, KnowledgeProvider, KnowledgeRuntimeState, KnowledgeSearchQuery,
+        KnowledgeSourceInfo, KnowledgeStatus, KnowledgeSyncProgress, KnowledgeSyncResult,
     };
     use tokio::sync::mpsc;
 
@@ -447,6 +454,23 @@ mod tests {
 
         async fn list_sources(&self) -> Result<Vec<KnowledgeSourceInfo>, KnowledgeError> {
             Ok(Vec::new())
+        }
+
+        async fn create_note(
+            &self,
+            input: CreateKnowledgeNoteInput,
+        ) -> Result<KnowledgeEntry, KnowledgeError> {
+            Ok(KnowledgeEntry {
+                id: input.path.clone(),
+                title: "Created".to_string(),
+                content: input.content,
+                tags: Vec::new(),
+                uri: input.path,
+                source: "fake".to_string(),
+                metadata: serde_json::json!({}),
+                created_at_ms: 1,
+                updated_at_ms: 1,
+            })
         }
     }
 

--- a/klaw-tool/CHANGELOG.md
+++ b/klaw-tool/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2026-04-27
+
+### Added
+- `knowledge` 工具新增 `create_note` 动作，可按 vault 相对路径创建新的 Obsidian Markdown 笔记并返回立即可检索的 `KnowledgeEntry`
+
+### Changed
+- `knowledge` 工具文档与参数 schema 现在显式区分受限写回能力：仅支持 Obsidian、新建 `.md` 笔记、路径必须位于 vault 内
+
+### Fixed
+- `knowledge.create_note` 现在会把 provider 侧路径校验错误映射为参数错误，帮助调用方更快收敛到合法请求
+
 ## 2026-04-25
 
 ### Fixed

--- a/klaw-tool/README.md
+++ b/klaw-tool/README.md
@@ -23,6 +23,7 @@
 - `shell` approval-required signals now include `command_preview` so channel-specific approval cards can render the pending command directly from outbound metadata
 - the `channel_attachment` tool is gated by `tools.channel_attachment.enabled`, and its local path policy comes from `tools.channel_attachment.local_attachments`
 - the `knowledge` tool can be registered with the runtime-owned Knowledge provider, so tool calls share the same loaded service as GUI search and explicit index/vector sync
+- the `knowledge` tool now supports `create_note` for constrained Obsidian vault write-back; created notes are indexed immediately and become available to subsequent knowledge searches
 - the `shell` tool now supports two rule lists: `blocked_patterns` reject immediately, while `unsafe_patterns` require approval; commands that match neither execute directly
 - the `cron_manager` tool accepts planner-friendly schedule inputs such as 5-field cron (`0 8 * * *`), `every 24h`, and daily time shorthand (`8:00`), then normalizes them before persistence
 - the `cron_manager` tool also accepts either a JSON object or a JSON string for payloads, and tolerates common boolean strings like `"true"` / `"false"` for `enabled`

--- a/klaw-tool/src/knowledge.rs
+++ b/klaw-tool/src/knowledge.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use klaw_config::{AppConfig, KnowledgeToolConfig};
 use klaw_knowledge::{
-    KnowledgeEntry, KnowledgeHit, KnowledgeProvider, KnowledgeSearchQuery, assemble_context_bundle,
-    open_configured_obsidian_provider,
+    CreateKnowledgeNoteInput, KnowledgeEntry, KnowledgeHit, KnowledgeProvider,
+    KnowledgeSearchQuery, assemble_context_bundle, open_configured_obsidian_provider,
 };
 use serde_json::{Value, json};
 
@@ -76,6 +76,14 @@ impl KnowledgeTool {
             .ok_or_else(|| ToolError::InvalidArgs(format!("missing `{key}`")))
     }
 
+    fn require_nonempty_content(args: &Value, key: &'static str) -> Result<String, ToolError> {
+        args.get(key)
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+            .ok_or_else(|| ToolError::InvalidArgs(format!("missing `{key}`")))
+    }
+
     fn parse_limit(value: Option<u64>, fallback: usize) -> Result<usize, ToolError> {
         match value {
             Some(limit) if limit > 0 => Ok(limit as usize),
@@ -101,6 +109,22 @@ impl KnowledgeTool {
             parsed.push(tag.trim().to_string());
         }
         Ok(Some(parsed))
+    }
+
+    fn validate_source(args: &Value) -> Result<(), ToolError> {
+        let Some(source) = args.get("source") else {
+            return Ok(());
+        };
+        let source = source
+            .as_str()
+            .ok_or_else(|| ToolError::InvalidArgs("`source` must be a string".to_string()))?;
+        let source = source.trim();
+        if source.is_empty() || matches!(source, "obsidian" | "Obsidian Vault") {
+            return Ok(());
+        }
+        Err(ToolError::InvalidArgs(format!(
+            "`source` must match the configured Obsidian provider, got `{source}`"
+        )))
     }
 
     async fn run_search(&self, args: &Value) -> Result<Vec<KnowledgeHit>, ToolError> {
@@ -139,49 +163,125 @@ impl Tool for KnowledgeTool {
     }
 
     fn description(&self) -> &str {
-        "Search connected knowledge bases such as an Obsidian vault for relevant notes, documents, and reference material. Use this when the answer may exist in the user's personal or project knowledge sources."
+        "Access the user's connected knowledge base (e.g. an Obsidian vault) to retrieve or store information. Use `search` to find relevant notes by keywords or tags. Use `get` to fetch a specific note by its ID. Use `context` to assemble a compact, budget-controlled context bundle for injection into the conversation. Use `list_sources` to discover available knowledge sources. Use `create_note` to write a new note into the vault when the user asks you to save or record information persistently."
     }
 
     fn parameters(&self) -> Value {
         json!({
             "type": "object",
-            "description": "Search read-only knowledge sources, fetch a specific entry, or assemble a context bundle.",
+            "description": "Interact with the user's knowledge base (Obsidian vault). Choose an action to search notes, retrieve a specific entry, build a compact context bundle, discover available sources, or create a new note.",
             "oneOf": [
                 {
+                    "description": "List all configured knowledge sources (e.g. Obsidian vault name, provider, entry count). Use this first to discover what sources are available before searching.",
                     "properties": {
-                        "action": { "const": "list_sources" }
+                        "action": {
+                            "const": "list_sources",
+                            "description": "List available knowledge sources and their metadata."
+                        }
                     },
                     "required": ["action"],
                     "additionalProperties": false
                 },
                 {
+                    "description": "Search the knowledge base for notes matching a query. Returns ranked hits with title, excerpt, score, and tags. Use this when you need relevant reference material on a topic.",
                     "properties": {
-                        "action": { "const": "search" },
-                        "query": { "type": "string", "minLength": 1 },
-                        "tags": { "type": "array", "items": { "type": "string" } },
-                        "limit": { "type": "integer", "minimum": 1 },
-                        "source": { "type": "string" },
-                        "mode": { "type": "string" }
+                        "action": {
+                            "const": "search",
+                            "description": "Search knowledge base for relevant notes."
+                        },
+                        "query": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "Natural language search query describing the topic or question. Use specific keywords for better results, e.g. 'Rust async error handling' or 'project deployment workflow'."
+                        },
+                        "tags": {
+                            "type": "array",
+                            "items": { "type": "string" },
+                            "description": "Filter results to notes that contain at least one of these Obsidian tags (without the # prefix). Example: ['project-alpha', 'meeting-notes']."
+                        },
+                        "limit": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "description": "Maximum number of search hits to return. Defaults to the runtime-configured search limit (typically 10)."
+                        },
+                        "source": {
+                            "type": "string",
+                            "description": "Restrict search to a specific knowledge source by name. Must match a source returned by `list_sources`. Example: 'Obsidian Vault'."
+                        },
+                        "mode": {
+                            "type": "string",
+                            "enum": ["keyword", "semantic", "hybrid"],
+                            "description": "Search retrieval mode. 'keyword' matches exact terms, 'semantic' uses embedding similarity for conceptual matches, 'hybrid' combines both. Defaults to the provider's default mode."
+                        }
                     },
                     "required": ["action", "query"],
                     "additionalProperties": false
                 },
                 {
+                    "description": "Retrieve a single knowledge entry by its unique ID. Returns the full note content, metadata, tags, and timestamps. Use this when you already have an entry ID (e.g. from a prior search hit) and need the complete document.",
                     "properties": {
-                        "action": { "const": "get" },
-                        "id": { "type": "string", "minLength": 1 }
+                        "action": {
+                            "const": "get",
+                            "description": "Retrieve a specific knowledge entry by ID."
+                        },
+                        "id": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "Unique identifier of the knowledge entry to retrieve. This is the `id` field returned by `search` or `list_sources`."
+                        }
                     },
                     "required": ["action", "id"],
                     "additionalProperties": false
                 },
                 {
+                    "description": "Search the knowledge base and assemble a compact context bundle that fits within a character budget. Use this instead of `search` when you need a ready-to-inject summary of relevant knowledge that won't overwhelm the conversation context.",
                     "properties": {
-                        "action": { "const": "context" },
-                        "query": { "type": "string", "minLength": 1 },
-                        "limit": { "type": "integer", "minimum": 1 },
-                        "budget_chars": { "type": "integer", "minimum": 1 }
+                        "action": {
+                            "const": "context",
+                            "description": "Assemble a budget-controlled context bundle from search results."
+                        },
+                        "query": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "Natural language query describing the topic for which context is needed."
+                        },
+                        "limit": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "description": "Maximum number of search hits to consider for the bundle. Defaults to the runtime-configured context limit (typically 5)."
+                        },
+                        "budget_chars": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "description": "Maximum total character length of the assembled context bundle. Excerpts are trimmed to fit within this budget. Defaults to 2000."
+                        }
                     },
                     "required": ["action", "query"],
+                    "additionalProperties": false
+                },
+                {
+                    "description": "Create a new note in the user's Obsidian vault. Use this when the user explicitly asks you to save, record, or write information into their knowledge base, or when a conversation result should be persisted as a vault note.",
+                    "properties": {
+                        "action": {
+                            "const": "create_note",
+                            "description": "Create a new note in the knowledge base."
+                        },
+                        "path": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "Vault-relative path for the new note, including the filename with a .md extension. Subfolders are created automatically. Example: 'projects/alpha/meeting-2024-01-15.md'."
+                        },
+                        "content": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "Full Markdown content of the note. Obsidian wikilinks, tags, and frontmatter (YAML) are supported."
+                        },
+                        "source": {
+                            "type": "string",
+                            "description": "Target knowledge source where the note should be created. Must match a source returned by `list_sources`. Defaults to the primary configured vault."
+                        }
+                    },
+                    "required": ["action", "path", "content"],
                     "additionalProperties": false
                 }
             ]
@@ -234,9 +334,31 @@ impl Tool for KnowledgeTool {
                     "bundle": assemble_context_bundle(&query, &hits, budget_chars),
                 })
             }
+            "create_note" => {
+                Self::validate_source(&args)?;
+                let path = Self::require_string(&args, "path")?;
+                let content = Self::require_nonempty_content(&args, "content")?;
+                let entry = self
+                    .provider
+                    .create_note(CreateKnowledgeNoteInput { path, content })
+                    .await
+                    .map_err(map_knowledge_error)?;
+                let path = entry.uri.clone();
+                let id = entry.id.clone();
+                let uri = entry.uri.clone();
+                json!({
+                    "action": "create_note",
+                    "created": true,
+                    "path": path,
+                    "id": id,
+                    "uri": uri,
+                    "entry": entry,
+                })
+            }
             _ => {
                 return Err(ToolError::InvalidArgs(
-                    "`action` must be one of list_sources/search/get/context".to_string(),
+                    "`action` must be one of list_sources/search/get/context/create_note"
+                        .to_string(),
                 ));
             }
         };
@@ -255,7 +377,10 @@ impl Tool for KnowledgeTool {
 fn map_knowledge_error(err: klaw_knowledge::KnowledgeError) -> ToolError {
     match err {
         klaw_knowledge::KnowledgeError::InvalidConfig(message)
-        | klaw_knowledge::KnowledgeError::InvalidQuery(message) => ToolError::InvalidArgs(message),
+        | klaw_knowledge::KnowledgeError::InvalidQuery(message)
+        | klaw_knowledge::KnowledgeError::InvalidNotePath(message) => {
+            ToolError::InvalidArgs(message)
+        }
         other => ToolError::ExecutionFailed(other.to_string()),
     }
 }
@@ -267,7 +392,7 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use async_trait::async_trait;
-    use klaw_knowledge::{KnowledgeError, KnowledgeSourceInfo};
+    use klaw_knowledge::{CreateKnowledgeNoteInput, KnowledgeError, KnowledgeSourceInfo};
     use serde_json::json;
 
     use super::*;
@@ -352,6 +477,23 @@ mod tests {
                 entry_count: 1,
             }])
         }
+
+        async fn create_note(
+            &self,
+            input: CreateKnowledgeNoteInput,
+        ) -> Result<KnowledgeEntry, KnowledgeError> {
+            Ok(KnowledgeEntry {
+                id: input.path.clone(),
+                title: "Created".to_string(),
+                content: input.content,
+                tags: vec!["created".to_string()],
+                uri: input.path,
+                source: "mock".to_string(),
+                metadata: json!({}),
+                created_at_ms: 2,
+                updated_at_ms: 2,
+            })
+        }
     }
 
     fn tool() -> KnowledgeTool {
@@ -430,5 +572,30 @@ mod tests {
             .expect("context should succeed");
         assert!(output.content_for_model.contains("\"bundle\""));
         assert!(output.content_for_model.contains("Direct match"));
+    }
+
+    #[tokio::test]
+    async fn create_note_action_returns_created_entry() {
+        let output = tool()
+            .execute(
+                json!({"action":"create_note","path":"notes/new.md","content":"# New note"}),
+                &ctx(),
+            )
+            .await
+            .expect("create_note should succeed");
+        assert!(output.content_for_model.contains("\"created\": true"));
+        assert!(output.content_for_model.contains("notes/new.md"));
+    }
+
+    #[tokio::test]
+    async fn create_note_rejects_unknown_source() {
+        let err = tool()
+            .execute(
+                json!({"action":"create_note","path":"notes/new.md","content":"# New note","source":"notion"}),
+                &ctx(),
+            )
+            .await
+            .expect_err("create_note should reject unsupported source");
+        assert!(matches!(err, ToolError::InvalidArgs(_)));
     }
 }


### PR DESCRIPTION
## Purpose

Introduce a `PromptExtension` trait that conditionally includes template sections based on runtime environment conditions. Template files use Handlebars `{{#if name}}` / `{{/if}}` blocks; the condition check (`is_active()`) is implemented in code, not left to the LLM.

Closes #220

## Impacted Crates

- `klaw-core` (prompt module)

## Key Changes

- Add `handlebars = 6` workspace dependency
- Add `PromptExtension` trait (`name`, `is_active`, `prompt_section`) — condition checks are implemented in code (e.g., probing the system for a command)
- Add `RtkPromptExtension` — checks whether `rtk` command-proxy exists via `which`/`where`. When active, all shell-tool commands must be prefixed with `rtk`
- Add `render_template_with_extensions()` using Handlebars (`strict_mode=false`, fallback to raw content on rendering errors)
- Add `build_runtime_system_prompt_with_extensions()` for explicit extension control; original `build_runtime_system_prompt()` keeps backward compatibility via `default_prompt_extensions()`
- Modify `format_inlined_workspace_context_for_prompt_in_dir()` to render each inlined file through Handlebars before including it
- Add rtk extension section to `AGENTS.md` template wrapped in `{{#if rtk}}` / `{{/if}}`
- Export new types from `klaw-core/src/lib.rs`

## AGENTS.md Template

```markdown
{{#if rtk}}
## Extension Agent: rtk Command Proxy

The rtk command is available on this system and acts as a proxy/wrapper for shell operations.
**Rule:** When using the shell tool to execute commands, **always prefix the command with `rtk`**.
- Instead of `git status` → run `rtk git status`
- Instead of `npm install` → run `rtk npm install`
{{/if}}
```

The condition (`rtk` exists on the system) is checked in Rust code by `is_command_available("rtk")`, not by the LLM.

## Extensibility

Adding a new prompt extension requires:
1. Implement `PromptExtension` trait (write the condition check in `is_active()`)
2. Wrap the template section with `{{#if new_name}}` / `{{/if}}` in AGENTS.md or other template files
3. Register the extension in `default_prompt_extensions()`

## Test Evidence

```
cargo test -p klaw-core --offline
# 35 unit tests + 4 integration tests — all passed
```

New tests added:
- `render_template_keeps_active_if_block`
- `render_template_strips_inactive_if_block`
- `render_template_preserves_content_without_handlebars_syntax`
- `render_template_handles_multiple_extensions`
- `render_template_if_else_block_works`
- `render_template_falls_back_on_invalid_syntax`
- `rtk_prompt_extension_has_correct_name`
- `rtk_prompt_extension_section_contains_shell_prefix_rule`
- `is_command_available_returns_false_for_nonexistent_command`
- `default_prompt_extensions_includes_rtk`
- `format_inlined_workspace_context_strips_inactive_extension_from_template`
- `format_inlined_workspace_context_keeps_active_extension_from_template`
