### PR TITLE
feat(webui): switch websocket transport to gateway v1

### DIFF
--- a/docs/src/gateway/websocket-v1.md
+++ b/docs/src/gateway/websocket-v1.md
@@ -1,6 +1,6 @@
 # Gateway WebSocket v1 基线协议
 
-Gateway WebSocket v1 是 `klaw-gateway` 面向 WebUI、桌面端、移动端和第三方客户端的长期 agent 交互协议底座。旧版 `type: "method"` 协议继续保留为兼容层，新客户端应优先使用 v1 JSON-RPC 形态。
+Gateway WebSocket v1 是 `klaw-gateway` 面向 WebUI、桌面端、移动端和第三方客户端的长期 agent 交互协议底座。`klaw-webui` 已直接切换到 v1 JSON-RPC envelope，不再把旧版 `type: "method"` 帧作为正常收发路径。
 
 ## Envelope
 
@@ -17,7 +17,7 @@ v1 使用 JSON-RPC 2.0 语义，但线上帧省略 `jsonrpc` 字段。每个 Web
 
 ## 初始化
 
-连接建立后服务端仍会发送旧版 `session.connected` 事件以兼容现有客户端。v1 客户端随后发送 `initialize`：
+v1 客户端连接建立后发送 `initialize`：
 
 ```json
 {
@@ -42,6 +42,26 @@ v1 使用 JSON-RPC 2.0 语义，但线上帧省略 `jsonrpc` 字段。每个 Web
 ```
 
 响应包含协议名、连接 ID、服务端信息和协商后的 capabilities。实验字段必须通过 `capabilities.experimental = true` 显式启用。
+
+## 工作区与历史
+
+WebUI 启动后使用 v1 方法加载工作区、provider 和历史：
+
+```json
+{ "id": "sessions_1", "method": "session/list", "params": {} }
+{ "id": "providers_1", "method": "provider/list", "params": {} }
+{
+  "id": "history_1",
+  "method": "thread/history",
+  "params": {
+    "session_key": "websocket:session",
+    "before_message_id": null,
+    "limit": 30
+  }
+}
+```
+
+会话操作使用 `session/create`、`session/update`、`session/delete`、`session/subscribe` 和 `session/unsubscribe`。所有响应均使用 v1 success/error envelope，不返回旧版 `type: "result"`。
 
 ## 身份模型
 
@@ -82,7 +102,7 @@ v1 使用 JSON-RPC 2.0 语义，但线上帧省略 `jsonrpc` 字段。每个 Web
 { "method": "turn/completed", "params": { "turn_id": "turn_1", "status": "completed" } }
 ```
 
-旧版 `session.message` 与 `session.stream.*` 会继续发送，直到客户端迁移完成。
+WebUI 以 `item/*` 与 `turn/*` 为实时渲染主路径，不依赖旧版 `session.message` 或 `session.stream.*` 帧。
 
 ## 内容与工具
 
@@ -130,7 +150,7 @@ v1 稳定 item 类型包括 `userMessage`、`agentMessage`、`reasoning`、`plan
 }
 ```
 
-协议预留 `turn/steer`、`turn/read`、`thread/resume`、`thread/history` 和 `thread/rollback`，用于后续恢复、追加输入、分页历史和回滚能力。
+协议预留 `turn/steer`、`turn/read`、`thread/resume` 和 `thread/rollback`，用于后续恢复、追加输入和回滚能力；`thread/history` 当前用于分页读取会话历史。
 
 ## 错误与背压
 

--- a/klaw-gateway/CHANGELOG.md
+++ b/klaw-gateway/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - 新增 Gateway WebSocket v1 基线协议类型，覆盖 JSON-RPC envelope、initialize capabilities、turn/item 生命周期、结构化 content blocks、tool call、approval request、server request resolved、稳定错误码与 JSON Schema bundle
 - `/ws/chat` 现在接受 v1 `initialize`、`turn/start`、`turn/cancel`、`approval/respond`、`tool/respond` 和 `user_input/respond` JSON-RPC 形态帧，并继续兼容旧版 `type: "method"` 协议
+- `/ws/chat` v1 现在实现 WebUI 所需的 `session/list`、`session/create`、`session/update`、`session/delete`、`session/subscribe`、`session/unsubscribe`、`provider/list` 和 `thread/history` 方法，响应统一使用 v1 success/error envelope
 - v1 streaming 在 runtime 可根据 websocket v1 metadata 额外发出 `item/started`、`item/agentMessage/delta`、`item/completed` 和 `turn/completed` 通知
 - 新增 Gateway WebSocket v1 mdBook 文档，说明身份模型、生命周期、工具审批、背压、安全和迁移策略
 

--- a/klaw-gateway/src/protocol.rs
+++ b/klaw-gateway/src/protocol.rs
@@ -128,6 +128,12 @@ pub enum GatewayProtocolMethod {
     SessionSubscribe,
     #[serde(rename = "session/unsubscribe")]
     SessionUnsubscribe,
+    #[serde(rename = "session/subscribed")]
+    SessionSubscribed,
+    #[serde(rename = "session/unsubscribed")]
+    SessionUnsubscribed,
+    #[serde(rename = "provider/list")]
+    ProviderList,
     #[serde(rename = "thread/start")]
     ThreadStart,
     #[serde(rename = "thread/resume")]

--- a/klaw-gateway/src/tests.rs
+++ b/klaw-gateway/src/tests.rs
@@ -567,6 +567,386 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn websocket_v1_session_list_returns_workspace_bootstrap() {
+        let config = test_gateway_config();
+        let handle = match spawn_gateway_with_options(
+            &config,
+            GatewayOptions {
+                websocket_handler: Some(Arc::new(RecordingWebsocketHandler::default())),
+                ..GatewayOptions::default()
+            },
+        )
+        .await
+        {
+            Ok(handle) => handle,
+            Err(crate::GatewayError::Bind(err))
+                if err.kind() == std::io::ErrorKind::PermissionDenied =>
+            {
+                return;
+            }
+            Err(err) => panic!("gateway should start: {err}"),
+        };
+
+        let (mut socket, _) = connect_async(ws_url(handle.info().actual_port, None))
+            .await
+            .expect("websocket should connect");
+        let _connected = socket.next().await;
+
+        socket
+            .send(Message::Text(
+                json!({
+                    "id": "sessions-v1",
+                    "method": "session/list",
+                    "params": {}
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .expect("session/list should send");
+
+        let frame = socket
+            .next()
+            .await
+            .expect("session/list response")
+            .expect("session/list message");
+        let Message::Text(text) = frame else {
+            panic!("unexpected session/list frame: {frame:?}");
+        };
+        let frame =
+            serde_json::from_str::<serde_json::Value>(&text).expect("session/list should parse");
+        assert_eq!(
+            frame.get("id").and_then(|value| value.as_str()),
+            Some("sessions-v1")
+        );
+        assert!(frame.get("type").is_none());
+        assert_eq!(
+            frame
+                .pointer("/result/sessions/0/session_key")
+                .and_then(|value| value.as_str()),
+            Some("websocket:newer")
+        );
+        assert_eq!(
+            frame
+                .pointer("/result/active_session_key")
+                .and_then(|value| value.as_str()),
+            Some("websocket:newer")
+        );
+
+        handle.shutdown().await.expect("gateway should stop");
+    }
+
+    #[tokio::test]
+    async fn websocket_v1_provider_list_returns_runtime_provider_catalog() {
+        let config = test_gateway_config();
+        let handle = match spawn_gateway_with_options(
+            &config,
+            GatewayOptions {
+                websocket_handler: Some(Arc::new(RecordingWebsocketHandler::default())),
+                ..GatewayOptions::default()
+            },
+        )
+        .await
+        {
+            Ok(handle) => handle,
+            Err(crate::GatewayError::Bind(err))
+                if err.kind() == std::io::ErrorKind::PermissionDenied =>
+            {
+                return;
+            }
+            Err(err) => panic!("gateway should start: {err}"),
+        };
+
+        let (mut socket, _) = connect_async(ws_url(handle.info().actual_port, None))
+            .await
+            .expect("websocket should connect");
+        let _connected = socket.next().await;
+
+        socket
+            .send(Message::Text(
+                json!({
+                    "id": "providers-v1",
+                    "method": "provider/list",
+                    "params": {}
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .expect("provider/list should send");
+
+        let frame = socket
+            .next()
+            .await
+            .expect("provider/list response")
+            .expect("provider/list message");
+        let Message::Text(text) = frame else {
+            panic!("unexpected provider/list frame: {frame:?}");
+        };
+        let frame =
+            serde_json::from_str::<serde_json::Value>(&text).expect("provider/list should parse");
+        assert_eq!(
+            frame.get("id").and_then(|value| value.as_str()),
+            Some("providers-v1")
+        );
+        assert_eq!(
+            frame
+                .pointer("/result/default_provider")
+                .and_then(|value| value.as_str()),
+            Some("anthropic")
+        );
+        assert_eq!(
+            frame
+                .pointer("/result/providers/0/id")
+                .and_then(|value| value.as_str()),
+            Some("anthropic")
+        );
+
+        handle.shutdown().await.expect("gateway should stop");
+    }
+
+    #[tokio::test]
+    async fn websocket_v1_session_create_update_delete_and_subscribe_use_rpc_frames() {
+        let config = test_gateway_config();
+        let handle = match spawn_gateway_with_options(
+            &config,
+            GatewayOptions {
+                websocket_handler: Some(Arc::new(RecordingWebsocketHandler::default())),
+                ..GatewayOptions::default()
+            },
+        )
+        .await
+        {
+            Ok(handle) => handle,
+            Err(crate::GatewayError::Bind(err))
+                if err.kind() == std::io::ErrorKind::PermissionDenied =>
+            {
+                return;
+            }
+            Err(err) => panic!("gateway should start: {err}"),
+        };
+
+        let (mut socket, _) = connect_async(ws_url(handle.info().actual_port, None))
+            .await
+            .expect("websocket should connect");
+        let _connected = socket.next().await;
+
+        socket
+            .send(Message::Text(
+                json!({
+                    "id": "create-v1",
+                    "method": "session/create",
+                    "params": {}
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .expect("session/create should send");
+        let create = socket
+            .next()
+            .await
+            .expect("create response")
+            .expect("create message");
+        let Message::Text(text) = create else {
+            panic!("unexpected create frame: {create:?}");
+        };
+        let create = serde_json::from_str::<serde_json::Value>(&text).expect("create should parse");
+        assert_eq!(
+            create
+                .pointer("/result/session_key")
+                .and_then(|value| value.as_str()),
+            Some("websocket:created")
+        );
+
+        socket
+            .send(Message::Text(
+                json!({
+                    "id": "update-v1",
+                    "method": "session/update",
+                    "params": {
+                        "session_key": "websocket:newer",
+                        "title": "Renamed v1"
+                    }
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .expect("session/update should send");
+        let update = socket
+            .next()
+            .await
+            .expect("update response")
+            .expect("update message");
+        let Message::Text(text) = update else {
+            panic!("unexpected update frame: {update:?}");
+        };
+        let update = serde_json::from_str::<serde_json::Value>(&text).expect("update should parse");
+        assert_eq!(
+            update
+                .pointer("/result/title")
+                .and_then(|value| value.as_str()),
+            Some("Renamed v1")
+        );
+        assert_eq!(
+            update
+                .pointer("/result/updated")
+                .and_then(|value| value.as_bool()),
+            Some(true)
+        );
+
+        socket
+            .send(Message::Text(
+                json!({
+                    "id": "subscribe-v1",
+                    "method": "session/subscribe",
+                    "params": { "session_key": "websocket:newer" }
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .expect("session/subscribe should send");
+        let subscribe = socket
+            .next()
+            .await
+            .expect("subscribe response")
+            .expect("subscribe message");
+        let Message::Text(text) = subscribe else {
+            panic!("unexpected subscribe frame: {subscribe:?}");
+        };
+        let subscribe =
+            serde_json::from_str::<serde_json::Value>(&text).expect("subscribe should parse");
+        assert_eq!(
+            subscribe
+                .pointer("/result/session_key")
+                .and_then(|value| value.as_str()),
+            Some("websocket:newer")
+        );
+        let subscribed_event = socket
+            .next()
+            .await
+            .expect("subscribed notification")
+            .expect("subscribed notification message");
+        let Message::Text(text) = subscribed_event else {
+            panic!("unexpected subscribed event: {subscribed_event:?}");
+        };
+        let subscribed_event = serde_json::from_str::<serde_json::Value>(&text)
+            .expect("subscribed event should parse");
+        assert_eq!(
+            subscribed_event
+                .get("method")
+                .and_then(|value| value.as_str()),
+            Some("session/subscribed")
+        );
+
+        socket
+            .send(Message::Text(
+                json!({
+                    "id": "delete-v1",
+                    "method": "session/delete",
+                    "params": { "session_key": "websocket:newer" }
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .expect("session/delete should send");
+        let delete = socket
+            .next()
+            .await
+            .expect("delete response")
+            .expect("delete message");
+        let Message::Text(text) = delete else {
+            panic!("unexpected delete frame: {delete:?}");
+        };
+        let delete = serde_json::from_str::<serde_json::Value>(&text).expect("delete should parse");
+        assert_eq!(
+            delete
+                .pointer("/result/deleted")
+                .and_then(|value| value.as_bool()),
+            Some(true)
+        );
+
+        handle.shutdown().await.expect("gateway should stop");
+    }
+
+    #[tokio::test]
+    async fn websocket_v1_thread_history_loads_paginated_session_history() {
+        let config = test_gateway_config();
+        let handle = match spawn_gateway_with_options(
+            &config,
+            GatewayOptions {
+                websocket_handler: Some(Arc::new(RecordingWebsocketHandler::default())),
+                ..GatewayOptions::default()
+            },
+        )
+        .await
+        {
+            Ok(handle) => handle,
+            Err(crate::GatewayError::Bind(err))
+                if err.kind() == std::io::ErrorKind::PermissionDenied =>
+            {
+                return;
+            }
+            Err(err) => panic!("gateway should start: {err}"),
+        };
+
+        let (mut socket, _) = connect_async(ws_url(handle.info().actual_port, None))
+            .await
+            .expect("websocket should connect");
+        let _connected = socket.next().await;
+
+        socket
+            .send(Message::Text(
+                json!({
+                    "id": "history-v1",
+                    "method": "thread/history",
+                    "params": {
+                        "session_key": "websocket:history",
+                        "before_message_id": null,
+                        "limit": 30
+                    }
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .expect("thread/history should send");
+
+        let frame = socket
+            .next()
+            .await
+            .expect("history response")
+            .expect("history message");
+        let Message::Text(text) = frame else {
+            panic!("unexpected history frame: {frame:?}");
+        };
+        let frame = serde_json::from_str::<serde_json::Value>(&text).expect("history should parse");
+        assert_eq!(
+            frame
+                .pointer("/result/session_key")
+                .and_then(|value| value.as_str()),
+            Some("websocket:history")
+        );
+        assert_eq!(
+            frame
+                .pointer("/result/messages/0/content")
+                .and_then(|value| value.as_str()),
+            Some("previous answer (30)")
+        );
+        assert_eq!(
+            frame
+                .pointer("/result/has_more")
+                .and_then(|value| value.as_bool()),
+            Some(true)
+        );
+
+        handle.shutdown().await.expect("gateway should stop");
+    }
+
+    #[tokio::test]
     async fn websocket_v1_turn_start_links_request_session_thread_turn_and_handler_metadata() {
         let config = test_gateway_config();
         let handler = RecordingWebsocketHandler::default();

--- a/klaw-gateway/src/websocket.rs
+++ b/klaw-gateway/src/websocket.rs
@@ -1140,6 +1140,333 @@ async fn handle_protocol_message(
             )]
         }
         GatewayProtocolMethod::Initialized => Vec::new(),
+        GatewayProtocolMethod::SessionList => {
+            let Some(id) = id else {
+                return vec![protocol_error_frame(
+                    None,
+                    GatewayProtocolErrorCode::InvalidRequest,
+                    "session/list requires an id",
+                )];
+            };
+            let Some(websocket) = state.websocket.as_ref() else {
+                return vec![protocol_error_frame(
+                    Some(id),
+                    GatewayProtocolErrorCode::InternalError,
+                    "gateway websocket handler is not configured",
+                )];
+            };
+            match websocket.handler.bootstrap().await {
+                Ok(mut workspace) => {
+                    workspace.sessions.sort_by(|left, right| {
+                        right
+                            .created_at_ms
+                            .cmp(&left.created_at_ms)
+                            .then_with(|| right.session_key.cmp(&left.session_key))
+                    });
+                    vec![GatewayWebsocketServerFrame::Protocol(
+                        GatewayRpcMessage::success(
+                            id,
+                            json!({
+                                "sessions": workspace.sessions,
+                                "active_session_key": workspace.active_session_key,
+                            }),
+                        ),
+                    )]
+                }
+                Err(err) => vec![handler_protocol_error_frame(Some(id), err)],
+            }
+        }
+        GatewayProtocolMethod::ProviderList => {
+            let Some(id) = id else {
+                return vec![protocol_error_frame(
+                    None,
+                    GatewayProtocolErrorCode::InvalidRequest,
+                    "provider/list requires an id",
+                )];
+            };
+            let Some(websocket) = state.websocket.as_ref() else {
+                return vec![protocol_error_frame(
+                    Some(id),
+                    GatewayProtocolErrorCode::InternalError,
+                    "gateway websocket handler is not configured",
+                )];
+            };
+            match websocket.handler.list_providers().await {
+                Ok(catalog) => vec![GatewayWebsocketServerFrame::Protocol(
+                    GatewayRpcMessage::success(
+                        id,
+                        json!({
+                            "default_provider": catalog.default_provider,
+                            "providers": catalog.providers,
+                        }),
+                    ),
+                )],
+                Err(err) => vec![handler_protocol_error_frame(Some(id), err)],
+            }
+        }
+        GatewayProtocolMethod::SessionCreate => {
+            let Some(id) = id else {
+                return vec![protocol_error_frame(
+                    None,
+                    GatewayProtocolErrorCode::InvalidRequest,
+                    "session/create requires an id",
+                )];
+            };
+            let Some(websocket) = state.websocket.as_ref() else {
+                return vec![protocol_error_frame(
+                    Some(id),
+                    GatewayProtocolErrorCode::InternalError,
+                    "gateway websocket handler is not configured",
+                )];
+            };
+            match websocket.handler.create_session().await {
+                Ok(session) => {
+                    *current_session_key = Some(session.session_key.clone());
+                    track_connection_session_key(state, connection_id, session.session_key.clone())
+                        .await;
+                    vec![GatewayWebsocketServerFrame::Protocol(
+                        GatewayRpcMessage::success(
+                            id,
+                            json!({
+                                "session_key": session.session_key,
+                                "title": session.title,
+                                "created_at_ms": session.created_at_ms,
+                                "model_provider": session.model_provider,
+                                "model": session.model,
+                            }),
+                        ),
+                    )]
+                }
+                Err(err) => vec![handler_protocol_error_frame(Some(id), err)],
+            }
+        }
+        GatewayProtocolMethod::SessionUpdate => {
+            let Some(id) = id else {
+                return vec![protocol_error_frame(
+                    None,
+                    GatewayProtocolErrorCode::InvalidRequest,
+                    "session/update requires an id",
+                )];
+            };
+            let params = match serde_json::from_value::<SessionUpdateParams>(params) {
+                Ok(params) => params,
+                Err(err) => {
+                    return vec![protocol_error_frame(
+                        Some(id),
+                        GatewayProtocolErrorCode::InvalidParams,
+                        format!("invalid session/update params: {err}"),
+                    )];
+                }
+            };
+            let session_key = params.session_key.trim().to_string();
+            if session_key.is_empty() {
+                return vec![protocol_error_frame(
+                    Some(id),
+                    GatewayProtocolErrorCode::InvalidParams,
+                    "session/update requires a non-empty session_key",
+                )];
+            }
+            let title = params.title.trim().to_string();
+            if title.is_empty() {
+                return vec![protocol_error_frame(
+                    Some(id),
+                    GatewayProtocolErrorCode::InvalidParams,
+                    "session/update requires a non-empty title",
+                )];
+            }
+            let Some(websocket) = state.websocket.as_ref() else {
+                return vec![protocol_error_frame(
+                    Some(id),
+                    GatewayProtocolErrorCode::InternalError,
+                    "gateway websocket handler is not configured",
+                )];
+            };
+            match websocket.handler.update_session(&session_key, title).await {
+                Ok(session) => vec![GatewayWebsocketServerFrame::Protocol(
+                    GatewayRpcMessage::success(
+                        id,
+                        json!({
+                            "session_key": session.session_key,
+                            "title": session.title,
+                            "created_at_ms": session.created_at_ms,
+                            "model_provider": session.model_provider,
+                            "model": session.model,
+                            "updated": true,
+                        }),
+                    ),
+                )],
+                Err(err) => vec![handler_protocol_error_frame(Some(id), err)],
+            }
+        }
+        GatewayProtocolMethod::SessionDelete => {
+            let Some(id) = id else {
+                return vec![protocol_error_frame(
+                    None,
+                    GatewayProtocolErrorCode::InvalidRequest,
+                    "session/delete requires an id",
+                )];
+            };
+            let params = match serde_json::from_value::<SessionDeleteParams>(params) {
+                Ok(params) => params,
+                Err(err) => {
+                    return vec![protocol_error_frame(
+                        Some(id),
+                        GatewayProtocolErrorCode::InvalidParams,
+                        format!("invalid session/delete params: {err}"),
+                    )];
+                }
+            };
+            let session_key = params.session_key.trim().to_string();
+            if session_key.is_empty() {
+                return vec![protocol_error_frame(
+                    Some(id),
+                    GatewayProtocolErrorCode::InvalidParams,
+                    "session/delete requires a non-empty session_key",
+                )];
+            }
+            let Some(websocket) = state.websocket.as_ref() else {
+                return vec![protocol_error_frame(
+                    Some(id),
+                    GatewayProtocolErrorCode::InternalError,
+                    "gateway websocket handler is not configured",
+                )];
+            };
+            match websocket.handler.delete_session(&session_key).await {
+                Ok(deleted) => vec![GatewayWebsocketServerFrame::Protocol(
+                    GatewayRpcMessage::success(
+                        id,
+                        json!({
+                            "session_key": session_key,
+                            "deleted": deleted,
+                        }),
+                    ),
+                )],
+                Err(err) => vec![handler_protocol_error_frame(Some(id), err)],
+            }
+        }
+        GatewayProtocolMethod::SessionSubscribe => {
+            let Some(id) = id else {
+                return vec![protocol_error_frame(
+                    None,
+                    GatewayProtocolErrorCode::InvalidRequest,
+                    "session/subscribe requires an id",
+                )];
+            };
+            let params = match serde_json::from_value::<SessionSubscribeParams>(params) {
+                Ok(params) => params,
+                Err(err) => {
+                    return vec![protocol_error_frame(
+                        Some(id),
+                        GatewayProtocolErrorCode::InvalidParams,
+                        format!("invalid session/subscribe params: {err}"),
+                    )];
+                }
+            };
+            let session_key = params.session_key.trim().to_string();
+            if session_key.is_empty() {
+                return vec![protocol_error_frame(
+                    Some(id),
+                    GatewayProtocolErrorCode::InvalidParams,
+                    "session/subscribe requires a non-empty session_key",
+                )];
+            }
+            let Some(_websocket) = state.websocket.as_ref() else {
+                return vec![protocol_error_frame(
+                    Some(id),
+                    GatewayProtocolErrorCode::InternalError,
+                    "gateway websocket handler is not configured",
+                )];
+            };
+            *current_session_key = Some(session_key.clone());
+            track_connection_session_key(state, connection_id, session_key.clone()).await;
+            let payload = json!({ "session_key": session_key });
+            vec![
+                GatewayWebsocketServerFrame::Protocol(GatewayRpcMessage::success(
+                    id,
+                    payload.clone(),
+                )),
+                GatewayWebsocketServerFrame::Protocol(GatewayRpcMessage::notification(
+                    GatewayProtocolMethod::SessionSubscribed,
+                    payload,
+                )),
+            ]
+        }
+        GatewayProtocolMethod::SessionUnsubscribe => {
+            let Some(id) = id else {
+                return vec![protocol_error_frame(
+                    None,
+                    GatewayProtocolErrorCode::InvalidRequest,
+                    "session/unsubscribe requires an id",
+                )];
+            };
+            let previous_session_key = current_session_key.take();
+            clear_connection_session_keys(state, connection_id).await;
+            let payload = json!({ "session_key": previous_session_key });
+            vec![
+                GatewayWebsocketServerFrame::Protocol(GatewayRpcMessage::success(
+                    id,
+                    payload.clone(),
+                )),
+                GatewayWebsocketServerFrame::Protocol(GatewayRpcMessage::notification(
+                    GatewayProtocolMethod::SessionUnsubscribed,
+                    payload,
+                )),
+            ]
+        }
+        GatewayProtocolMethod::ThreadHistory | GatewayProtocolMethod::ThreadRead => {
+            let Some(id) = id else {
+                return vec![protocol_error_frame(
+                    None,
+                    GatewayProtocolErrorCode::InvalidRequest,
+                    "thread/history requires an id",
+                )];
+            };
+            let params = match serde_json::from_value::<SessionHistoryLoadParams>(params) {
+                Ok(params) => params,
+                Err(err) => {
+                    return vec![protocol_error_frame(
+                        Some(id),
+                        GatewayProtocolErrorCode::InvalidParams,
+                        format!("invalid thread/history params: {err}"),
+                    )];
+                }
+            };
+            let session_key = params.session_key.trim().to_string();
+            if session_key.is_empty() {
+                return vec![protocol_error_frame(
+                    Some(id),
+                    GatewayProtocolErrorCode::InvalidParams,
+                    "thread/history requires a non-empty session_key",
+                )];
+            }
+            let Some(websocket) = state.websocket.as_ref() else {
+                return vec![protocol_error_frame(
+                    Some(id),
+                    GatewayProtocolErrorCode::InternalError,
+                    "gateway websocket handler is not configured",
+                )];
+            };
+            let limit = params.limit.unwrap_or(10).max(1);
+            match websocket
+                .handler
+                .load_session_history(&session_key, params.before_message_id.as_deref(), limit)
+                .await
+            {
+                Ok(page) => vec![GatewayWebsocketServerFrame::Protocol(
+                    GatewayRpcMessage::success(
+                        id,
+                        json!({
+                            "session_key": session_key,
+                            "thread_id": session_key,
+                            "messages": page.messages,
+                            "has_more": page.has_more,
+                            "oldest_loaded_message_id": page.oldest_loaded_message_id,
+                        }),
+                    ),
+                )],
+                Err(err) => vec![handler_protocol_error_frame(Some(id), err)],
+            }
+        }
         GatewayProtocolMethod::TurnStart => {
             let Some(id) = id else {
                 return vec![protocol_error_frame(
@@ -1500,6 +1827,29 @@ fn protocol_error_frame_with_data(
             code,
             message: message.into(),
             data: Some(data),
+        },
+    })
+}
+
+fn handler_protocol_error_frame(
+    id: Option<String>,
+    err: GatewayWebsocketHandlerError,
+) -> GatewayWebsocketServerFrame {
+    let code = match err.code.as_str() {
+        "invalid_request" => GatewayProtocolErrorCode::InvalidParams,
+        "session_not_found" | "missing_session" => GatewayProtocolErrorCode::SessionNotFound,
+        "thread_not_found" => GatewayProtocolErrorCode::ThreadNotFound,
+        "turn_not_found" => GatewayProtocolErrorCode::TurnNotFound,
+        "permission_denied" => GatewayProtocolErrorCode::PermissionDenied,
+        "timeout" => GatewayProtocolErrorCode::Timeout,
+        _ => GatewayProtocolErrorCode::InternalError,
+    };
+    GatewayWebsocketServerFrame::Protocol(GatewayRpcMessage::Error {
+        id,
+        error: GatewayProtocolError {
+            code,
+            message: err.message,
+            data: err.data,
         },
     })
 }

--- a/klaw-runtime/CHANGELOG.md
+++ b/klaw-runtime/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Added
 
-- Gateway WebSocket streaming now emits v1 `item/started`, `item/agentMessage/delta`, `item/completed`, and `turn/completed` notifications when a submit request carries websocket v1 thread/turn metadata, while preserving existing legacy stream frames
+- Gateway WebSocket streaming now emits v1 `item/started`, `item/agentMessage/delta`, `item/completed`, and `turn/completed` notifications when a submit request carries websocket v1 thread/turn metadata
+- Gateway WebSocket non-streaming v1 turns now emit `item/completed` and `turn/completed` instead of falling back to the legacy result frame
 
 ## 2026-04-26
 

--- a/klaw-runtime/README.md
+++ b/klaw-runtime/README.md
@@ -9,7 +9,7 @@
 - wire runtime submission helpers for one-shot and streaming flows
 - host runtime-only IM command handling and session routing policy
 - integrate background services, webhook processing, and gateway lifecycle glue
-- map gateway WebSocket v1 turn metadata into structured `item/*` and `turn/*` protocol notifications while preserving legacy `session.stream.*` frames
+- map gateway WebSocket v1 turn metadata into structured `item/*` and `turn/*` protocol notifications for both streaming and non-streaming turns
 - own the shared Knowledge service so GUI search, Knowledge tool calls, and index/vector sync reuse one provider/model runtime instead of reopening it per request
 - clear the shared Knowledge service during runtime shutdown so local model resources are released before process exit
 

--- a/klaw-runtime/src/gateway_websocket.rs
+++ b/klaw-runtime/src/gateway_websocket.rs
@@ -366,6 +366,7 @@ impl GatewayWebsocketHandler for RuntimeWebsocketHandler {
                         .as_ref()
                         .map(|response| serialize_response(response, config.show_reasoning)),
                 )?;
+                return Ok(());
             }
             send_frame(
                 &frame_tx,
@@ -395,6 +396,19 @@ impl GatewayWebsocketHandler for RuntimeWebsocketHandler {
         let response = submit_channel_request(self.runtime.as_ref(), channel_request)
             .await
             .map_err(|err| GatewayWebsocketHandlerError::internal(err.to_string()))?;
+        if let Some(context) = v1_context.as_ref() {
+            send_v1_item_completed(&frame_tx, context, response.as_ref(), config.show_reasoning)?;
+            send_v1_turn_finished(
+                &frame_tx,
+                context,
+                GatewayProtocolMethod::TurnCompleted,
+                GatewayTurnStatus::Completed,
+                response
+                    .as_ref()
+                    .map(|response| serialize_response(response, config.show_reasoning)),
+            )?;
+            return Ok(());
+        }
         send_frame(
             &frame_tx,
             GatewayWebsocketServerFrame::Result {
@@ -487,6 +501,7 @@ impl GatewayStreamState {
                         send_v1_agent_delta(frame_tx, &context, &delta)
                             .map_err(|err| std::io::Error::other(err.message.clone()))?;
                     }
+                    return Ok(());
                 }
                 send_frame(
                     frame_tx,
@@ -517,6 +532,9 @@ impl GatewayStreamState {
             }
             klaw_channel::ChannelStreamEvent::Clear => {
                 self.last_snapshot = None;
+                if self.v1_context.is_some() {
+                    return Ok(());
+                }
                 send_frame(
                     frame_tx,
                     GatewayWebsocketServerFrame::Event {
@@ -858,6 +876,10 @@ mod tests {
             }
             _ => false,
         }));
+        assert!(frames.iter().all(|frame| matches!(
+            frame,
+            klaw_gateway::GatewayWebsocketServerFrame::Protocol(_)
+        )));
     }
 
     #[test]

--- a/klaw-webui/CHANGELOG.md
+++ b/klaw-webui/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 2026-05-03
+
+### Changed
+
+- WebUI WebSocket 实现已直接切换到 Gateway WebSocket v1 JSON-RPC envelope：连接初始化使用 `initialize`，工作区、provider、历史和会话操作使用 v1 方法，发送消息使用 `turn/start` content blocks。
+- WebUI 实时渲染现在消费 v1 `item/agentMessage/delta`、`item/completed`、`turn/completed` 和 `turn/interrupted` 通知，不再以旧版 `type: "method"` / `session.submit` / `session.message` 帧作为正常协议路径。
+
 ## 2026-04-22
 
 ### Changed

--- a/klaw-webui/README.md
+++ b/klaw-webui/README.md
@@ -1,6 +1,6 @@
 # klaw-webui
 
-基于 **egui** + **eframe** Web 后端的浏览器聊天壳，连接本仓库 `klaw-gateway` 的 `GET /ws/chat`（按 `session_key` 房间广播纯文本）。
+基于 **egui** + **eframe** Web 后端的浏览器聊天壳，连接本仓库 `klaw-gateway` 的 `GET /ws/chat`，使用 Gateway WebSocket v1 JSON-RPC envelope 与 agent 交互。
 
 - 会话键：`websocket:<uuid>`；业务状态默认写入浏览器 `localStorage`（`klaw_webui_workspace_state`），现包含 gateway token 与会话列表
 - `egui/eframe` 的内建持久化已启用，主题偏好与页面布局（如侧栏宽度、浮动窗口位置和尺寸）交由框架写入浏览器存储恢复
@@ -8,6 +8,7 @@
 - 底部状态栏显示主题切换、agent/open 计数、stream 开关，以及当前 agent 的路由、消息数、活动状态和实时 FPS
 - 顶部菜单栏包含 `Connection` 和 `Help` 菜单；`Help -> About` 会弹出版本信息，并复用连接页同源的 crab 图片
 - agent 对话输入框支持 slash command 自动补全；输入 `/` 会弹出命令建议面板，便于插入 runtime 支持的会话命令
+- WebSocket 路径连接后发送 `initialize`，工作区/会话/provider/历史使用 v1 `session/*`、`provider/list`、`thread/history` 方法，用户输入使用 `turn/start` 结构化 content blocks；浏览器端不再发送旧版 `type: "method"` 帧，也不把旧版服务端帧作为正常输入
 
 ## 模块布局
 

--- a/klaw-webui/src/lib.rs
+++ b/klaw-webui/src/lib.rs
@@ -557,33 +557,42 @@ pub(crate) fn resolve_session_route_inputs(
 }
 
 #[cfg(any(test, target_arch = "wasm32"))]
-pub(crate) fn build_websocket_submit_params(
-    session_key: &str,
-    input: &str,
+pub(crate) fn build_websocket_turn_start_params(
+    session_id: &str,
+    thread_id: &str,
+    turn_id: &str,
+    text: &str,
     stream: bool,
     attachments: &[WebArchiveAttachment],
     model_provider: &str,
     model: &str,
     metadata: Option<&BTreeMap<String, Value>>,
 ) -> Value {
+    let mut input = Vec::new();
+    if !text.trim().is_empty() {
+        input.push(json!({
+            "type": "text",
+            "text": text,
+        }));
+    }
+    input.extend(attachments.iter().map(|attachment| {
+        json!({
+            "type": "attachment",
+            "archive_id": attachment.archive_id,
+            "filename": attachment.filename,
+            "mime_type": attachment.mime_type,
+            "size_bytes": attachment.size_bytes,
+        })
+    }));
     let mut params = json!({
-        "session_key": session_key,
-        "chat_id": session_key,
+        "session_id": session_id,
+        "thread_id": thread_id,
+        "turn_id": turn_id,
         "input": input,
         "stream": stream,
         "model_provider": model_provider,
         "model": model,
     });
-    if let Some(archive_id) = attachments
-        .first()
-        .map(|attachment| attachment.archive_id.trim())
-        .filter(|value| !value.is_empty())
-    {
-        params["archive_id"] = json!(archive_id);
-    }
-    if !attachments.is_empty() {
-        params["attachments"] = json!(attachments);
-    }
     if let Some(metadata) = metadata.filter(|metadata| !metadata.is_empty()) {
         params["metadata"] = json!(metadata);
     }
@@ -915,20 +924,22 @@ mod tests {
 
     use serde_json::json;
 
+    use klaw_ui_kit::ThemeMode;
+
     use super::{
         ArchiveRecord, ArchiveUploadResponse, ConnectionState, ImCardKind, MessageRole, PageMode,
         ProviderCatalog, ProviderCatalogEntry, ResolvedSessionRoute, SessionListEntry,
-        StreamMessageAction, ThemeMode, WebArchiveAttachment, WorkspaceSessionEntry,
-        apply_slash_completion, attachment_action_in_progress, build_websocket_submit_params,
-        can_trigger_file_picker, classify_message_role, classify_stream_message_action,
-        connection_action_label, delete_confirmation_body, derive_page_mode,
-        detect_active_slash_command, has_exact_slash_command_match,
-        next_pending_attachments_after_submit, normalize_gateway_token_input,
-        resolve_assistant_bubble_palette, resolve_gateway_token, resolve_im_card,
-        resolve_im_card_palette, resolve_session_route_inputs, session_card_activity_label,
-        should_activate_session_window, should_cancel_file_picker_selection,
-        should_prompt_for_gateway_token_before_connect, should_register_non_stream_fade,
-        slash_command_matches, sort_session_entries_by_created_at_desc,
+        StreamMessageAction, WebArchiveAttachment, apply_slash_completion,
+        attachment_action_in_progress, build_websocket_turn_start_params, can_trigger_file_picker,
+        classify_message_role, classify_stream_message_action, connection_action_label,
+        delete_confirmation_body, derive_page_mode, detect_active_slash_command,
+        has_exact_slash_command_match, next_pending_attachments_after_submit,
+        normalize_gateway_token_input, resolve_assistant_bubble_palette, resolve_gateway_token,
+        resolve_im_card, resolve_im_card_palette, resolve_session_route_inputs,
+        session_card_activity_label, should_activate_session_window,
+        should_cancel_file_picker_selection, should_prompt_for_gateway_token_before_connect,
+        should_register_non_stream_fade, slash_command_matches,
+        sort_session_entries_by_created_at_desc,
     };
 
     #[test]
@@ -1330,9 +1341,11 @@ mod tests {
     }
 
     #[test]
-    fn websocket_submit_params_include_model_route() {
-        let params = build_websocket_submit_params(
+    fn websocket_turn_start_params_include_model_route_and_content_blocks() {
+        let params = build_websocket_turn_start_params(
             "websocket:test",
+            "websocket:test",
+            "turn-1",
             "hello",
             true,
             &[WebArchiveAttachment {
@@ -1347,18 +1360,32 @@ mod tests {
         );
 
         assert_eq!(
-            params
-                .get("session_key")
-                .and_then(serde_json::Value::as_str),
+            params.get("session_id").and_then(serde_json::Value::as_str),
             Some("websocket:test")
         );
         assert_eq!(
-            params.get("chat_id").and_then(serde_json::Value::as_str),
+            params.get("thread_id").and_then(serde_json::Value::as_str),
             Some("websocket:test")
         );
         assert_eq!(
-            params.get("input").and_then(serde_json::Value::as_str),
-            Some("hello")
+            params.get("turn_id").and_then(serde_json::Value::as_str),
+            Some("turn-1")
+        );
+        assert_eq!(
+            params["input"],
+            json!([
+                {
+                    "type": "text",
+                    "text": "hello",
+                },
+                {
+                    "type": "attachment",
+                    "archive_id": "archive-1",
+                    "filename": "report.pdf",
+                    "mime_type": "application/pdf",
+                    "size_bytes": 42
+                }
+            ])
         );
         assert_eq!(
             params.get("stream").and_then(serde_json::Value::as_bool),
@@ -1374,29 +1401,18 @@ mod tests {
             params.get("model").and_then(serde_json::Value::as_str),
             Some("claude-sonnet-4-5")
         );
-        assert_eq!(
-            params.get("archive_id").and_then(serde_json::Value::as_str),
-            Some("archive-1")
-        );
-        assert_eq!(
-            params["attachments"],
-            json!([{
-                "archive_id": "archive-1",
-                "filename": "report.pdf",
-                "mime_type": "application/pdf",
-                "size_bytes": 42
-            }])
-        );
     }
 
     #[test]
-    fn websocket_submit_params_include_card_metadata() {
+    fn websocket_turn_start_params_include_card_metadata() {
         let metadata = BTreeMap::from([(
             "webui.card.action".to_string(),
             serde_json::Value::Bool(true),
         )]);
-        let params = build_websocket_submit_params(
+        let params = build_websocket_turn_start_params(
             "websocket:test",
+            "websocket:test",
+            "turn-2",
             "/approve approval-1",
             false,
             &[],

--- a/klaw-webui/src/web_chat/app.rs
+++ b/klaw-webui/src/web_chat/app.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 use super::{
-    protocol::ServerFrame,
+    protocol::RpcFrame,
     session::{SessionWindow, session_window_id, window_anchor_for_slot},
     storage::{PersistedWorkspaceState, load_workspace_state, save_workspace_state},
 };
@@ -26,7 +26,7 @@ pub(super) struct ChatApp {
     pub(in crate::web_chat) gateway_token_input: String,
     pub(in crate::web_chat) ws: Rc<RefCell<Option<WebSocket>>>,
     pub(in crate::web_chat) connection_state: Rc<RefCell<ConnectionState>>,
-    pub(in crate::web_chat) pending_frames: Rc<RefCell<Vec<ServerFrame>>>,
+    pub(in crate::web_chat) pending_frames: Rc<RefCell<Vec<RpcFrame>>>,
     pub(in crate::web_chat) sessions: Vec<SessionWindow>,
     pub(in crate::web_chat) provider_catalog: ProviderCatalog,
     pub(in crate::web_chat) active_session_key: Option<String>,

--- a/klaw-webui/src/web_chat/protocol.rs
+++ b/klaw-webui/src/web_chat/protocol.rs
@@ -3,35 +3,111 @@ use serde_json::Value;
 use web_sys::WebSocket;
 
 #[derive(Debug, Serialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
-pub(super) enum ClientFrame<'a> {
-    Method {
+#[serde(untagged)]
+pub(super) enum ClientRpcMessage<'a> {
+    Request {
         id: &'a str,
+        method: &'a str,
+        #[serde(default)]
+        params: Value,
+    },
+    Notification {
         method: &'a str,
         #[serde(default)]
         params: Value,
     },
 }
 
-#[derive(Clone, Debug, Deserialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
-pub(super) enum ServerFrame {
-    Event {
-        event: String,
-        #[serde(default)]
-        payload: Value,
-    },
-    Result {
-        #[allow(dead_code)]
-        id: String,
-        #[serde(default)]
-        result: Value,
-    },
+#[derive(Clone, Debug)]
+pub(super) enum RpcFrame {
     Error {
         #[allow(dead_code)]
         id: Option<String>,
         error: ServerErrorFrame,
     },
+    Success {
+        #[allow(dead_code)]
+        id: String,
+        result: Value,
+    },
+    Request {
+        #[allow(dead_code)]
+        id: String,
+        method: String,
+        params: Value,
+    },
+    Notification {
+        method: String,
+        params: Value,
+    },
+}
+
+impl<'de> Deserialize<'de> for RpcFrame {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = Value::deserialize(deserializer)?;
+        if value.get("type").is_some() {
+            return Err(serde::de::Error::custom(
+                "legacy websocket frames are not accepted by the v1 webui client",
+            ));
+        }
+        if value.get("error").is_some() {
+            #[derive(Deserialize)]
+            #[serde(deny_unknown_fields)]
+            struct ErrorFrame {
+                #[serde(default)]
+                id: Option<String>,
+                error: ServerErrorFrame,
+            }
+            let frame = ErrorFrame::deserialize(value).map_err(serde::de::Error::custom)?;
+            return Ok(Self::Error {
+                id: frame.id,
+                error: frame.error,
+            });
+        }
+        if value.get("result").is_some() {
+            #[derive(Deserialize)]
+            #[serde(deny_unknown_fields)]
+            struct SuccessFrame {
+                id: String,
+                #[serde(default)]
+                result: Value,
+            }
+            let frame = SuccessFrame::deserialize(value).map_err(serde::de::Error::custom)?;
+            return Ok(Self::Success {
+                id: frame.id,
+                result: frame.result,
+            });
+        }
+        if value.get("method").is_some() {
+            #[derive(Deserialize)]
+            #[serde(deny_unknown_fields)]
+            struct MethodFrame {
+                #[serde(default)]
+                id: Option<String>,
+                method: String,
+                #[serde(default)]
+                params: Value,
+            }
+            let frame = MethodFrame::deserialize(value).map_err(serde::de::Error::custom)?;
+            return Ok(match frame.id {
+                Some(id) => Self::Request {
+                    id,
+                    method: frame.method,
+                    params: frame.params,
+                },
+                None => Self::Notification {
+                    method: frame.method,
+                    params: frame.params,
+                },
+            });
+        }
+        Err(serde::de::Error::custom(
+            "websocket frame is not a v1 rpc message",
+        ))
+    }
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -40,15 +116,27 @@ pub(super) struct ServerErrorFrame {
     pub(super) message: String,
 }
 
-pub(super) fn send_method(
+pub(super) fn send_rpc_request(
     ws: &WebSocket,
     id: &str,
     method: &str,
     params: Value,
 ) -> Result<(), String> {
-    let frame = ClientFrame::Method { id, method, params };
+    let frame = ClientRpcMessage::Request { id, method, params };
     let payload = serde_json::to_string(&frame)
-        .map_err(|err| format!("serialize websocket method: {err}"))?;
+        .map_err(|err| format!("serialize websocket rpc request: {err}"))?;
     ws.send_with_str(&payload)
-        .map_err(|_| format!("websocket send failed for method '{method}'"))
+        .map_err(|_| format!("websocket send failed for rpc request '{method}'"))
+}
+
+pub(super) fn send_rpc_notification(
+    ws: &WebSocket,
+    method: &str,
+    params: Value,
+) -> Result<(), String> {
+    let frame = ClientRpcMessage::Notification { method, params };
+    let payload = serde_json::to_string(&frame)
+        .map_err(|err| format!("serialize websocket rpc notification: {err}"))?;
+    ws.send_with_str(&payload)
+        .map_err(|_| format!("websocket send failed for rpc notification '{method}'"))
 }

--- a/klaw-webui/src/web_chat/transport.rs
+++ b/klaw-webui/src/web_chat/transport.rs
@@ -6,14 +6,14 @@ use web_sys::{CloseEvent, MessageEvent, WebSocket};
 
 use crate::{
     ConnectionState, MessageRole, ProviderCatalog, WebArchiveAttachment, WorkspaceSessionEntry,
-    build_websocket_submit_params, classify_stream_message_action,
+    build_websocket_turn_start_params, classify_stream_message_action,
     next_pending_attachments_after_submit, should_hide_heartbeat_operational_message,
     should_hide_heartbeat_silent_ack, should_register_non_stream_fade,
 };
 
 use super::{
     app::ChatApp,
-    protocol::{ServerFrame, send_method},
+    protocol::{RpcFrame, send_rpc_notification, send_rpc_request},
     session::ChatMessage,
     session::HistoryRequestCursor,
     session::PendingHistoryScrollRestore,
@@ -105,11 +105,32 @@ impl ChatApp {
             } else {
                 "[non-text message]".to_string()
             };
-            let frame =
-                serde_json::from_str::<ServerFrame>(&text).unwrap_or_else(|_| ServerFrame::Event {
-                    event: "system.raw".to_string(),
-                    payload: json!({ "text": text }),
-                });
+            let raw_value = match serde_json::from_str::<Value>(&text) {
+                Ok(value) => value,
+                Err(_) => {
+                    pending_frames.borrow_mut().push(RpcFrame::Error {
+                        id: None,
+                        error: super::protocol::ServerErrorFrame {
+                            code: "invalid_frame".to_string(),
+                            message: text,
+                        },
+                    });
+                    ctx.request_repaint();
+                    return;
+                }
+            };
+            if raw_value.get("type").is_some() {
+                return;
+            }
+            let frame = serde_json::from_value::<RpcFrame>(raw_value).unwrap_or_else(|err| {
+                RpcFrame::Error {
+                    id: None,
+                    error: super::protocol::ServerErrorFrame {
+                        code: "invalid_frame".to_string(),
+                        message: err.to_string(),
+                    },
+                }
+            });
             pending_frames.borrow_mut().push(frame);
             ctx.request_repaint();
         }) as Box<dyn FnMut(MessageEvent)>);
@@ -121,15 +142,39 @@ impl ChatApp {
         let ctx_open = self.ctx.clone();
         let onopen = Closure::wrap(Box::new(move |_event: JsValue| {
             *state_open.borrow_mut() = ConnectionState::Connected;
-            let bootstrap_id = Uuid::new_v4().to_string();
-            if let Err(err) = send_method(&ws_open, &bootstrap_id, "workspace.bootstrap", json!({}))
-            {
+            let initialize_id = Uuid::new_v4().to_string();
+            if let Err(err) = send_rpc_request(
+                &ws_open,
+                &initialize_id,
+                "initialize",
+                json!({
+                    "client_info": {
+                        "name": "klaw-webui",
+                        "version": env!("CARGO_PKG_VERSION"),
+                    },
+                    "capabilities": {
+                        "protocol_version": "v1",
+                        "turns": true,
+                        "items": true,
+                        "server_requests": true,
+                        "cancellation": true,
+                    },
+                }),
+            ) {
+                *state_open.borrow_mut() = ConnectionState::Error(err);
+                ctx_open.request_repaint();
+                return;
+            }
+            let _ = send_rpc_notification(&ws_open, "initialized", json!({}));
+            let sessions_id = Uuid::new_v4().to_string();
+            if let Err(err) = send_rpc_request(&ws_open, &sessions_id, "session/list", json!({})) {
                 *state_open.borrow_mut() = ConnectionState::Error(err);
                 ctx_open.request_repaint();
                 return;
             }
             let providers_id = Uuid::new_v4().to_string();
-            if let Err(err) = send_method(&ws_open, &providers_id, "provider.list", json!({})) {
+            if let Err(err) = send_rpc_request(&ws_open, &providers_id, "provider/list", json!({}))
+            {
                 *state_open.borrow_mut() = ConnectionState::Error(err);
             }
             ctx_open.request_repaint();
@@ -172,7 +217,7 @@ impl ChatApp {
             return;
         }
         let request_id = Uuid::new_v4().to_string();
-        let _ = send_method(&ws, &request_id, "session.create", json!({}));
+        let _ = send_rpc_request(&ws, &request_id, "session/create", json!({}));
     }
 
     pub(in crate::web_chat) fn ensure_session_ready(&mut self, session_key: &str) {
@@ -194,10 +239,10 @@ impl ChatApp {
             return;
         }
         let request_id = Uuid::new_v4().to_string();
-        if let Err(err) = send_method(
+        if let Err(err) = send_rpc_request(
             &ws,
             &request_id,
-            "session.subscribe",
+            "session/subscribe",
             json!({ "session_key": session_key }),
         ) {
             self.toasts.borrow_mut().error(err);
@@ -238,10 +283,10 @@ impl ChatApp {
         *self.sessions[index].buffers.history_loading.borrow_mut() = true;
         self.sessions[index].last_requested_history_cursor = Some(request_cursor);
         self.sessions[index].pending_history_scroll_restore = scroll_restore;
-        if let Err(err) = send_method(
+        if let Err(err) = send_rpc_request(
             &ws,
             &request_id,
-            "session.history.load",
+            "thread/history",
             json!({
                 "session_key": session_key,
                 "before_message_id": before_message_id,
@@ -262,10 +307,10 @@ impl ChatApp {
             return;
         }
         let request_id = Uuid::new_v4().to_string();
-        let _ = send_method(
+        let _ = send_rpc_request(
             &ws,
             &request_id,
-            "session.update",
+            "session/update",
             json!({
                 "session_key": session_key,
                 "title": title,
@@ -281,10 +326,10 @@ impl ChatApp {
             return;
         }
         let request_id = Uuid::new_v4().to_string();
-        let _ = send_method(
+        let _ = send_rpc_request(
             &ws,
             &request_id,
-            "session.delete",
+            "session/delete",
             json!({
                 "session_key": session_key,
             }),
@@ -302,11 +347,18 @@ impl ChatApp {
         }
     }
 
-    pub(in crate::web_chat) fn process_frame(&mut self, frame: ServerFrame) {
+    pub(in crate::web_chat) fn process_frame(&mut self, frame: RpcFrame) {
         match frame {
-            ServerFrame::Event { event, payload } => self.process_event_frame(&event, &payload),
-            ServerFrame::Result { id: _, result } => self.process_result_frame(&result),
-            ServerFrame::Error { id: _, error } => {
+            RpcFrame::Success { id: _, result } => self.process_result_frame(&result),
+            RpcFrame::Notification { method, params } => {
+                self.process_notification_frame(&method, &params)
+            }
+            RpcFrame::Request {
+                id: _,
+                method,
+                params,
+            } => self.process_server_request_frame(&method, &params),
+            RpcFrame::Error { id: _, error } => {
                 let message = format!("{}: {}", error.code, error.message);
                 *self.connection_state.borrow_mut() = ConnectionState::Error(message.clone());
                 self.workspace_loaded = false;
@@ -506,139 +558,10 @@ impl ChatApp {
             .borrow_mut() = None;
     }
 
-    fn process_event_frame(&mut self, event: &str, payload: &Value) {
-        match event {
-            "session.connected" => {
-                *self.connection_state.borrow_mut() = ConnectionState::Connected;
-            }
-            "session.message" => {
-                let Some(session_key) = payload.get("session_key").and_then(Value::as_str) else {
-                    return;
-                };
-                let Some(index) = self.session_index(session_key) else {
-                    return;
-                };
-                let request_id = payload
-                    .get("request_id")
-                    .and_then(Value::as_str)
-                    .map(ToString::to_string);
-                let content = payload
-                    .get("response")
-                    .and_then(|response| response.get("content"))
-                    .and_then(Value::as_str)
-                    .unwrap_or_default()
-                    .to_string();
-                let role = match payload.get("role").and_then(Value::as_str) {
-                    Some("user") => MessageRole::User,
-                    Some("system") => MessageRole::System,
-                    _ => MessageRole::Assistant,
-                };
-                let timestamp_ms = payload
-                    .get("timestamp_ms")
-                    .and_then(Value::as_i64)
-                    .unwrap_or_else(current_timestamp_ms);
-                let history_event = payload
-                    .get("history")
-                    .and_then(Value::as_bool)
-                    .unwrap_or(false);
-                let response_metadata = payload
-                    .get("response")
-                    .and_then(|response| response.get("metadata"))
-                    .cloned()
-                    .and_then(|value| serde_json::from_value::<BTreeMap<String, Value>>(value).ok())
-                    .unwrap_or_default();
-                let mut history = self.sessions[index].buffers.messages.borrow_mut();
-                if history_event || !matches!(role, MessageRole::Assistant) {
-                    if message_id_exists(
-                        &history,
-                        payload.get("message_id").and_then(Value::as_str),
-                    ) {
-                        return;
-                    }
-                    if matches!(role, MessageRole::Assistant)
-                        && should_hide_heartbeat_silent_ack(&content, &response_metadata)
-                    {
-                        return;
-                    }
-                    let message = ChatMessage::new_with_metadata(
-                        content,
-                        role,
-                        timestamp_ms,
-                        payload
-                            .get("message_id")
-                            .and_then(Value::as_str)
-                            .map(ToString::to_string),
-                        response_metadata,
-                    );
-                    history.push(message);
-                    let messages = history.clone();
-                    drop(history);
-                    sync_card_state_overrides(
-                        &messages,
-                        &mut self.sessions[index].card_state_overrides,
-                    );
-                    return;
-                }
-                if should_hide_heartbeat_silent_ack(&content, &response_metadata) {
-                    *self.sessions[index]
-                        .buffers
-                        .active_stream_request_id
-                        .borrow_mut() = request_id;
-                    return;
-                }
-                let action = classify_stream_message_action(
-                    history.last().map(|message| message.role),
-                    self.sessions[index]
-                        .buffers
-                        .active_stream_request_id
-                        .borrow()
-                        .as_deref(),
-                    request_id.as_deref(),
-                    &content,
-                );
-                match action {
-                    crate::StreamMessageAction::IgnoreEmpty => {}
-                    crate::StreamMessageAction::ReplaceLastAssistant => {
-                        if let Some(message) = history.last_mut() {
-                            message.text = content;
-                            message.timestamp_ms = current_timestamp_ms();
-                            message.metadata = response_metadata.clone();
-                            message.card = crate::resolve_im_card(&message.text, &message.metadata);
-                        }
-                        let messages = history.clone();
-                        drop(history);
-                        sync_card_state_overrides(
-                            &messages,
-                            &mut self.sessions[index].card_state_overrides,
-                        );
-                    }
-                    crate::StreamMessageAction::PushAssistant => {
-                        history.push(ChatMessage::new_with_metadata(
-                            content.clone(),
-                            MessageRole::Assistant,
-                            timestamp_ms,
-                            payload
-                                .get("message_id")
-                                .and_then(Value::as_str)
-                                .map(ToString::to_string),
-                            response_metadata,
-                        ));
-                        let messages = history.clone();
-                        *self.sessions[index]
-                            .buffers
-                            .active_stream_request_id
-                            .borrow_mut() = request_id;
-                        drop(history);
-                        sync_card_state_overrides(
-                            &messages,
-                            &mut self.sessions[index].card_state_overrides,
-                        );
-                        self.notify_new_assistant_reply(session_key, &content);
-                    }
-                }
-            }
-            "session.subscribed" => {
-                let Some(session_key) = payload.get("session_key").and_then(Value::as_str) else {
+    fn process_notification_frame(&mut self, method: &str, params: &Value) {
+        match method {
+            "session/subscribed" => {
+                let Some(session_key) = params.get("session_key").and_then(Value::as_str) else {
                     return;
                 };
                 let Some(index) = self.session_index(session_key) else {
@@ -646,28 +569,227 @@ impl ChatApp {
                 };
                 self.sessions[index].subscribed = true;
             }
-            "session.stream.clear" | "session.stream.done" => {
-                let Some(session_key) = payload.get("session_key").and_then(Value::as_str) else {
+            "item/agentMessage/delta" => {
+                let Some(session_key) = params.get("session_id").and_then(Value::as_str) else {
                     return;
                 };
-                let Some(index) = self.session_index(session_key) else {
-                    return;
-                };
-                *self.sessions[index]
-                    .buffers
-                    .active_stream_request_id
-                    .borrow_mut() = None;
-            }
-            "system.raw" => {
-                let text = payload
-                    .get("text")
+                let turn_id = params
+                    .get("turn_id")
                     .and_then(Value::as_str)
-                    .unwrap_or_default()
-                    .to_string();
-                self.toasts.borrow_mut().info(text);
+                    .map(ToString::to_string);
+                let delta = params
+                    .get("delta")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default();
+                self.apply_assistant_stream_delta(
+                    session_key,
+                    turn_id,
+                    delta,
+                    BTreeMap::new(),
+                    None,
+                );
+            }
+            "item/completed" => {
+                let Some(session_key) = params.get("session_id").and_then(Value::as_str) else {
+                    return;
+                };
+                let Some(item) = params.get("item") else {
+                    return;
+                };
+                let response = item
+                    .get("payload")
+                    .and_then(|payload| payload.get("response"))
+                    .filter(|value| !value.is_null());
+                let content = response
+                    .and_then(|response| response.get("content"))
+                    .and_then(Value::as_str)
+                    .unwrap_or_default();
+                let metadata = response
+                    .and_then(|response| response.get("metadata"))
+                    .cloned()
+                    .and_then(|value| serde_json::from_value::<BTreeMap<String, Value>>(value).ok())
+                    .unwrap_or_default();
+                let message_id = response
+                    .and_then(|response| response.get("message_id"))
+                    .and_then(Value::as_str)
+                    .map(ToString::to_string);
+                self.complete_assistant_response(session_key, content, metadata, message_id);
+            }
+            "turn/completed" => {
+                let Some(session_key) = params.get("session_id").and_then(Value::as_str) else {
+                    return;
+                };
+                let response = params.get("response").filter(|value| !value.is_null());
+                let content = response
+                    .and_then(|response| response.get("content"))
+                    .and_then(Value::as_str)
+                    .unwrap_or_default();
+                let metadata = response
+                    .and_then(|response| response.get("metadata"))
+                    .cloned()
+                    .and_then(|value| serde_json::from_value::<BTreeMap<String, Value>>(value).ok())
+                    .unwrap_or_default();
+                let message_id = response
+                    .and_then(|response| response.get("message_id"))
+                    .and_then(Value::as_str)
+                    .map(ToString::to_string);
+                self.complete_assistant_response(session_key, content, metadata, message_id);
+                if let Some(index) = self.session_index(session_key) {
+                    *self.sessions[index]
+                        .buffers
+                        .active_stream_request_id
+                        .borrow_mut() = None;
+                }
+            }
+            "turn/interrupted" => {
+                let Some(session_key) = params.get("session_id").and_then(Value::as_str) else {
+                    return;
+                };
+                if let Some(index) = self.session_index(session_key) {
+                    *self.sessions[index]
+                        .buffers
+                        .active_stream_request_id
+                        .borrow_mut() = None;
+                }
+            }
+            "serverRequest/resolved" => {
+                for session in &mut self.sessions {
+                    let messages = session.buffers.messages.borrow().clone();
+                    sync_card_state_overrides(&messages, &mut session.card_state_overrides);
+                }
             }
             _ => {}
         }
+    }
+
+    fn process_server_request_frame(&mut self, method: &str, _params: &Value) {
+        self.toasts
+            .borrow_mut()
+            .info(format!("Unsupported gateway server request: {method}"));
+    }
+
+    fn apply_assistant_stream_delta(
+        &mut self,
+        session_key: &str,
+        request_id: Option<String>,
+        content: &str,
+        response_metadata: BTreeMap<String, Value>,
+        message_id: Option<String>,
+    ) {
+        let Some(index) = self.session_index(session_key) else {
+            return;
+        };
+        if should_hide_heartbeat_silent_ack(content, &response_metadata) {
+            *self.sessions[index]
+                .buffers
+                .active_stream_request_id
+                .borrow_mut() = request_id;
+            return;
+        }
+        let mut history = self.sessions[index].buffers.messages.borrow_mut();
+        let action = classify_stream_message_action(
+            history.last().map(|message| message.role),
+            self.sessions[index]
+                .buffers
+                .active_stream_request_id
+                .borrow()
+                .as_deref(),
+            request_id.as_deref(),
+            content,
+        );
+        match action {
+            crate::StreamMessageAction::IgnoreEmpty => {}
+            crate::StreamMessageAction::ReplaceLastAssistant => {
+                if let Some(message) = history.last_mut() {
+                    message.text.push_str(content);
+                    message.timestamp_ms = current_timestamp_ms();
+                    if !response_metadata.is_empty() {
+                        message.metadata = response_metadata;
+                    }
+                    message.card = crate::resolve_im_card(&message.text, &message.metadata);
+                }
+                let messages = history.clone();
+                drop(history);
+                sync_card_state_overrides(
+                    &messages,
+                    &mut self.sessions[index].card_state_overrides,
+                );
+            }
+            crate::StreamMessageAction::PushAssistant => {
+                history.push(ChatMessage::new_with_metadata(
+                    content.to_string(),
+                    MessageRole::Assistant,
+                    current_timestamp_ms(),
+                    message_id,
+                    response_metadata,
+                ));
+                let messages = history.clone();
+                *self.sessions[index]
+                    .buffers
+                    .active_stream_request_id
+                    .borrow_mut() = request_id;
+                drop(history);
+                sync_card_state_overrides(
+                    &messages,
+                    &mut self.sessions[index].card_state_overrides,
+                );
+                self.notify_new_assistant_reply(session_key, content);
+            }
+        }
+    }
+
+    fn complete_assistant_response(
+        &mut self,
+        session_key: &str,
+        content: &str,
+        metadata: BTreeMap<String, Value>,
+        message_id: Option<String>,
+    ) {
+        let Some(index) = self.session_index(session_key) else {
+            return;
+        };
+        if content.is_empty() || should_hide_heartbeat_silent_ack(content, &metadata) {
+            return;
+        }
+        let mut history = self.sessions[index].buffers.messages.borrow_mut();
+        if message_id_exists(&history, message_id.as_deref()) {
+            return;
+        }
+        if let Some(message) = history
+            .last_mut()
+            .filter(|message| matches!(message.role, MessageRole::Assistant))
+        {
+            if message.text.is_empty() {
+                message.text = content.to_string();
+            }
+            if message.message_id.is_none() {
+                message.message_id = message_id;
+            }
+            if !metadata.is_empty() {
+                message.metadata = metadata;
+                message.card = crate::resolve_im_card(&message.text, &message.metadata);
+            }
+            let messages = history.clone();
+            drop(history);
+            sync_card_state_overrides(&messages, &mut self.sessions[index].card_state_overrides);
+            return;
+        }
+        let message = ChatMessage::new_with_metadata(
+            content.to_string(),
+            MessageRole::Assistant,
+            current_timestamp_ms(),
+            message_id,
+            metadata,
+        );
+        let should_fade =
+            should_register_non_stream_fade(message.role, false, false, &message.text);
+        history.push(message);
+        let messages = history.clone();
+        drop(history);
+        if should_fade && let Some(message) = messages.last() {
+            self.sessions[index].register_fade_in_message(message);
+        }
+        sync_card_state_overrides(&messages, &mut self.sessions[index].card_state_overrides);
     }
 
     pub(in crate::web_chat) fn send_session_draft(&mut self, session_key: &str) {
@@ -761,8 +883,9 @@ impl ChatApp {
                 .active_stream_request_id
                 .borrow_mut() = stream.then_some(request_id.clone());
         }
-        let params = build_submit_params(
+        let params = build_turn_start_params(
             session_key,
+            &request_id,
             text,
             stream,
             attachments,
@@ -770,7 +893,7 @@ impl ChatApp {
             model,
             metadata,
         );
-        let send_result = send_method(&ws, &request_id, "session.submit", params);
+        let send_result = send_rpc_request(&ws, &request_id, "turn/start", params);
         if let Err(err) = send_result {
             *self.connection_state.borrow_mut() = ConnectionState::Error(err);
             return false;
@@ -779,8 +902,9 @@ impl ChatApp {
     }
 }
 
-fn build_submit_params(
+fn build_turn_start_params(
     session_key: &str,
+    turn_id: &str,
     input: &str,
     stream: bool,
     attachments: &[WebArchiveAttachment],
@@ -788,8 +912,10 @@ fn build_submit_params(
     model: &str,
     metadata: Option<&BTreeMap<String, Value>>,
 ) -> Value {
-    build_websocket_submit_params(
+    build_websocket_turn_start_params(
         session_key,
+        session_key,
+        turn_id,
         input,
         stream,
         attachments,


### PR DESCRIPTION
## Summary
- Completes the Gateway WebSocket v1 session/provider/history surface required by WebUI.
- Switches WebUI to v1 RPC frames and `turn/start` content blocks, with v1 `item/*` and `turn/*` rendering.
- Updates runtime v1 turn completion behavior plus protocol docs, README, and changelogs.

Closes #235

## Test plan
- [x] `cargo test -p klaw-gateway websocket_v1 --lib`
- [x] `cargo test -p klaw-gateway --test protocol_v1`
- [x] `cargo test -p klaw-webui`
- [x] `cargo test -p klaw-runtime stream_ --lib`
- [x] `cargo check -p klaw-webui --target wasm32-unknown-unknown`
- [x] `mdbook build docs`

## Notes
- `cargo test -p klaw-webui` still reports existing unused/dead_code warnings in test-only code.
- `mdbook build docs` reports the existing `mdbook-mermaid` preprocessor version warning.

Made with [Cursor](https://cursor.com)