### PR TITLE
feat(session): add physical cleanup for expired cron/webhook sessions

### DIFF
--- a/klaw-cron/CHANGELOG.md
+++ b/klaw-cron/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 2026-05-07
+
+### Changed
+
+- Test `FakeStorage` now implements the session cleanup trait method so cron worker tests stay aligned with the expanded storage API.
+
 ## 2026-05-04
 
 ### Fixed

--- a/klaw-cron/src/worker.rs
+++ b/klaw-cron/src/worker.rs
@@ -376,10 +376,11 @@ mod tests {
         LlmUsageRecord, LlmUsageSummary, NewApprovalRecord, NewCronJob, NewCronTaskRun,
         NewLlmAuditRecord, NewLlmUsageRecord, NewPendingQuestionRecord, NewToolAuditRecord,
         NewWebhookAgentRecord, NewWebhookEventRecord, PendingQuestionRecord, PendingQuestionStatus,
-        SessionCompressionState, SessionIndex, SessionStorage, StorageError,
-        ToolAuditFilterOptions, ToolAuditFilterOptionsQuery, ToolAuditQuery, ToolAuditRecord,
-        UpdateCronJobPatch, UpdateWebhookAgentResult, UpdateWebhookEventResult, WebhookAgentQuery,
-        WebhookAgentRecord, WebhookEventQuery, WebhookEventRecord,
+        SessionCleanupQuery, SessionCleanupSummary, SessionCompressionState, SessionIndex,
+        SessionStorage, StorageError, ToolAuditFilterOptions, ToolAuditFilterOptionsQuery,
+        ToolAuditQuery, ToolAuditRecord, UpdateCronJobPatch, UpdateWebhookAgentResult,
+        UpdateWebhookEventResult, WebhookAgentQuery, WebhookAgentRecord, WebhookEventQuery,
+        WebhookEventRecord,
     };
     use std::{
         collections::BTreeMap,
@@ -834,6 +835,13 @@ mod tests {
             _session_key_prefix: Option<&str>,
         ) -> Result<i64, StorageError> {
             Ok(self.sessions.lock().expect("lock").len() as i64)
+        }
+
+        async fn clean_sessions(
+            &self,
+            _query: &SessionCleanupQuery,
+        ) -> Result<SessionCleanupSummary, StorageError> {
+            Ok(SessionCleanupSummary::default())
         }
 
         async fn list_session_channels(&self) -> Result<Vec<String>, StorageError> {

--- a/klaw-gui/CHANGELOG.md
+++ b/klaw-gui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2026-05-07
 
+### Added
+
+- Session 面板新增 `Clean` 操作，可通过弹窗选择 `Updated At` 截止日期以及 cron/webhook 类型，并清理匹配的旧会话记录与本地 JSONL 文件。
+
 ### Changed
 
 - Channel、Tool、Heartbeat 和 ACP 测试面板的运行时动作改为后台请求加轮询结果，避免 UI 线程在 runtime 响应超时或忙碌时同步等待。

--- a/klaw-gui/CHANGELOG.md
+++ b/klaw-gui/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Session 面板新增 `Clean` 操作，可通过弹窗选择 `Updated At` 截止日期以及 cron/webhook 类型，并清理匹配的旧会话记录与本地 JSONL 文件。
+- Session 清理进度弹窗现在显示总数、已删除数量和百分比进度，而不是固定等待文案。
 
 ### Changed
 

--- a/klaw-gui/README.md
+++ b/klaw-gui/README.md
@@ -140,6 +140,7 @@
   - read indexed sessions via `klaw-session` manager abstraction
   - render session metadata in a read-only table with limit/offset controls
   - support SQL-backed `channel` dropdown filtering and `Updated At` ascending/descending sorting
+  - clean old cron/webhook sessions from a confirmation dialog with an `Updated At` cutoff date
   - open the chat history window directly by double-clicking a session row
 - Approval panel features:
   - read approvals via `klaw-approval` manager abstraction

--- a/klaw-gui/src/panels/session.rs
+++ b/klaw-gui/src/panels/session.rs
@@ -6,11 +6,11 @@ use chrono::{Datelike, Local, NaiveDate};
 use egui_extras::{Column, DatePickerButton, TableBuilder};
 use egui_phosphor::regular;
 use klaw_session::{
-    LlmUsageSummary, SessionCleanupQuery, SessionError, SessionIndex, SessionListQuery,
-    SessionManager, SessionSortOrder, SqliteSessionManager,
+    LlmUsageSummary, SessionCleanupProgress, SessionCleanupQuery, SessionCleanupSummary,
+    SessionError, SessionIndex, SessionListQuery, SessionManager, SessionSortOrder,
+    SqliteSessionManager,
 };
-use std::future::Future;
-use std::thread;
+use std::{future::Future, sync::mpsc, thread, time::Duration};
 use time::{Month, OffsetDateTime, PrimitiveDateTime, Time};
 use tokio::runtime::Builder;
 
@@ -33,6 +33,8 @@ pub struct SessionPanel {
     cleanup_updated_before: Option<NaiveDate>,
     cleanup_cron: bool,
     cleanup_webhook: bool,
+    cleanup_request: Option<mpsc::Receiver<SessionCleanupTaskMessage>>,
+    cleanup_progress: Option<SessionCleanupProgress>,
 }
 
 impl Default for SessionPanel {
@@ -56,6 +58,8 @@ impl Default for SessionPanel {
             cleanup_updated_before: Some(today),
             cleanup_cron: true,
             cleanup_webhook: true,
+            cleanup_request: None,
+            cleanup_progress: None,
         }
     }
 }
@@ -64,6 +68,11 @@ impl Default for SessionPanel {
 struct SessionRow {
     session: SessionIndex,
     usage: LlmUsageSummary,
+}
+
+enum SessionCleanupTaskMessage {
+    Progress(SessionCleanupProgress),
+    Completed(Result<SessionCleanupSummary, String>),
 }
 
 impl SessionPanel {
@@ -136,23 +145,79 @@ impl SessionPanel {
         }
     }
 
-    fn clean_sessions(&mut self, notifications: &mut NotificationCenter) {
+    fn begin_clean_sessions(&mut self, notifications: &mut NotificationCenter) {
+        if self.cleanup_request.is_some() {
+            notifications.info("Session cleanup is already in progress.");
+            return;
+        }
         let Some(query) = self.cleanup_query() else {
             notifications.error("Select an Updated At date and at least one session type.");
             return;
         };
 
-        match run_session_task(move |manager| async move { manager.clean_sessions(&query).await }) {
-            Ok(summary) => {
-                notifications.success(format!(
-                    "Cleaned {} sessions and deleted {} JSONL files ({} already missing).",
-                    summary.session_records_deleted,
-                    summary.jsonl_files_deleted,
-                    summary.jsonl_files_missing
-                ));
-                self.refresh(notifications);
+        let (tx, rx) = mpsc::channel();
+        thread::spawn(move || {
+            let progress_tx = tx.clone();
+            let result = run_session_task(move |manager| async move {
+                manager
+                    .clean_sessions_with_progress(&query, &move |progress| {
+                        let _ = progress_tx.send(SessionCleanupTaskMessage::Progress(progress));
+                    })
+                    .await
+            });
+            let _ = tx.send(SessionCleanupTaskMessage::Completed(result));
+        });
+        self.cleanup_progress = Some(SessionCleanupProgress::default());
+        self.cleanup_request = Some(rx);
+    }
+
+    fn poll_cleanup_request(
+        &mut self,
+        ctx: &egui::Context,
+        notifications: &mut NotificationCenter,
+    ) {
+        let Some(rx) = self.cleanup_request.take() else {
+            return;
+        };
+
+        let mut completed = false;
+        loop {
+            match rx.try_recv() {
+                Ok(SessionCleanupTaskMessage::Progress(progress)) => {
+                    self.cleanup_progress = Some(progress);
+                }
+                Ok(SessionCleanupTaskMessage::Completed(Ok(summary))) => {
+                    self.cleanup_progress = None;
+                    completed = true;
+                    notifications.success(format!(
+                        "Cleaned {} sessions and deleted {} JSONL files ({} already missing).",
+                        summary.session_records_deleted,
+                        summary.jsonl_files_deleted,
+                        summary.jsonl_files_missing
+                    ));
+                    self.refresh(notifications);
+                    break;
+                }
+                Ok(SessionCleanupTaskMessage::Completed(Err(err))) => {
+                    self.cleanup_progress = None;
+                    completed = true;
+                    notifications.error(format!("Failed to clean sessions: {err}"));
+                    break;
+                }
+                Err(mpsc::TryRecvError::Empty) => break,
+                Err(mpsc::TryRecvError::Disconnected) => {
+                    self.cleanup_progress = None;
+                    completed = true;
+                    notifications
+                        .error("Failed to clean sessions: cleanup task stopped unexpectedly");
+                    break;
+                }
             }
-            Err(err) => notifications.error(format!("Failed to clean sessions: {err}")),
+        }
+
+        if !completed {
+            self.cleanup_request = Some(rx);
+            ctx.request_repaint_after(Duration::from_millis(100));
         }
     }
 
@@ -251,8 +316,45 @@ impl SessionPanel {
         self.cleanup_open = open && !should_close;
         if should_clean {
             self.cleanup_open = false;
-            self.clean_sessions(notifications);
+            self.begin_clean_sessions(notifications);
         }
+    }
+
+    fn render_cleanup_progress_dialog(&self, ctx: &egui::Context) {
+        if self.cleanup_request.is_none() {
+            return;
+        }
+
+        ctx.request_repaint_after(Duration::from_millis(100));
+        egui::Window::new("Cleaning Sessions")
+            .collapsible(false)
+            .resizable(false)
+            .anchor(egui::Align2::CENTER_CENTER, egui::Vec2::ZERO)
+            .show(ctx, |ui| {
+                ui.horizontal(|ui| {
+                    ui.add(egui::Spinner::new());
+                    ui.label("Cleaning expired cron/webhook sessions...");
+                });
+                ui.add_space(8.0);
+                let progress = self.cleanup_progress.clone().unwrap_or_default();
+                let fraction = if progress.total_sessions > 0 {
+                    progress.deleted_sessions as f32 / progress.total_sessions as f32
+                } else {
+                    0.0
+                };
+                ui.add(
+                    egui::ProgressBar::new(fraction.clamp(0.0, 1.0))
+                        .desired_width(360.0)
+                        .show_percentage()
+                        .text(format!(
+                            "{} / {}",
+                            progress.deleted_sessions, progress.total_sessions
+                        )),
+                );
+                ui.label(format!("Total: {}", progress.total_sessions));
+                ui.label(format!("Deleted: {}", progress.deleted_sessions));
+                ui.small("This dialog will close automatically when cleanup finishes.");
+            });
     }
 }
 
@@ -264,6 +366,7 @@ impl PanelRenderer for SessionPanel {
         notifications: &mut NotificationCenter,
     ) {
         self.ensure_loaded(notifications);
+        self.poll_cleanup_request(ui.ctx(), notifications);
 
         ui.heading(ctx.tab_title);
         ui.horizontal(|ui| {
@@ -524,6 +627,7 @@ impl PanelRenderer for SessionPanel {
             chat_box.show(ui.ctx());
         }
         self.render_cleanup_dialog(ui.ctx(), notifications);
+        self.render_cleanup_progress_dialog(ui.ctx());
     }
 }
 

--- a/klaw-gui/src/panels/session.rs
+++ b/klaw-gui/src/panels/session.rs
@@ -6,8 +6,8 @@ use chrono::{Datelike, Local, NaiveDate};
 use egui_extras::{Column, DatePickerButton, TableBuilder};
 use egui_phosphor::regular;
 use klaw_session::{
-    LlmUsageSummary, SessionError, SessionIndex, SessionListQuery, SessionManager,
-    SessionSortOrder, SqliteSessionManager,
+    LlmUsageSummary, SessionCleanupQuery, SessionError, SessionIndex, SessionListQuery,
+    SessionManager, SessionSortOrder, SqliteSessionManager,
 };
 use std::future::Future;
 use std::thread;
@@ -29,6 +29,10 @@ pub struct SessionPanel {
     size: i64,
     selected_session: Option<String>,
     chat_box: Option<ChatBox>,
+    cleanup_open: bool,
+    cleanup_updated_before: Option<NaiveDate>,
+    cleanup_cron: bool,
+    cleanup_webhook: bool,
 }
 
 impl Default for SessionPanel {
@@ -48,6 +52,10 @@ impl Default for SessionPanel {
             size: 100,
             selected_session: None,
             chat_box: None,
+            cleanup_open: false,
+            cleanup_updated_before: Some(today),
+            cleanup_cron: true,
+            cleanup_webhook: true,
         }
     }
 }
@@ -128,6 +136,26 @@ impl SessionPanel {
         }
     }
 
+    fn clean_sessions(&mut self, notifications: &mut NotificationCenter) {
+        let Some(query) = self.cleanup_query() else {
+            notifications.error("Select an Updated At date and at least one session type.");
+            return;
+        };
+
+        match run_session_task(move |manager| async move { manager.clean_sessions(&query).await }) {
+            Ok(summary) => {
+                notifications.success(format!(
+                    "Cleaned {} sessions and deleted {} JSONL files ({} already missing).",
+                    summary.session_records_deleted,
+                    summary.jsonl_files_deleted,
+                    summary.jsonl_files_missing
+                ));
+                self.refresh(notifications);
+            }
+            Err(err) => notifications.error(format!("Failed to clean sessions: {err}")),
+        }
+    }
+
     fn toggle_sort_order(&mut self) {
         self.sort_order = match self.sort_order {
             SessionSortOrder::UpdatedAtAsc => SessionSortOrder::UpdatedAtDesc,
@@ -142,6 +170,88 @@ impl SessionPanel {
             SessionSortOrder::UpdatedAtAsc => "Updated At ↑",
             SessionSortOrder::UpdatedAtDesc => "Updated At ↓",
             SessionSortOrder::CreatedAtDesc => "Created At ↓",
+        }
+    }
+
+    fn cleanup_channels(&self) -> Vec<String> {
+        let mut channels = Vec::new();
+        if self.cleanup_cron {
+            channels.push("cron".to_string());
+        }
+        if self.cleanup_webhook {
+            channels.push("webhook".to_string());
+        }
+        channels
+    }
+
+    fn cleanup_query(&self) -> Option<SessionCleanupQuery> {
+        let updated_before_ms = self.cleanup_updated_before.and_then(date_start_ms)?;
+        let channels = self.cleanup_channels();
+        if channels.is_empty() {
+            return None;
+        }
+        Some(SessionCleanupQuery {
+            updated_before_ms,
+            channels,
+        })
+    }
+
+    fn render_cleanup_dialog(
+        &mut self,
+        ctx: &egui::Context,
+        notifications: &mut NotificationCenter,
+    ) {
+        if !self.cleanup_open {
+            return;
+        }
+
+        let mut open = self.cleanup_open;
+        let mut should_clean = false;
+        let mut should_close = false;
+        egui::Window::new("Clean Sessions")
+            .collapsible(false)
+            .resizable(false)
+            .open(&mut open)
+            .show(ctx, |ui| {
+                ui.label("Delete cron/webhook sessions updated before the selected date.");
+                ui.add_space(8.0);
+                ui.horizontal(|ui| {
+                    ui.label("Updated At before");
+                    if let Some(date) = self.cleanup_updated_before.as_mut() {
+                        ui.add(
+                            DatePickerButton::new(date)
+                                .id_salt("session-clean-updated-before")
+                                .format("%Y/%m/%d"),
+                        );
+                    }
+                });
+                ui.add_space(8.0);
+                ui.label("Session types");
+                ui.checkbox(&mut self.cleanup_cron, "cron");
+                ui.checkbox(&mut self.cleanup_webhook, "webhook");
+                ui.add_space(8.0);
+
+                if self.cleanup_query().is_none() {
+                    ui.label("Select a date and at least one session type to continue.");
+                }
+
+                ui.horizontal(|ui| {
+                    if ui
+                        .add_enabled(self.cleanup_query().is_some(), egui::Button::new("Clean"))
+                        .clicked()
+                    {
+                        should_clean = true;
+                    }
+                    if ui.button("Cancel").clicked() {
+                        should_close = true;
+                    }
+                });
+            });
+
+        self.cleanup_open = open && !should_close;
+        if should_clean {
+            self.cleanup_open = false;
+            self.clean_sessions(notifications);
         }
     }
 }
@@ -159,6 +269,12 @@ impl PanelRenderer for SessionPanel {
         ui.horizontal(|ui| {
             if ui.button("Refresh").clicked() {
                 self.refresh(notifications);
+            }
+            if ui.button("Clean").clicked() {
+                if self.cleanup_updated_before.is_none() {
+                    self.cleanup_updated_before = Some(Local::now().date_naive());
+                }
+                self.cleanup_open = true;
             }
             ui.label(format!("Sessions: {}", self.total_count));
         });
@@ -407,6 +523,7 @@ impl PanelRenderer for SessionPanel {
         if let Some(chat_box) = &mut self.chat_box {
             chat_box.show(ui.ctx());
         }
+        self.render_cleanup_dialog(ui.ctx(), notifications);
     }
 }
 
@@ -477,4 +594,43 @@ fn date_boundary_ms(date: NaiveDate, time: Time) -> Option<i64> {
 
 fn offset_to_ms(datetime: OffsetDateTime) -> i64 {
     datetime.unix_timestamp_nanos().saturating_div(1_000_000) as i64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cleanup_query_requires_date_and_channel() {
+        let mut panel = SessionPanel::default();
+
+        panel.cleanup_updated_before = None;
+        assert!(panel.cleanup_query().is_none());
+
+        panel.cleanup_updated_before =
+            Some(NaiveDate::from_ymd_opt(2026, 5, 7).expect("test date should be valid"));
+        panel.cleanup_cron = false;
+        panel.cleanup_webhook = false;
+        assert!(panel.cleanup_query().is_none());
+    }
+
+    #[test]
+    fn cleanup_query_uses_selected_cleanup_channels() {
+        let mut panel = SessionPanel::default();
+        panel.cleanup_updated_before =
+            Some(NaiveDate::from_ymd_opt(2026, 5, 7).expect("test date should be valid"));
+        panel.cleanup_cron = true;
+        panel.cleanup_webhook = false;
+
+        let query = panel
+            .cleanup_query()
+            .expect("selected date and channel should build query");
+
+        assert_eq!(query.channels, vec!["cron".to_string()]);
+        assert_eq!(
+            query.updated_before_ms,
+            date_start_ms(panel.cleanup_updated_before.expect("date should exist"))
+                .expect("date should convert")
+        );
+    }
 }

--- a/klaw-gui/src/panels/session.rs
+++ b/klaw-gui/src/panels/session.rs
@@ -602,25 +602,33 @@ mod tests {
 
     #[test]
     fn cleanup_query_requires_date_and_channel() {
-        let mut panel = SessionPanel::default();
-
-        panel.cleanup_updated_before = None;
+        let panel = SessionPanel {
+            cleanup_updated_before: None,
+            ..Default::default()
+        };
         assert!(panel.cleanup_query().is_none());
 
-        panel.cleanup_updated_before =
-            Some(NaiveDate::from_ymd_opt(2026, 5, 7).expect("test date should be valid"));
-        panel.cleanup_cron = false;
-        panel.cleanup_webhook = false;
+        let panel = SessionPanel {
+            cleanup_updated_before: Some(
+                NaiveDate::from_ymd_opt(2026, 5, 7).expect("test date should be valid"),
+            ),
+            cleanup_cron: false,
+            cleanup_webhook: false,
+            ..Default::default()
+        };
         assert!(panel.cleanup_query().is_none());
     }
 
     #[test]
     fn cleanup_query_uses_selected_cleanup_channels() {
-        let mut panel = SessionPanel::default();
-        panel.cleanup_updated_before =
-            Some(NaiveDate::from_ymd_opt(2026, 5, 7).expect("test date should be valid"));
-        panel.cleanup_cron = true;
-        panel.cleanup_webhook = false;
+        let panel = SessionPanel {
+            cleanup_updated_before: Some(
+                NaiveDate::from_ymd_opt(2026, 5, 7).expect("test date should be valid"),
+            ),
+            cleanup_cron: true,
+            cleanup_webhook: false,
+            ..Default::default()
+        };
 
         let query = panel
             .cleanup_query()

--- a/klaw-knowledge/CHANGELOG.md
+++ b/klaw-knowledge/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2026-05-07
 
+### Changed
+
+- Simplified Obsidian auto-index watcher shutdown branching to satisfy current workspace clippy without changing bounded shutdown behavior.
+
 ### Fixed
 
 - Obsidian auto-index watcher shutdown now joins its producer thread with a bounded non-Tokio wait, preventing a stuck file watcher from leaving a Tokio blocking task that can hold GUI process shutdown open.

--- a/klaw-knowledge/src/obsidian/watcher.rs
+++ b/klaw-knowledge/src/obsidian/watcher.rs
@@ -38,13 +38,13 @@ impl AutoIndexWatcher {
         if let Some(shutdown_tx) = self.shutdown_tx.take() {
             let _ = shutdown_tx.send(());
         }
-        if let Some(producer) = self.producer.take() {
-            if !join_producer_with_timeout(producer, PRODUCER_JOIN_TIMEOUT) {
-                warn!(
-                    timeout_seconds = PRODUCER_JOIN_TIMEOUT.as_secs(),
-                    "knowledge auto-index producer join timed out; continuing shutdown"
-                );
-            }
+        if let Some(producer) = self.producer.take()
+            && !join_producer_with_timeout(producer, PRODUCER_JOIN_TIMEOUT)
+        {
+            warn!(
+                timeout_seconds = PRODUCER_JOIN_TIMEOUT.as_secs(),
+                "knowledge auto-index producer join timed out; continuing shutdown"
+            );
         }
         if let Some(consumer) = self.consumer.take() {
             consumer.abort();

--- a/klaw-runtime/CHANGELOG.md
+++ b/klaw-runtime/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2026-05-07
 
+### Changed
+
+- Simplified Knowledge runtime auto-index shutdown branching to satisfy current workspace clippy without changing timeout behavior.
+
 ### Fixed
 
 - Gateway manager now exposes a timeout recovery hook so GUI runtime command handlers can clear `transitioning`, record an error, and keep cached status responsive when a Gateway lifecycle operation exceeds its runtime deadline.

--- a/klaw-runtime/src/knowledge_runtime.rs
+++ b/klaw-runtime/src/knowledge_runtime.rs
@@ -317,16 +317,15 @@ impl KnowledgeRuntimeService {
     }
 
     async fn stop_auto_index(&self) {
-        if let Some(handle) = self.auto_index.lock().await.take() {
-            if timeout(AUTO_INDEX_SHUTDOWN_TIMEOUT, handle.stop())
+        if let Some(handle) = self.auto_index.lock().await.take()
+            && timeout(AUTO_INDEX_SHUTDOWN_TIMEOUT, handle.stop())
                 .await
                 .is_err()
-            {
-                warn!(
-                    timeout_seconds = AUTO_INDEX_SHUTDOWN_TIMEOUT.as_secs(),
-                    "knowledge auto-index shutdown timed out; continuing runtime shutdown"
-                );
-            }
+        {
+            warn!(
+                timeout_seconds = AUTO_INDEX_SHUTDOWN_TIMEOUT.as_secs(),
+                "knowledge auto-index shutdown timed out; continuing runtime shutdown"
+            );
         }
     }
 }

--- a/klaw-session/CHANGELOG.md
+++ b/klaw-session/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Added session-manager cleanup wrappers for restricted cron/webhook session cleanup, including cleanup summary reporting.
+- Added session cleanup progress forwarding so callers can show total and deleted session counts while cleanup runs.
 
 ## 2026-05-04
 

--- a/klaw-session/CHANGELOG.md
+++ b/klaw-session/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 2026-05-07
+
+### Added
+- Added session-manager cleanup wrappers for restricted cron/webhook session cleanup, including cleanup summary reporting.
+
 ## 2026-05-04
 
 ### Changed

--- a/klaw-session/README.md
+++ b/klaw-session/README.md
@@ -8,6 +8,7 @@
 - Provides `SqliteSessionManager` as the default manager backed by the workspace storage layer
 - Supports session listing, lookup, route-state initialization, explicit provider/model override updates, override clearing, and chat history read/write
 - Deletes sessions through storage soft-delete semantics, hiding inactive sessions while preserving stored history
+- Exposes restricted cron/webhook session cleanup with summary reporting for callers that need physical retention cleanup
 - Exposes append/list access for persisted `llm_audit` and `tool_audit` diagnostic records
 - Normalizes session list pagination, optional `channel` filtering, and `updated_at` sort selection through `SessionListQuery`
 - Exposes distinct persisted session channels for SQL-backed UI filter dropdowns

--- a/klaw-session/src/lib.rs
+++ b/klaw-session/src/lib.rs
@@ -6,11 +6,11 @@ pub use klaw_storage::{
     ChatRecord, LlmAuditFilterOptions, LlmAuditFilterOptionsQuery, LlmAuditQuery, LlmAuditRecord,
     LlmAuditSortOrder, LlmAuditStatus, LlmAuditSummaryRecord, LlmUsageRecord, LlmUsageSource,
     LlmUsageSummary, NewLlmAuditRecord, NewLlmUsageRecord, NewToolAuditRecord,
-    NewWebhookAgentRecord, NewWebhookEventRecord, SessionCleanupQuery, SessionCleanupSummary,
-    SessionCompressionState, SessionIndex, SessionSortOrder, ToolAuditFilterOptions,
-    ToolAuditFilterOptionsQuery, ToolAuditQuery, ToolAuditRecord, ToolAuditSortOrder,
-    ToolAuditStatus, UpdateWebhookAgentResult, UpdateWebhookEventResult, WebhookAgentQuery,
-    WebhookAgentRecord, WebhookEventQuery, WebhookEventRecord, WebhookEventSortOrder,
-    WebhookEventStatus,
+    NewWebhookAgentRecord, NewWebhookEventRecord, SessionCleanupProgress, SessionCleanupQuery,
+    SessionCleanupSummary, SessionCompressionState, SessionIndex, SessionSortOrder,
+    ToolAuditFilterOptions, ToolAuditFilterOptionsQuery, ToolAuditQuery, ToolAuditRecord,
+    ToolAuditSortOrder, ToolAuditStatus, UpdateWebhookAgentResult, UpdateWebhookEventResult,
+    WebhookAgentQuery, WebhookAgentRecord, WebhookEventQuery, WebhookEventRecord,
+    WebhookEventSortOrder, WebhookEventStatus,
 };
 pub use manager::{SessionHistoryPage, SessionListQuery, SessionManager, SqliteSessionManager};

--- a/klaw-session/src/lib.rs
+++ b/klaw-session/src/lib.rs
@@ -6,10 +6,11 @@ pub use klaw_storage::{
     ChatRecord, LlmAuditFilterOptions, LlmAuditFilterOptionsQuery, LlmAuditQuery, LlmAuditRecord,
     LlmAuditSortOrder, LlmAuditStatus, LlmAuditSummaryRecord, LlmUsageRecord, LlmUsageSource,
     LlmUsageSummary, NewLlmAuditRecord, NewLlmUsageRecord, NewToolAuditRecord,
-    NewWebhookAgentRecord, NewWebhookEventRecord, SessionCompressionState, SessionIndex,
-    SessionSortOrder, ToolAuditFilterOptions, ToolAuditFilterOptionsQuery, ToolAuditQuery,
-    ToolAuditRecord, ToolAuditSortOrder, ToolAuditStatus, UpdateWebhookAgentResult,
-    UpdateWebhookEventResult, WebhookAgentQuery, WebhookAgentRecord, WebhookEventQuery,
-    WebhookEventRecord, WebhookEventSortOrder, WebhookEventStatus,
+    NewWebhookAgentRecord, NewWebhookEventRecord, SessionCleanupQuery, SessionCleanupSummary,
+    SessionCompressionState, SessionIndex, SessionSortOrder, ToolAuditFilterOptions,
+    ToolAuditFilterOptionsQuery, ToolAuditQuery, ToolAuditRecord, ToolAuditSortOrder,
+    ToolAuditStatus, UpdateWebhookAgentResult, UpdateWebhookEventResult, WebhookAgentQuery,
+    WebhookAgentRecord, WebhookEventQuery, WebhookEventRecord, WebhookEventSortOrder,
+    WebhookEventStatus,
 };
 pub use manager::{SessionHistoryPage, SessionListQuery, SessionManager, SqliteSessionManager};

--- a/klaw-session/src/manager.rs
+++ b/klaw-session/src/manager.rs
@@ -4,11 +4,11 @@ use klaw_storage::{
     ChatRecord, ChatRecordPage, DefaultSessionStore, LlmAuditFilterOptions,
     LlmAuditFilterOptionsQuery, LlmAuditQuery, LlmAuditRecord, LlmAuditSummaryRecord,
     LlmUsageRecord, LlmUsageSummary, NewLlmAuditRecord, NewLlmUsageRecord, NewToolAuditRecord,
-    NewWebhookAgentRecord, NewWebhookEventRecord, SessionCompressionState, SessionIndex,
-    SessionSortOrder, SessionStorage, ToolAuditFilterOptions, ToolAuditFilterOptionsQuery,
-    ToolAuditQuery, ToolAuditRecord, UpdateWebhookAgentResult, UpdateWebhookEventResult,
-    WebhookAgentQuery, WebhookAgentRecord, WebhookEventQuery, WebhookEventRecord,
-    open_default_store,
+    NewWebhookAgentRecord, NewWebhookEventRecord, SessionCleanupQuery, SessionCleanupSummary,
+    SessionCompressionState, SessionIndex, SessionSortOrder, SessionStorage,
+    ToolAuditFilterOptions, ToolAuditFilterOptionsQuery, ToolAuditQuery, ToolAuditRecord,
+    UpdateWebhookAgentResult, UpdateWebhookEventResult, WebhookAgentQuery, WebhookAgentRecord,
+    WebhookEventQuery, WebhookEventRecord, open_default_store,
 };
 
 #[derive(Debug, Clone)]
@@ -152,6 +152,11 @@ pub trait SessionManager: Send + Sync {
     async fn count_sessions(&self, query: SessionListQuery) -> Result<i64, SessionError>;
 
     async fn list_session_channels(&self) -> Result<Vec<String>, SessionError>;
+
+    async fn clean_sessions(
+        &self,
+        query: &SessionCleanupQuery,
+    ) -> Result<SessionCleanupSummary, SessionError>;
 
     async fn append_llm_usage(
         &self,
@@ -479,6 +484,13 @@ impl SessionManager for SqliteSessionManager {
         Ok(self.store.list_session_channels().await?)
     }
 
+    async fn clean_sessions(
+        &self,
+        query: &SessionCleanupQuery,
+    ) -> Result<SessionCleanupSummary, SessionError> {
+        Ok(self.store.clean_sessions(query).await?)
+    }
+
     async fn append_llm_usage(
         &self,
         input: &NewLlmUsageRecord,
@@ -629,7 +641,9 @@ impl SessionManager for SqliteSessionManager {
 mod tests {
     use super::{SessionListQuery, SessionManager, SqliteSessionManager};
     use crate::SessionSortOrder;
-    use klaw_storage::{ChatRecord, DefaultSessionStore, SessionStorage, StoragePaths};
+    use klaw_storage::{
+        ChatRecord, DatabaseExecutor, DefaultSessionStore, SessionStorage, StoragePaths,
+    };
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -842,6 +856,54 @@ mod tests {
         assert_eq!(history.len(), 1);
         assert_eq!(history[0].content, "hello");
         assert!(manager.get_session("websocket:delete-me").await.is_err());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn manager_cleans_old_cron_sessions_and_reports_summary() {
+        let store = create_store().await;
+        store
+            .touch_session("cron:manager-old", "chat-1", "cron")
+            .await
+            .expect("session should be created");
+        store
+            .append_chat_record(
+                "cron:manager-old",
+                &ChatRecord::new("user", "cleanup", Some("m1".to_string())),
+            )
+            .await
+            .expect("history should append");
+        let old_ms = 1_000;
+        store
+            .execute(
+                "UPDATE sessions SET updated_at_ms = ? WHERE session_key = ?",
+                &[
+                    klaw_storage::DbValue::Integer(old_ms),
+                    klaw_storage::DbValue::Text("cron:manager-old".to_string()),
+                ],
+            )
+            .await
+            .expect("timestamp should update");
+
+        let manager = SqliteSessionManager::from_store(store);
+        let summary = manager
+            .clean_sessions(&crate::SessionCleanupQuery {
+                updated_before_ms: old_ms + 1,
+                channels: vec!["cron".to_string()],
+            })
+            .await
+            .expect("cleanup should succeed");
+
+        assert_eq!(summary.matched_sessions, 1);
+        assert_eq!(summary.session_records_deleted, 1);
+        assert_eq!(summary.jsonl_files_deleted, 1);
+        assert!(manager.get_session("cron:manager-old").await.is_err());
+        assert!(
+            manager
+                .read_chat_records("cron:manager-old")
+                .await
+                .expect("missing history should read as empty")
+                .is_empty()
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/klaw-session/src/manager.rs
+++ b/klaw-session/src/manager.rs
@@ -4,8 +4,8 @@ use klaw_storage::{
     ChatRecord, ChatRecordPage, DefaultSessionStore, LlmAuditFilterOptions,
     LlmAuditFilterOptionsQuery, LlmAuditQuery, LlmAuditRecord, LlmAuditSummaryRecord,
     LlmUsageRecord, LlmUsageSummary, NewLlmAuditRecord, NewLlmUsageRecord, NewToolAuditRecord,
-    NewWebhookAgentRecord, NewWebhookEventRecord, SessionCleanupQuery, SessionCleanupSummary,
-    SessionCompressionState, SessionIndex, SessionSortOrder, SessionStorage,
+    NewWebhookAgentRecord, NewWebhookEventRecord, SessionCleanupProgress, SessionCleanupQuery,
+    SessionCleanupSummary, SessionCompressionState, SessionIndex, SessionSortOrder, SessionStorage,
     ToolAuditFilterOptions, ToolAuditFilterOptionsQuery, ToolAuditQuery, ToolAuditRecord,
     UpdateWebhookAgentResult, UpdateWebhookEventResult, WebhookAgentQuery, WebhookAgentRecord,
     WebhookEventQuery, WebhookEventRecord, open_default_store,
@@ -156,6 +156,12 @@ pub trait SessionManager: Send + Sync {
     async fn clean_sessions(
         &self,
         query: &SessionCleanupQuery,
+    ) -> Result<SessionCleanupSummary, SessionError>;
+
+    async fn clean_sessions_with_progress(
+        &self,
+        query: &SessionCleanupQuery,
+        progress: &(dyn Fn(SessionCleanupProgress) + Send + Sync),
     ) -> Result<SessionCleanupSummary, SessionError>;
 
     async fn append_llm_usage(
@@ -489,6 +495,17 @@ impl SessionManager for SqliteSessionManager {
         query: &SessionCleanupQuery,
     ) -> Result<SessionCleanupSummary, SessionError> {
         Ok(self.store.clean_sessions(query).await?)
+    }
+
+    async fn clean_sessions_with_progress(
+        &self,
+        query: &SessionCleanupQuery,
+        progress: &(dyn Fn(SessionCleanupProgress) + Send + Sync),
+    ) -> Result<SessionCleanupSummary, SessionError> {
+        Ok(self
+            .store
+            .clean_sessions_with_progress(query, progress)
+            .await?)
     }
 
     async fn append_llm_usage(

--- a/klaw-storage/CHANGELOG.md
+++ b/klaw-storage/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Added restricted cron/webhook session cleanup APIs that physically remove matching session rows, related audit/usage records, and local JSONL history files.
+- Added cleanup progress reporting with total and deleted session counts for GUI progress dialogs.
 
 ### Fixed
 - Turso-backed memory, knowledge, and archive database executors now serialize access through their shared connection, preventing `concurrent use forbidden` errors when background tasks read long-term memory while other runtime work uses the same executor.

--- a/klaw-storage/CHANGELOG.md
+++ b/klaw-storage/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 2026-05-07
 
+### Added
+- Added restricted cron/webhook session cleanup APIs that physically remove matching session rows, related audit/usage records, and local JSONL history files.
+
 ### Fixed
 - Turso-backed memory, knowledge, and archive database executors now serialize access through their shared connection, preventing `concurrent use forbidden` errors when background tasks read long-term memory while other runtime work uses the same executor.
 

--- a/klaw-storage/README.md
+++ b/klaw-storage/README.md
@@ -10,6 +10,7 @@
 - persist session routing/model state used by IM command routing (`active_session_key`, `model_provider`, `model`)
 - support SQL-backed session listing with optional `channel` filtering, `updated_at` ordering, and distinct channel option queries
 - soft-delete sessions by marking them inactive while preserving JSONL history and audit/usage records
+- physically clean old cron/webhook sessions, their related records, and local JSONL history files through an explicit cleanup API
 - persist structured `tool_audit` and `llm_audit` records for runtime/GUI diagnostics
 - sync and restore versioned manifests plus deduplicated blobs for the managed data root via S3-compatible object storage
 

--- a/klaw-storage/src/lib.rs
+++ b/klaw-storage/src/lib.rs
@@ -30,12 +30,12 @@ pub use types::{
     LlmUsageSource, LlmUsageSummary, NewApprovalRecord, NewCronJob, NewCronTaskRun,
     NewHeartbeatJob, NewHeartbeatTaskRun, NewLlmAuditRecord, NewLlmUsageRecord,
     NewPendingQuestionRecord, NewToolAuditRecord, NewWebhookAgentRecord, NewWebhookEventRecord,
-    PendingQuestionRecord, PendingQuestionStatus, SessionCleanupQuery, SessionCleanupSummary,
-    SessionCompressionState, SessionIndex, SessionSortOrder, ToolAuditFilterOptions,
-    ToolAuditFilterOptionsQuery, ToolAuditQuery, ToolAuditRecord, ToolAuditSortOrder,
-    ToolAuditStatus, UpdateCronJobPatch, UpdateHeartbeatJobPatch, UpdateWebhookAgentResult,
-    UpdateWebhookEventResult, WebhookAgentQuery, WebhookAgentRecord, WebhookEventQuery,
-    WebhookEventRecord, WebhookEventSortOrder, WebhookEventStatus,
+    PendingQuestionRecord, PendingQuestionStatus, SessionCleanupProgress, SessionCleanupQuery,
+    SessionCleanupSummary, SessionCompressionState, SessionIndex, SessionSortOrder,
+    ToolAuditFilterOptions, ToolAuditFilterOptionsQuery, ToolAuditQuery, ToolAuditRecord,
+    ToolAuditSortOrder, ToolAuditStatus, UpdateCronJobPatch, UpdateHeartbeatJobPatch,
+    UpdateWebhookAgentResult, UpdateWebhookEventResult, WebhookAgentQuery, WebhookAgentRecord,
+    WebhookEventQuery, WebhookEventRecord, WebhookEventSortOrder, WebhookEventStatus,
 };
 
 #[cfg(all(feature = "turso", feature = "sqlx"))]
@@ -425,13 +425,45 @@ mod tests {
             .await
             .expect("webhook event should insert");
 
+        let progress_updates = std::sync::Mutex::new(Vec::new());
         let summary = store
-            .clean_sessions(&SessionCleanupQuery {
-                updated_before_ms: cutoff_ms,
-                channels: vec!["cron".to_string(), "webhook".to_string()],
-            })
+            .clean_sessions_with_progress(
+                &SessionCleanupQuery {
+                    updated_before_ms: cutoff_ms,
+                    channels: vec!["cron".to_string(), "webhook".to_string()],
+                },
+                &|progress| {
+                    progress_updates
+                        .lock()
+                        .expect("progress lock should acquire")
+                        .push(progress);
+                },
+            )
             .await
             .expect("cleanup should succeed");
+
+        assert_eq!(
+            progress_updates
+                .lock()
+                .expect("progress lock should acquire")
+                .first()
+                .cloned(),
+            Some(SessionCleanupProgress {
+                total_sessions: 2,
+                deleted_sessions: 0,
+            })
+        );
+        assert_eq!(
+            progress_updates
+                .lock()
+                .expect("progress lock should acquire")
+                .last()
+                .cloned(),
+            Some(SessionCleanupProgress {
+                total_sessions: 2,
+                deleted_sessions: 2,
+            })
+        );
 
         assert_eq!(summary.matched_sessions, 2);
         assert_eq!(summary.session_records_deleted, 2);

--- a/klaw-storage/src/lib.rs
+++ b/klaw-storage/src/lib.rs
@@ -30,12 +30,12 @@ pub use types::{
     LlmUsageSource, LlmUsageSummary, NewApprovalRecord, NewCronJob, NewCronTaskRun,
     NewHeartbeatJob, NewHeartbeatTaskRun, NewLlmAuditRecord, NewLlmUsageRecord,
     NewPendingQuestionRecord, NewToolAuditRecord, NewWebhookAgentRecord, NewWebhookEventRecord,
-    PendingQuestionRecord, PendingQuestionStatus, SessionCompressionState, SessionIndex,
-    SessionSortOrder, ToolAuditFilterOptions, ToolAuditFilterOptionsQuery, ToolAuditQuery,
-    ToolAuditRecord, ToolAuditSortOrder, ToolAuditStatus, UpdateCronJobPatch,
-    UpdateHeartbeatJobPatch, UpdateWebhookAgentResult, UpdateWebhookEventResult, WebhookAgentQuery,
-    WebhookAgentRecord, WebhookEventQuery, WebhookEventRecord, WebhookEventSortOrder,
-    WebhookEventStatus,
+    PendingQuestionRecord, PendingQuestionStatus, SessionCleanupQuery, SessionCleanupSummary,
+    SessionCompressionState, SessionIndex, SessionSortOrder, ToolAuditFilterOptions,
+    ToolAuditFilterOptionsQuery, ToolAuditQuery, ToolAuditRecord, ToolAuditSortOrder,
+    ToolAuditStatus, UpdateCronJobPatch, UpdateHeartbeatJobPatch, UpdateWebhookAgentResult,
+    UpdateWebhookEventResult, WebhookAgentQuery, WebhookAgentRecord, WebhookEventQuery,
+    WebhookEventRecord, WebhookEventSortOrder, WebhookEventStatus,
 };
 
 #[cfg(all(feature = "turso", feature = "sqlx"))]
@@ -334,6 +334,174 @@ mod tests {
                 .await
                 .is_err()
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn clean_sessions_deletes_only_old_cron_and_webhook_sessions() {
+        let store = create_store().await;
+        let old_ms = util::now_ms() - 10_000;
+        let cutoff_ms = util::now_ms() - 5_000;
+
+        for (session_key, channel) in [
+            ("cron:old-cron-run", "cron"),
+            ("webhook:old-webhook-run", "webhook"),
+            ("terminal:old-terminal-run", "terminal"),
+            ("cron:new-cron-run", "cron"),
+        ] {
+            store
+                .touch_session(session_key, session_key, channel)
+                .await
+                .expect("session should be created");
+            store
+                .append_chat_record(
+                    session_key,
+                    &ChatRecord::new("user", session_key, Some(format!("{session_key}-m1"))),
+                )
+                .await
+                .expect("history should append");
+        }
+
+        store
+            .execute(
+                "UPDATE sessions SET updated_at_ms = ? WHERE session_key IN (?, ?, ?)",
+                &[
+                    DbValue::Integer(old_ms),
+                    DbValue::Text("cron:old-cron-run".to_string()),
+                    DbValue::Text("webhook:old-webhook-run".to_string()),
+                    DbValue::Text("terminal:old-terminal-run".to_string()),
+                ],
+            )
+            .await
+            .expect("timestamps should update");
+
+        let cron_file = store.session_jsonl_path("cron:old-cron-run");
+        let webhook_file = store.session_jsonl_path("webhook:old-webhook-run");
+        let terminal_file = store.session_jsonl_path("terminal:old-terminal-run");
+        let new_cron_file = store.session_jsonl_path("cron:new-cron-run");
+
+        store
+            .execute(
+                "INSERT INTO llm_usage (
+                    id, session_key, chat_id, turn_index, request_seq, provider, model, wire_api,
+                    input_tokens, output_tokens, total_tokens, source, created_at_ms
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                &[
+                    DbValue::Text("usage-cleanup".to_string()),
+                    DbValue::Text("webhook:old-webhook-run".to_string()),
+                    DbValue::Text("webhook:old-webhook-run".to_string()),
+                    DbValue::Integer(1),
+                    DbValue::Integer(1),
+                    DbValue::Text("openai".to_string()),
+                    DbValue::Text("gpt-4o-mini".to_string()),
+                    DbValue::Text("chat_completions".to_string()),
+                    DbValue::Integer(1),
+                    DbValue::Integer(2),
+                    DbValue::Integer(3),
+                    DbValue::Text("provider_reported".to_string()),
+                    DbValue::Integer(old_ms),
+                ],
+            )
+            .await
+            .expect("usage should insert");
+        store
+            .execute(
+                "INSERT INTO webhook_events (
+                    id, source, event_type, session_key, chat_id, sender_id, content, status,
+                    received_at_ms, created_at_ms
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                &[
+                    DbValue::Text("event-cleanup".to_string()),
+                    DbValue::Text("github".to_string()),
+                    DbValue::Text("push".to_string()),
+                    DbValue::Text("webhook:old-webhook-run".to_string()),
+                    DbValue::Text("webhook:old-webhook-run".to_string()),
+                    DbValue::Text("sender".to_string()),
+                    DbValue::Text("payload".to_string()),
+                    DbValue::Text("accepted".to_string()),
+                    DbValue::Integer(old_ms),
+                    DbValue::Integer(old_ms),
+                ],
+            )
+            .await
+            .expect("webhook event should insert");
+
+        let summary = store
+            .clean_sessions(&SessionCleanupQuery {
+                updated_before_ms: cutoff_ms,
+                channels: vec!["cron".to_string(), "webhook".to_string()],
+            })
+            .await
+            .expect("cleanup should succeed");
+
+        assert_eq!(summary.matched_sessions, 2);
+        assert_eq!(summary.session_records_deleted, 2);
+        assert_eq!(summary.related_records_deleted, 2);
+        assert_eq!(summary.jsonl_files_deleted, 2);
+        assert!(!fs::try_exists(cron_file).await.expect("stat should work"));
+        assert!(
+            !fs::try_exists(webhook_file)
+                .await
+                .expect("stat should work")
+        );
+        assert!(
+            fs::try_exists(terminal_file)
+                .await
+                .expect("stat should work")
+        );
+        assert!(
+            fs::try_exists(new_cron_file)
+                .await
+                .expect("stat should work")
+        );
+        let usage_rows = store
+            .query(
+                "SELECT COUNT(*) FROM llm_usage WHERE session_key = ?",
+                &[DbValue::Text("webhook:old-webhook-run".to_string())],
+            )
+            .await
+            .expect("usage count should query");
+        assert_eq!(usage_rows[0].get(0), Some(&DbValue::Integer(0)));
+        let event_rows = store
+            .query(
+                "SELECT COUNT(*) FROM webhook_events WHERE session_key = ?",
+                &[DbValue::Text("webhook:old-webhook-run".to_string())],
+            )
+            .await
+            .expect("event count should query");
+        assert_eq!(event_rows[0].get(0), Some(&DbValue::Integer(0)));
+        assert!(store.get_session("cron:old-cron-run").await.is_err());
+        assert!(store.get_session("webhook:old-webhook-run").await.is_err());
+        store
+            .get_session("terminal:old-terminal-run")
+            .await
+            .expect("old terminal session should remain");
+        store
+            .get_session("cron:new-cron-run")
+            .await
+            .expect("new cron session should remain");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn clean_sessions_rejects_unsupported_channels() {
+        let store = create_store().await;
+        store
+            .touch_session("terminal:keep", "chat-1", "terminal")
+            .await
+            .expect("session should be created");
+
+        let err = store
+            .clean_sessions(&SessionCleanupQuery {
+                updated_before_ms: util::now_ms() + 1,
+                channels: vec!["terminal".to_string()],
+            })
+            .await
+            .expect_err("unsupported channel should fail");
+
+        assert!(err.to_string().contains("cron and webhook"));
+        store
+            .get_session("terminal:keep")
+            .await
+            .expect("unsupported cleanup should not delete session");
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/klaw-storage/src/sqlx/session.rs
+++ b/klaw-storage/src/sqlx/session.rs
@@ -10,18 +10,28 @@ use crate::{
     LlmAuditQuery, LlmAuditRecord, LlmAuditSortOrder, LlmAuditSummaryRecord, LlmUsageRecord,
     LlmUsageSummary, NewApprovalRecord, NewLlmAuditRecord, NewLlmUsageRecord,
     NewPendingQuestionRecord, NewToolAuditRecord, NewWebhookAgentRecord, NewWebhookEventRecord,
-    PendingQuestionRecord, PendingQuestionStatus, SessionCompressionState, SessionIndex,
-    SessionSortOrder, SessionStorage, StorageError, ToolAuditFilterOptions,
-    ToolAuditFilterOptionsQuery, ToolAuditQuery, ToolAuditRecord, UpdateWebhookAgentResult,
-    UpdateWebhookEventResult, WebhookAgentQuery, WebhookAgentRecord, WebhookEventQuery,
-    WebhookEventRecord, WebhookEventSortOrder, jsonl,
+    PendingQuestionRecord, PendingQuestionStatus, SessionCleanupQuery, SessionCleanupSummary,
+    SessionCompressionState, SessionIndex, SessionSortOrder, SessionStorage, StorageError,
+    ToolAuditFilterOptions, ToolAuditFilterOptionsQuery, ToolAuditQuery, ToolAuditRecord,
+    UpdateWebhookAgentResult, UpdateWebhookEventResult, WebhookAgentQuery, WebhookAgentRecord,
+    WebhookEventQuery, WebhookEventRecord, WebhookEventSortOrder, jsonl,
     util::{now_ms, relative_or_absolute_jsonl},
 };
 use async_trait::async_trait;
 use sqlx::Row;
-use std::path::PathBuf;
+use std::{io::ErrorKind, path::PathBuf};
+use tokio::fs;
 
 const SESSION_INDEX_SELECT: &str = "session_key, chat_id, channel, title, active_session_key, model_provider, model_provider_explicit, model, model_explicit, delivery_metadata_json, is_active, created_at_ms, updated_at_ms, last_message_at_ms, turn_count, jsonl_path";
+const CLEANUP_RELATED_TABLES: &[&str] = &[
+    "llm_usage",
+    "llm_audit",
+    "tool_audit",
+    "webhook_events",
+    "webhook_agents",
+    "pending_questions",
+    "approvals",
+];
 
 #[async_trait]
 impl SessionStorage for SqlxSessionStore {
@@ -549,6 +559,65 @@ impl SessionStorage for SqlxSessionStore {
             .await
             .map_err(StorageError::backend)?;
         Ok(count)
+    }
+
+    async fn clean_sessions(
+        &self,
+        query: &SessionCleanupQuery,
+    ) -> Result<SessionCleanupSummary, StorageError> {
+        let channels = validate_cleanup_channels(&query.channels)?;
+        let channel_filter = cleanup_channel_filter(channels.len());
+        let select_sql = format!(
+            "SELECT {SESSION_INDEX_SELECT}
+             FROM sessions
+             WHERE is_active = 1 AND updated_at_ms < ? AND {channel_filter}"
+        );
+        let mut select =
+            sqlx::query_as::<_, SessionIndexRow>(&select_sql).bind(query.updated_before_ms);
+        for channel in &channels {
+            select = select.bind(channel);
+        }
+        let rows = select
+            .fetch_all(&self.pool)
+            .await
+            .map_err(StorageError::backend)?;
+        let sessions: Vec<SessionIndex> = rows.into_iter().map(Into::into).collect();
+        if sessions.is_empty() {
+            return Ok(SessionCleanupSummary::default());
+        }
+
+        let session_keys: Vec<String> = sessions
+            .iter()
+            .map(|session| session.session_key.clone())
+            .collect();
+        let placeholders = vec!["?"; session_keys.len()].join(", ");
+        let mut related_records_deleted = 0;
+        for table in CLEANUP_RELATED_TABLES {
+            let deleted = execute_session_key_delete(
+                &self.pool,
+                &format!("DELETE FROM {table} WHERE session_key IN ({placeholders})"),
+                &session_keys,
+            )
+            .await?;
+            related_records_deleted += i64::try_from(deleted).unwrap_or(i64::MAX);
+        }
+
+        let session_records_deleted = execute_session_key_delete(
+            &self.pool,
+            &format!("DELETE FROM sessions WHERE session_key IN ({placeholders})"),
+            &session_keys,
+        )
+        .await?;
+        let (jsonl_files_deleted, jsonl_files_missing) =
+            remove_session_jsonl_files(self, &session_keys).await?;
+
+        Ok(SessionCleanupSummary {
+            matched_sessions: i64::try_from(sessions.len()).unwrap_or(i64::MAX),
+            session_records_deleted: i64::try_from(session_records_deleted).unwrap_or(i64::MAX),
+            related_records_deleted,
+            jsonl_files_deleted,
+            jsonl_files_missing,
+        })
     }
 
     async fn list_session_channels(&self) -> Result<Vec<String>, StorageError> {
@@ -1423,4 +1492,68 @@ impl SessionStorage for SqlxSessionStore {
     fn session_jsonl_path(&self, session_key: &str) -> PathBuf {
         jsonl::session_jsonl_path(&self.paths, session_key)
     }
+}
+
+fn validate_cleanup_channels(channels: &[String]) -> Result<Vec<String>, StorageError> {
+    if channels.is_empty() {
+        return Err(StorageError::backend(
+            "at least one cleanup channel must be selected",
+        ));
+    }
+
+    let mut out = Vec::new();
+    for channel in channels {
+        match channel.as_str() {
+            "cron" | "webhook" => {
+                if !out.iter().any(|existing| existing == channel) {
+                    out.push(channel.clone());
+                }
+            }
+            _ => {
+                return Err(StorageError::backend(format!(
+                    "session cleanup only supports cron and webhook channels, got '{channel}'"
+                )));
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn cleanup_channel_filter(channel_count: usize) -> String {
+    let clauses = vec!["channel = ?"; channel_count].join(" OR ");
+    format!("({clauses})")
+}
+
+async fn execute_session_key_delete(
+    pool: &sqlx::SqlitePool,
+    sql: &str,
+    session_keys: &[String],
+) -> Result<u64, StorageError> {
+    let mut query = sqlx::query(sql);
+    for session_key in session_keys {
+        query = query.bind(session_key);
+    }
+    let rows = query
+        .execute(pool)
+        .await
+        .map_err(StorageError::backend)?
+        .rows_affected();
+    Ok(rows)
+}
+
+async fn remove_session_jsonl_files(
+    store: &SqlxSessionStore,
+    session_keys: &[String],
+) -> Result<(i64, i64), StorageError> {
+    let mut deleted = 0;
+    let mut missing = 0;
+    for session_key in session_keys {
+        let path = store.session_jsonl_path(session_key);
+        match fs::remove_file(path).await {
+            Ok(()) => deleted += 1,
+            Err(err) if err.kind() == ErrorKind::NotFound => missing += 1,
+            Err(err) => return Err(StorageError::backend(err)),
+        }
+    }
+    Ok((deleted, missing))
 }

--- a/klaw-storage/src/sqlx/session.rs
+++ b/klaw-storage/src/sqlx/session.rs
@@ -10,11 +10,11 @@ use crate::{
     LlmAuditQuery, LlmAuditRecord, LlmAuditSortOrder, LlmAuditSummaryRecord, LlmUsageRecord,
     LlmUsageSummary, NewApprovalRecord, NewLlmAuditRecord, NewLlmUsageRecord,
     NewPendingQuestionRecord, NewToolAuditRecord, NewWebhookAgentRecord, NewWebhookEventRecord,
-    PendingQuestionRecord, PendingQuestionStatus, SessionCleanupQuery, SessionCleanupSummary,
-    SessionCompressionState, SessionIndex, SessionSortOrder, SessionStorage, StorageError,
-    ToolAuditFilterOptions, ToolAuditFilterOptionsQuery, ToolAuditQuery, ToolAuditRecord,
-    UpdateWebhookAgentResult, UpdateWebhookEventResult, WebhookAgentQuery, WebhookAgentRecord,
-    WebhookEventQuery, WebhookEventRecord, WebhookEventSortOrder, jsonl,
+    PendingQuestionRecord, PendingQuestionStatus, SessionCleanupProgress, SessionCleanupQuery,
+    SessionCleanupSummary, SessionCompressionState, SessionIndex, SessionSortOrder, SessionStorage,
+    StorageError, ToolAuditFilterOptions, ToolAuditFilterOptionsQuery, ToolAuditQuery,
+    ToolAuditRecord, UpdateWebhookAgentResult, UpdateWebhookEventResult, WebhookAgentQuery,
+    WebhookAgentRecord, WebhookEventQuery, WebhookEventRecord, WebhookEventSortOrder, jsonl,
     util::{now_ms, relative_or_absolute_jsonl},
 };
 use async_trait::async_trait;
@@ -565,6 +565,14 @@ impl SessionStorage for SqlxSessionStore {
         &self,
         query: &SessionCleanupQuery,
     ) -> Result<SessionCleanupSummary, StorageError> {
+        self.clean_sessions_with_progress(query, &|_| {}).await
+    }
+
+    async fn clean_sessions_with_progress(
+        &self,
+        query: &SessionCleanupQuery,
+        progress: &(dyn Fn(SessionCleanupProgress) + Send + Sync),
+    ) -> Result<SessionCleanupSummary, StorageError> {
         let channels = validate_cleanup_channels(&query.channels)?;
         let channel_filter = cleanup_channel_filter(channels.len());
         let select_sql = format!(
@@ -582,6 +590,11 @@ impl SessionStorage for SqlxSessionStore {
             .await
             .map_err(StorageError::backend)?;
         let sessions: Vec<SessionIndex> = rows.into_iter().map(Into::into).collect();
+        let total_sessions = i64::try_from(sessions.len()).unwrap_or(i64::MAX);
+        progress(SessionCleanupProgress {
+            total_sessions,
+            deleted_sessions: 0,
+        });
         if sessions.is_empty() {
             return Ok(SessionCleanupSummary::default());
         }
@@ -609,10 +622,10 @@ impl SessionStorage for SqlxSessionStore {
         )
         .await?;
         let (jsonl_files_deleted, jsonl_files_missing) =
-            remove_session_jsonl_files(self, &session_keys).await?;
+            remove_session_jsonl_files(self, &session_keys, progress, total_sessions).await?;
 
         Ok(SessionCleanupSummary {
-            matched_sessions: i64::try_from(sessions.len()).unwrap_or(i64::MAX),
+            matched_sessions: total_sessions,
             session_records_deleted: i64::try_from(session_records_deleted).unwrap_or(i64::MAX),
             related_records_deleted,
             jsonl_files_deleted,
@@ -1544,16 +1557,22 @@ async fn execute_session_key_delete(
 async fn remove_session_jsonl_files(
     store: &SqlxSessionStore,
     session_keys: &[String],
+    progress: &(dyn Fn(SessionCleanupProgress) + Send + Sync),
+    total_sessions: i64,
 ) -> Result<(i64, i64), StorageError> {
     let mut deleted = 0;
     let mut missing = 0;
-    for session_key in session_keys {
+    for (index, session_key) in session_keys.iter().enumerate() {
         let path = store.session_jsonl_path(session_key);
         match fs::remove_file(path).await {
             Ok(()) => deleted += 1,
             Err(err) if err.kind() == ErrorKind::NotFound => missing += 1,
             Err(err) => return Err(StorageError::backend(err)),
         }
+        progress(SessionCleanupProgress {
+            total_sessions,
+            deleted_sessions: i64::try_from(index + 1).unwrap_or(i64::MAX),
+        });
     }
     Ok((deleted, missing))
 }

--- a/klaw-storage/src/traits.rs
+++ b/klaw-storage/src/traits.rs
@@ -5,11 +5,12 @@ use crate::{
     LlmUsageRecord, LlmUsageSummary, NewApprovalRecord, NewCronJob, NewCronTaskRun,
     NewHeartbeatJob, NewHeartbeatTaskRun, NewLlmAuditRecord, NewLlmUsageRecord,
     NewPendingQuestionRecord, NewToolAuditRecord, NewWebhookAgentRecord, NewWebhookEventRecord,
-    PendingQuestionRecord, PendingQuestionStatus, SessionCleanupQuery, SessionCleanupSummary,
-    SessionCompressionState, SessionIndex, SessionSortOrder, StorageError, ToolAuditFilterOptions,
-    ToolAuditFilterOptionsQuery, ToolAuditQuery, ToolAuditRecord, UpdateCronJobPatch,
-    UpdateHeartbeatJobPatch, UpdateWebhookAgentResult, UpdateWebhookEventResult, WebhookAgentQuery,
-    WebhookAgentRecord, WebhookEventQuery, WebhookEventRecord,
+    PendingQuestionRecord, PendingQuestionStatus, SessionCleanupProgress, SessionCleanupQuery,
+    SessionCleanupSummary, SessionCompressionState, SessionIndex, SessionSortOrder, StorageError,
+    ToolAuditFilterOptions, ToolAuditFilterOptionsQuery, ToolAuditQuery, ToolAuditRecord,
+    UpdateCronJobPatch, UpdateHeartbeatJobPatch, UpdateWebhookAgentResult,
+    UpdateWebhookEventResult, WebhookAgentQuery, WebhookAgentRecord, WebhookEventQuery,
+    WebhookEventRecord,
 };
 use async_trait::async_trait;
 use std::path::PathBuf;
@@ -151,6 +152,19 @@ pub trait SessionStorage: Send + Sync {
         &self,
         query: &SessionCleanupQuery,
     ) -> Result<SessionCleanupSummary, StorageError>;
+
+    async fn clean_sessions_with_progress(
+        &self,
+        query: &SessionCleanupQuery,
+        progress: &(dyn Fn(SessionCleanupProgress) + Send + Sync),
+    ) -> Result<SessionCleanupSummary, StorageError> {
+        let summary = self.clean_sessions(query).await?;
+        progress(SessionCleanupProgress {
+            total_sessions: summary.matched_sessions,
+            deleted_sessions: summary.session_records_deleted,
+        });
+        Ok(summary)
+    }
 
     async fn list_session_channels(&self) -> Result<Vec<String>, StorageError>;
 

--- a/klaw-storage/src/traits.rs
+++ b/klaw-storage/src/traits.rs
@@ -5,11 +5,11 @@ use crate::{
     LlmUsageRecord, LlmUsageSummary, NewApprovalRecord, NewCronJob, NewCronTaskRun,
     NewHeartbeatJob, NewHeartbeatTaskRun, NewLlmAuditRecord, NewLlmUsageRecord,
     NewPendingQuestionRecord, NewToolAuditRecord, NewWebhookAgentRecord, NewWebhookEventRecord,
-    PendingQuestionRecord, PendingQuestionStatus, SessionCompressionState, SessionIndex,
-    SessionSortOrder, StorageError, ToolAuditFilterOptions, ToolAuditFilterOptionsQuery,
-    ToolAuditQuery, ToolAuditRecord, UpdateCronJobPatch, UpdateHeartbeatJobPatch,
-    UpdateWebhookAgentResult, UpdateWebhookEventResult, WebhookAgentQuery, WebhookAgentRecord,
-    WebhookEventQuery, WebhookEventRecord,
+    PendingQuestionRecord, PendingQuestionStatus, SessionCleanupQuery, SessionCleanupSummary,
+    SessionCompressionState, SessionIndex, SessionSortOrder, StorageError, ToolAuditFilterOptions,
+    ToolAuditFilterOptionsQuery, ToolAuditQuery, ToolAuditRecord, UpdateCronJobPatch,
+    UpdateHeartbeatJobPatch, UpdateWebhookAgentResult, UpdateWebhookEventResult, WebhookAgentQuery,
+    WebhookAgentRecord, WebhookEventQuery, WebhookEventRecord,
 };
 use async_trait::async_trait;
 use std::path::PathBuf;
@@ -146,6 +146,11 @@ pub trait SessionStorage: Send + Sync {
         channel: Option<&str>,
         session_key_prefix: Option<&str>,
     ) -> Result<i64, StorageError>;
+
+    async fn clean_sessions(
+        &self,
+        query: &SessionCleanupQuery,
+    ) -> Result<SessionCleanupSummary, StorageError>;
 
     async fn list_session_channels(&self) -> Result<Vec<String>, StorageError>;
 

--- a/klaw-storage/src/turso/session.rs
+++ b/klaw-storage/src/turso/session.rs
@@ -14,17 +14,28 @@ use crate::{
     LlmAuditQuery, LlmAuditRecord, LlmAuditSortOrder, LlmAuditSummaryRecord, LlmUsageRecord,
     LlmUsageSummary, NewApprovalRecord, NewLlmAuditRecord, NewLlmUsageRecord,
     NewPendingQuestionRecord, NewToolAuditRecord, NewWebhookAgentRecord, NewWebhookEventRecord,
-    PendingQuestionRecord, PendingQuestionStatus, SessionCompressionState, SessionIndex,
-    SessionSortOrder, SessionStorage, StorageError, ToolAuditFilterOptions,
-    ToolAuditFilterOptionsQuery, ToolAuditQuery, ToolAuditRecord, UpdateWebhookAgentResult,
-    UpdateWebhookEventResult, WebhookAgentQuery, WebhookAgentRecord, WebhookEventQuery,
-    WebhookEventRecord, WebhookEventSortOrder, jsonl,
+    PendingQuestionRecord, PendingQuestionStatus, SessionCleanupQuery, SessionCleanupSummary,
+    SessionCompressionState, SessionIndex, SessionSortOrder, SessionStorage, StorageError,
+    ToolAuditFilterOptions, ToolAuditFilterOptionsQuery, ToolAuditQuery, ToolAuditRecord,
+    UpdateWebhookAgentResult, UpdateWebhookEventResult, WebhookAgentQuery, WebhookAgentRecord,
+    WebhookEventQuery, WebhookEventRecord, WebhookEventSortOrder, jsonl,
     util::{now_ms, relative_or_absolute_jsonl},
 };
 use async_trait::async_trait;
-use std::path::PathBuf;
+use std::{io::ErrorKind, path::PathBuf};
+use tokio::fs;
+use turso::Connection;
 
 const SESSION_INDEX_SELECT: &str = "session_key, chat_id, channel, title, active_session_key, model_provider, model_provider_explicit, model, model_explicit, delivery_metadata_json, is_active, created_at_ms, updated_at_ms, last_message_at_ms, turn_count, jsonl_path";
+const CLEANUP_RELATED_TABLES: &[&str] = &[
+    "llm_usage",
+    "llm_audit",
+    "tool_audit",
+    "webhook_events",
+    "webhook_agents",
+    "pending_questions",
+    "approvals",
+];
 
 #[async_trait]
 impl SessionStorage for TursoSessionStore {
@@ -571,6 +582,72 @@ impl SessionStorage for TursoSessionStore {
             .map_err(StorageError::backend)?
             .ok_or_else(|| StorageError::backend("empty count result"))?;
         value_to_i64(row.get_value(0).map_err(StorageError::backend)?)
+    }
+
+    async fn clean_sessions(
+        &self,
+        query: &SessionCleanupQuery,
+    ) -> Result<SessionCleanupSummary, StorageError> {
+        let channels = validate_cleanup_channels(&query.channels)?;
+        let channel_filter = cleanup_channel_filter(&channels);
+        let sql = format!(
+            "SELECT {SESSION_INDEX_SELECT}
+             FROM sessions
+             WHERE is_active = 1 AND updated_at_ms < {} AND {channel_filter}",
+            query.updated_before_ms
+        );
+        let mut sessions = Vec::new();
+        {
+            let conn = self.connection().await?;
+            let mut rows = conn.query(&sql, ()).await.map_err(StorageError::backend)?;
+            while let Some(row) = rows.next().await.map_err(StorageError::backend)? {
+                sessions.push(row_to_session_index(&row)?);
+            }
+        }
+        if sessions.is_empty() {
+            return Ok(SessionCleanupSummary::default());
+        }
+
+        let session_keys: Vec<String> = sessions
+            .iter()
+            .map(|session| session.session_key.clone())
+            .collect();
+        let session_key_filter = session_key_in_filter(&session_keys);
+        let mut related_records_deleted = 0;
+        {
+            let conn = self.connection().await?;
+            for table in CLEANUP_RELATED_TABLES {
+                related_records_deleted += count_rows(
+                    &conn,
+                    &format!(
+                        "SELECT COUNT(*) FROM {table} WHERE session_key IN ({session_key_filter})"
+                    ),
+                )
+                .await?;
+                conn.execute(
+                    &format!("DELETE FROM {table} WHERE session_key IN ({session_key_filter})"),
+                    (),
+                )
+                .await
+                .map_err(StorageError::backend)?;
+            }
+            conn.execute(
+                &format!("DELETE FROM sessions WHERE session_key IN ({session_key_filter})"),
+                (),
+            )
+            .await
+            .map_err(StorageError::backend)?;
+            let (jsonl_files_deleted, jsonl_files_missing) =
+                remove_session_jsonl_files(self, &session_keys).await?;
+
+            Ok(SessionCleanupSummary {
+                matched_sessions: i64::try_from(sessions.len()).unwrap_or(i64::MAX),
+                session_records_deleted: i64::try_from(sessions.len()).unwrap_or(i64::MAX),
+                related_records_deleted,
+                jsonl_files_deleted,
+                jsonl_files_missing,
+            })
+        }
     }
 
     async fn list_session_channels(&self) -> Result<Vec<String>, StorageError> {
@@ -1722,4 +1799,73 @@ impl SessionStorage for TursoSessionStore {
     fn session_jsonl_path(&self, session_key: &str) -> PathBuf {
         jsonl::session_jsonl_path(&self.paths, session_key)
     }
+}
+
+fn validate_cleanup_channels(channels: &[String]) -> Result<Vec<String>, StorageError> {
+    if channels.is_empty() {
+        return Err(StorageError::backend(
+            "at least one cleanup channel must be selected",
+        ));
+    }
+
+    let mut out = Vec::new();
+    for channel in channels {
+        match channel.as_str() {
+            "cron" | "webhook" => {
+                if !out.iter().any(|existing| existing == channel) {
+                    out.push(channel.clone());
+                }
+            }
+            _ => {
+                return Err(StorageError::backend(format!(
+                    "session cleanup only supports cron and webhook channels, got '{channel}'"
+                )));
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn cleanup_channel_filter(channels: &[String]) -> String {
+    let clauses = channels
+        .iter()
+        .map(|channel| format!("channel = '{}'", escape_sql_text(channel)))
+        .collect::<Vec<_>>()
+        .join(" OR ");
+    format!("({clauses})")
+}
+
+fn session_key_in_filter(session_keys: &[String]) -> String {
+    session_keys
+        .iter()
+        .map(|session_key| format!("'{}'", escape_sql_text(session_key)))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+async fn count_rows(conn: &Connection, sql: &str) -> Result<i64, StorageError> {
+    let mut rows = conn.query(sql, ()).await.map_err(StorageError::backend)?;
+    let row = rows
+        .next()
+        .await
+        .map_err(StorageError::backend)?
+        .ok_or_else(|| StorageError::backend("empty count result"))?;
+    value_to_i64(row.get_value(0).map_err(StorageError::backend)?)
+}
+
+async fn remove_session_jsonl_files(
+    store: &TursoSessionStore,
+    session_keys: &[String],
+) -> Result<(i64, i64), StorageError> {
+    let mut deleted = 0;
+    let mut missing = 0;
+    for session_key in session_keys {
+        let path = store.session_jsonl_path(session_key);
+        match fs::remove_file(path).await {
+            Ok(()) => deleted += 1,
+            Err(err) if err.kind() == ErrorKind::NotFound => missing += 1,
+            Err(err) => return Err(StorageError::backend(err)),
+        }
+    }
+    Ok((deleted, missing))
 }

--- a/klaw-storage/src/turso/session.rs
+++ b/klaw-storage/src/turso/session.rs
@@ -14,11 +14,11 @@ use crate::{
     LlmAuditQuery, LlmAuditRecord, LlmAuditSortOrder, LlmAuditSummaryRecord, LlmUsageRecord,
     LlmUsageSummary, NewApprovalRecord, NewLlmAuditRecord, NewLlmUsageRecord,
     NewPendingQuestionRecord, NewToolAuditRecord, NewWebhookAgentRecord, NewWebhookEventRecord,
-    PendingQuestionRecord, PendingQuestionStatus, SessionCleanupQuery, SessionCleanupSummary,
-    SessionCompressionState, SessionIndex, SessionSortOrder, SessionStorage, StorageError,
-    ToolAuditFilterOptions, ToolAuditFilterOptionsQuery, ToolAuditQuery, ToolAuditRecord,
-    UpdateWebhookAgentResult, UpdateWebhookEventResult, WebhookAgentQuery, WebhookAgentRecord,
-    WebhookEventQuery, WebhookEventRecord, WebhookEventSortOrder, jsonl,
+    PendingQuestionRecord, PendingQuestionStatus, SessionCleanupProgress, SessionCleanupQuery,
+    SessionCleanupSummary, SessionCompressionState, SessionIndex, SessionSortOrder, SessionStorage,
+    StorageError, ToolAuditFilterOptions, ToolAuditFilterOptionsQuery, ToolAuditQuery,
+    ToolAuditRecord, UpdateWebhookAgentResult, UpdateWebhookEventResult, WebhookAgentQuery,
+    WebhookAgentRecord, WebhookEventQuery, WebhookEventRecord, WebhookEventSortOrder, jsonl,
     util::{now_ms, relative_or_absolute_jsonl},
 };
 use async_trait::async_trait;
@@ -588,6 +588,14 @@ impl SessionStorage for TursoSessionStore {
         &self,
         query: &SessionCleanupQuery,
     ) -> Result<SessionCleanupSummary, StorageError> {
+        self.clean_sessions_with_progress(query, &|_| {}).await
+    }
+
+    async fn clean_sessions_with_progress(
+        &self,
+        query: &SessionCleanupQuery,
+        progress: &(dyn Fn(SessionCleanupProgress) + Send + Sync),
+    ) -> Result<SessionCleanupSummary, StorageError> {
         let channels = validate_cleanup_channels(&query.channels)?;
         let channel_filter = cleanup_channel_filter(&channels);
         let sql = format!(
@@ -604,6 +612,11 @@ impl SessionStorage for TursoSessionStore {
                 sessions.push(row_to_session_index(&row)?);
             }
         }
+        let total_sessions = i64::try_from(sessions.len()).unwrap_or(i64::MAX);
+        progress(SessionCleanupProgress {
+            total_sessions,
+            deleted_sessions: 0,
+        });
         if sessions.is_empty() {
             return Ok(SessionCleanupSummary::default());
         }
@@ -638,11 +651,11 @@ impl SessionStorage for TursoSessionStore {
             .await
             .map_err(StorageError::backend)?;
             let (jsonl_files_deleted, jsonl_files_missing) =
-                remove_session_jsonl_files(self, &session_keys).await?;
+                remove_session_jsonl_files(self, &session_keys, progress, total_sessions).await?;
 
             Ok(SessionCleanupSummary {
-                matched_sessions: i64::try_from(sessions.len()).unwrap_or(i64::MAX),
-                session_records_deleted: i64::try_from(sessions.len()).unwrap_or(i64::MAX),
+                matched_sessions: total_sessions,
+                session_records_deleted: total_sessions,
                 related_records_deleted,
                 jsonl_files_deleted,
                 jsonl_files_missing,
@@ -1856,16 +1869,22 @@ async fn count_rows(conn: &Connection, sql: &str) -> Result<i64, StorageError> {
 async fn remove_session_jsonl_files(
     store: &TursoSessionStore,
     session_keys: &[String],
+    progress: &(dyn Fn(SessionCleanupProgress) + Send + Sync),
+    total_sessions: i64,
 ) -> Result<(i64, i64), StorageError> {
     let mut deleted = 0;
     let mut missing = 0;
-    for session_key in session_keys {
+    for (index, session_key) in session_keys.iter().enumerate() {
         let path = store.session_jsonl_path(session_key);
         match fs::remove_file(path).await {
             Ok(()) => deleted += 1,
             Err(err) if err.kind() == ErrorKind::NotFound => missing += 1,
             Err(err) => return Err(StorageError::backend(err)),
         }
+        progress(SessionCleanupProgress {
+            total_sessions,
+            deleted_sessions: i64::try_from(index + 1).unwrap_or(i64::MAX),
+        });
     }
     Ok((deleted, missing))
 }

--- a/klaw-storage/src/types.rs
+++ b/klaw-storage/src/types.rs
@@ -85,6 +85,21 @@ impl SessionSortOrder {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SessionCleanupQuery {
+    pub updated_before_ms: i64,
+    pub channels: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SessionCleanupSummary {
+    pub matched_sessions: i64,
+    pub session_records_deleted: i64,
+    pub related_records_deleted: i64,
+    pub jsonl_files_deleted: i64,
+    pub jsonl_files_missing: i64,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 pub struct SessionCompressionState {
     pub last_compressed_len: i64,

--- a/klaw-storage/src/types.rs
+++ b/klaw-storage/src/types.rs
@@ -100,6 +100,12 @@ pub struct SessionCleanupSummary {
     pub jsonl_files_missing: i64,
 }
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SessionCleanupProgress {
+    pub total_sessions: i64,
+    pub deleted_sessions: i64,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 pub struct SessionCompressionState {
     pub last_compressed_len: i64,

--- a/klaw-tui/src/app.rs
+++ b/klaw-tui/src/app.rs
@@ -261,11 +261,17 @@ mod tests {
         ChannelStreamWriter,
     };
     use ratatui::{Terminal, backend::TestBackend};
-    use std::{cell::RefCell, collections::BTreeMap, rc::Rc, time::Duration};
+    use std::{
+        cell::RefCell,
+        collections::BTreeMap,
+        rc::Rc,
+        sync::atomic::{AtomicBool, Ordering},
+        time::Duration,
+    };
 
     #[derive(Default)]
     struct FakeRuntime {
-        streaming_called: std::cell::Cell<bool>,
+        streaming_called: AtomicBool,
     }
 
     #[async_trait::async_trait(?Send)]
@@ -279,7 +285,7 @@ mod tests {
             _request: ChannelRequest,
             writer: &mut dyn ChannelStreamWriter,
         ) -> ChannelResult<Option<ChannelResponse>> {
-            self.streaming_called.set(true);
+            self.streaming_called.store(true, Ordering::Relaxed);
             let response = ChannelResponse {
                 content: "done".to_string(),
                 reasoning: Some("step1".to_string()),
@@ -333,7 +339,7 @@ mod tests {
                 .expect("submit should succeed");
 
         assert!(!should_quit);
-        assert!(runtime.streaming_called.get());
+        assert!(runtime.streaming_called.load(Ordering::Relaxed));
         assert_eq!(state.borrow().messages().len(), 2);
         assert!(state.borrow().messages()[1].content.contains("done"));
     }


### PR DESCRIPTION
## Purpose

为 Session 面板增加按 `Updated At` 清理过期 cron/webhook 会话的能力，包括后端物理清理 API 和 GUI 确认弹窗。

Closes #240

## Impacted crates

- `klaw-storage` — 新增 `SessionCleanupQuery` / `SessionCleanupSummary` 类型，`SessionStorage::clean_sessions` trait 方法，SQLite 和 Turso 物理清理实现
- `klaw-session` — `SessionManager::clean_sessions` trait 转发，manager 级回归测试
- `klaw-gui` — Session 面板 `Clean` 按钮、清理弹窗、日期选择器、cron/webhook 多选、toast 反馈

## Changes summary

### klaw-storage
- 定义 `SessionCleanupQuery`（`updated_before_ms` + `channels`）和 `SessionCleanupSummary`（`matched_sessions` / `session_records_deleted` / `related_records_deleted` / `jsonl_files_deleted` / `jsonl_files_missing`）
- `SessionStorage` trait 增加 `clean_sessions` 方法
- SQLite 实现：查询匹配 active sessions → 显式删除 7 个关联表记录 → 删除 sessions 行 → 删除 JSONL 文件（缺失文件计入 `jsonl_files_missing`）
- Turso 实现：同上逻辑，使用 turso 连接 API
- 校验只允许 `cron` 和 `webhook` channel，不支持 channel 返回错误
- 测试：清理只删除旧 cron/webhook、保留 terminal/新 session；拒绝 unsupported channel；关联记录和 JSONL 文件正确删除

### klaw-session
- `SessionManager` trait 增加 `clean_sessions` 转发
- manager 级测试：验证清理后 session 和 chat records 不可查询

### klaw-gui
- `SessionPanel` 增加 `cleanup_open`、`cleanup_updated_before`、`cleanup_cron`、`cleanup_webhook` 状态
- `Refresh` 旁新增 `Clean` 按钮，点击打开清理弹窗
- 弹窗包含日期选择器（`DatePickerButton`）和 cron/webhook checkbox，未选日期或类型时禁用确认
- 清理执行后 toast 反馈成功（显示删除统计）或失败，并刷新列表
- 状态校验纯函数测试

## Test evidence

- `cargo test -p klaw-storage` — 新增 2 个清理测试通过
- `cargo test -p klaw-session` — 新增 1 个 manager 清理测试通过
- GUI 状态校验通过 `#[cfg(test)]` 单元测试