### PR TITLE
feat: add archive-backed resource preview for WebSocket channel attachments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4967,6 +4967,7 @@ dependencies = [
  "egui_commonmark",
  "egui_extras",
  "ehttp 0.5.0",
+ "image",
  "js-sys",
  "klaw-ui-kit",
  "serde",

--- a/klaw-runtime/CHANGELOG.md
+++ b/klaw-runtime/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 2026-05-14
+
+### Added
+
+- Gateway WebSocket responses now enrich returned `channel_attachment` outputs with archive-backed `archive.resources` metadata, auto-archiving local path attachments when permitted so web clients can preview generated files through Gateway archive APIs.
+
 ## 2026-05-08
 
 ### Fixed

--- a/klaw-runtime/src/gateway_websocket.rs
+++ b/klaw-runtime/src/gateway_websocket.rs
@@ -2,8 +2,13 @@ use crate::{
     RuntimeBundle, submit_channel_request, submit_channel_request_streaming_with_callback,
 };
 use async_trait::async_trait;
-use klaw_channel::{ChannelResponse, websocket::WebsocketSubmitEnvelope};
-use klaw_config::{AppConfig, WebsocketConfig};
+use klaw_archive::{ArchiveIngestInput, ArchiveRecord, ArchiveSourceKind};
+use klaw_channel::{
+    ChannelResponse, LocalAttachmentPolicy, OutboundAttachment, OutboundAttachmentKind,
+    OutboundAttachmentSource, outbound::resolve_outbound_attachment,
+    websocket::WebsocketSubmitEnvelope,
+};
+use klaw_config::{AppConfig, LocalAttachmentConfig, WebsocketConfig};
 use klaw_core::{MediaReference, MediaSourceKind};
 use klaw_gateway::{
     GatewayProtocolMethod, GatewayProviderCatalog, GatewayProviderEntry, GatewayRpcMessage,
@@ -17,9 +22,13 @@ use klaw_gateway::{
 use klaw_heartbeat::{HeartbeatManager, should_exclude_chat_record_from_context};
 use klaw_session::{SessionHistoryPage, SessionListQuery, SessionManager};
 use klaw_storage::{ChatRecord, StorageError};
+use klaw_util::{default_data_dir, workspace_dir};
+use serde::Serialize;
 use serde_json::{Value, json};
-use std::{collections::BTreeMap, sync::Arc};
+use std::{collections::BTreeMap, path::PathBuf, sync::Arc};
 use uuid::Uuid;
+
+const META_ARCHIVE_RESOURCES_KEY: &str = "archive.resources";
 
 pub fn build_gateway_websocket_handler(
     runtime: Arc<RuntimeBundle>,
@@ -31,6 +40,7 @@ pub fn build_gateway_websocket_handler(
 struct RuntimeWebsocketHandler {
     runtime: Arc<RuntimeBundle>,
     configs: BTreeMap<String, WebsocketConfig>,
+    local_attachments: LocalAttachmentConfig,
 }
 
 impl RuntimeWebsocketHandler {
@@ -42,7 +52,11 @@ impl RuntimeWebsocketHandler {
             .cloned()
             .map(|entry| (entry.id.clone(), entry))
             .collect();
-        Self { runtime, configs }
+        Self {
+            runtime,
+            configs,
+            local_attachments: config.tools.channel_attachment.local_attachments.clone(),
+        }
     }
 
     fn resolve_config(
@@ -75,6 +89,127 @@ impl RuntimeWebsocketHandler {
                 .await
                 .map_err(|err| GatewayWebsocketHandlerError::internal(err.to_string()))?;
         Ok(build_web_workspace_bootstrap(sessions))
+    }
+
+    fn local_attachment_policy(
+        &self,
+    ) -> Result<LocalAttachmentPolicy, GatewayWebsocketHandlerError> {
+        let root = default_data_dir()
+            .ok_or_else(|| GatewayWebsocketHandlerError::internal("failed to resolve home dir"))?;
+        let workspace = workspace_dir(&root);
+        std::fs::create_dir_all(&workspace)
+            .map_err(|err| GatewayWebsocketHandlerError::internal(err.to_string()))?;
+        let workspace_root = std::fs::canonicalize(&workspace)
+            .map_err(|err| GatewayWebsocketHandlerError::internal(err.to_string()))?;
+        let allowlist = self
+            .local_attachments
+            .allowlist
+            .iter()
+            .map(|path| PathBuf::from(path.trim()))
+            .collect();
+        Ok(LocalAttachmentPolicy {
+            workspace_root,
+            allowlist,
+            max_bytes: self.local_attachments.max_bytes,
+        })
+    }
+
+    async fn enrich_web_archive_resources(
+        &self,
+        response: &mut ChannelResponse,
+        context: &GatewayV1StreamContext,
+    ) -> Result<(), GatewayWebsocketHandlerError> {
+        if response.attachments.is_empty() {
+            return Ok(());
+        }
+        let Some(archive_service) = self.runtime.archive_service.as_ref() else {
+            return Ok(());
+        };
+        let local_policy = self.local_attachment_policy()?;
+        let mut resources = Vec::new();
+        for attachment in &response.attachments {
+            let resource = match &attachment.source {
+                OutboundAttachmentSource::ArchiveId { archive_id } => {
+                    let record = archive_service.get(archive_id).await.map_err(|err| {
+                        GatewayWebsocketHandlerError::internal(format!(
+                            "failed to load archive attachment `{archive_id}`: {err}"
+                        ))
+                    })?;
+                    resource_from_archive_record(attachment, record)
+                }
+                OutboundAttachmentSource::LocalPath { .. } => {
+                    let resolved = resolve_outbound_attachment(
+                        archive_service.as_ref(),
+                        &local_policy,
+                        attachment,
+                    )
+                    .await
+                    .map_err(|err| {
+                        GatewayWebsocketHandlerError::internal(format!(
+                            "failed to resolve local websocket attachment: {err}"
+                        ))
+                    })?;
+                    let record = archive_service
+                        .ingest_bytes(
+                            ArchiveIngestInput {
+                                source_kind: ArchiveSourceKind::ModelGenerated,
+                                filename: Some(resolved.filename),
+                                declared_mime_type: resolved.mime_type,
+                                session_key: Some(context.session_id.clone()),
+                                channel: Some("websocket".to_string()),
+                                chat_id: Some(context.thread_id.clone()),
+                                message_id: None,
+                                metadata: json!({
+                                    "source": "channel_attachment",
+                                    "source_label": resolved.source_label,
+                                    "caption": resolved.caption,
+                                }),
+                            },
+                            &resolved.bytes,
+                        )
+                        .await
+                        .map_err(|err| {
+                            GatewayWebsocketHandlerError::internal(format!(
+                                "failed to archive websocket attachment: {err}"
+                            ))
+                        })?;
+                    resource_from_archive_record(attachment, record)
+                }
+            };
+            resources.push(resource);
+        }
+        response
+            .metadata
+            .insert(META_ARCHIVE_RESOURCES_KEY.to_string(), json!(resources));
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct WebArchiveResource {
+    archive_id: String,
+    filename: Option<String>,
+    mime_type: Option<String>,
+    size_bytes: i64,
+    kind: String,
+    caption: Option<String>,
+}
+
+fn resource_from_archive_record(
+    attachment: &OutboundAttachment,
+    record: ArchiveRecord,
+) -> WebArchiveResource {
+    WebArchiveResource {
+        archive_id: record.id,
+        filename: attachment.filename.clone().or(record.original_filename),
+        mime_type: record.mime_type,
+        size_bytes: record.size_bytes,
+        kind: match attachment.kind {
+            OutboundAttachmentKind::Image => "image",
+            OutboundAttachmentKind::File => "file",
+        }
+        .to_string(),
+        caption: attachment.caption.clone(),
     }
 }
 
@@ -340,7 +475,7 @@ impl GatewayWebsocketHandler for RuntimeWebsocketHandler {
 
         if stream_output {
             let mut stream_state = GatewayStreamState::new(v1_context.clone());
-            let response = submit_channel_request_streaming_with_callback(
+            let mut response = submit_channel_request_streaming_with_callback(
                 self.runtime.as_ref(),
                 channel_request,
                 |event| {
@@ -355,6 +490,10 @@ impl GatewayWebsocketHandler for RuntimeWebsocketHandler {
             )
             .await
             .map_err(|err| GatewayWebsocketHandlerError::internal(err.to_string()))?;
+            if let Some(response) = response.as_mut() {
+                self.enrich_web_archive_resources(response, &v1_context)
+                    .await?;
+            }
             send_v1_item_completed(
                 &frame_tx,
                 &v1_context,
@@ -373,9 +512,13 @@ impl GatewayWebsocketHandler for RuntimeWebsocketHandler {
             return Ok(());
         }
 
-        let response = submit_channel_request(self.runtime.as_ref(), channel_request)
+        let mut response = submit_channel_request(self.runtime.as_ref(), channel_request)
             .await
             .map_err(|err| GatewayWebsocketHandlerError::internal(err.to_string()))?;
+        if let Some(response) = response.as_mut() {
+            self.enrich_web_archive_resources(response, &v1_context)
+                .await?;
+        }
         send_v1_item_completed(
             &frame_tx,
             &v1_context,

--- a/klaw-webui/CHANGELOG.md
+++ b/klaw-webui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 2026-05-14
+
+### Added
+
+- WebUI chat now renders archive-backed resource cards for returned channel attachments and opens image or file previews in an in-app dialog through Gateway archive downloads.
+
 ## 2026-05-09
 
 ### Added

--- a/klaw-webui/Cargo.toml
+++ b/klaw-webui/Cargo.toml
@@ -26,6 +26,7 @@ egui_commonmark = { workspace = true }
 egui-phosphor = { workspace = true }
 egui-notify = { workspace = true }
 egui-twemoji = { workspace = true }
+image = { workspace = true, features = ["png", "jpeg", "gif", "webp"] }
 js-sys = { workspace = true }
 urlencoding = { workspace = true }
 serde-wasm-bindgen = { workspace = true }
@@ -43,6 +44,7 @@ web-sys = { workspace = true, features = [
     "File",
     "FormData",
     "Headers",
+    "HtmlAnchorElement",
     "HtmlElement",
     "HtmlInputElement",
     "Location",

--- a/klaw-webui/src/lib.rs
+++ b/klaw-webui/src/lib.rs
@@ -733,6 +733,72 @@ pub(crate) struct WebArchiveResource {
 }
 
 #[cfg(any(test, target_arch = "wasm32"))]
+pub(crate) fn archive_resource_card_action(resource: &WebArchiveResource) -> &'static str {
+    if archive_resource_is_previewable(resource) {
+        "Preview"
+    } else {
+        "Download"
+    }
+}
+
+#[cfg(any(test, target_arch = "wasm32"))]
+pub(crate) fn archive_resource_is_previewable(resource: &WebArchiveResource) -> bool {
+    archive_resource_is_image(resource) || archive_resource_is_text(resource)
+}
+
+#[cfg(any(test, target_arch = "wasm32"))]
+pub(crate) fn archive_resource_is_image(resource: &WebArchiveResource) -> bool {
+    resource
+        .mime_type
+        .as_deref()
+        .is_some_and(content_type_is_image)
+        || resource
+            .kind
+            .as_deref()
+            .is_some_and(|kind| kind.eq_ignore_ascii_case("image"))
+}
+
+#[cfg(any(test, target_arch = "wasm32"))]
+pub(crate) fn archive_resource_is_text(resource: &WebArchiveResource) -> bool {
+    resource
+        .mime_type
+        .as_deref()
+        .is_some_and(content_type_is_text)
+}
+
+#[cfg(any(test, target_arch = "wasm32"))]
+pub(crate) fn content_type_is_image(content_type: &str) -> bool {
+    normalized_content_type(content_type).starts_with("image/")
+}
+
+#[cfg(any(test, target_arch = "wasm32"))]
+pub(crate) fn content_type_is_text(content_type: &str) -> bool {
+    let normalized = normalized_content_type(content_type);
+    normalized.starts_with("text/")
+        || matches!(
+            normalized.as_str(),
+            "application/json"
+                | "application/javascript"
+                | "application/ecmascript"
+                | "application/xml"
+                | "application/yaml"
+                | "application/x-yaml"
+                | "application/toml"
+                | "application/x-toml"
+        )
+}
+
+#[cfg(any(test, target_arch = "wasm32"))]
+fn normalized_content_type(content_type: &str) -> String {
+    content_type
+        .split(';')
+        .next()
+        .unwrap_or(content_type)
+        .trim()
+        .to_ascii_lowercase()
+}
+
+#[cfg(any(test, target_arch = "wasm32"))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum PageMode {
     ConnectionGuide,
@@ -976,14 +1042,15 @@ mod tests {
         ArchiveRecord, ArchiveUploadResponse, ConnectionState, ImCardKind, MessageRole, PageMode,
         ProviderCatalog, ProviderCatalogEntry, ResolvedSessionRoute, SessionListEntry,
         StreamMessageAction, WebArchiveAttachment, WebArchiveResource, apply_slash_completion,
-        attachment_action_in_progress, build_websocket_turn_start_params, can_trigger_file_picker,
-        classify_message_role, classify_stream_message_action, connection_action_label,
-        delete_confirmation_body, derive_page_mode, detect_active_slash_command,
-        has_exact_slash_command_match, next_pending_attachments_after_submit,
-        normalize_gateway_token_input, resolve_assistant_bubble_palette, resolve_gateway_token,
-        resolve_im_card, resolve_im_card_palette, resolve_session_route_inputs,
-        session_card_activity_label, should_activate_session_window,
-        should_cancel_file_picker_selection, should_clear_active_stream_assistant_message,
+        archive_resource_card_action, attachment_action_in_progress,
+        build_websocket_turn_start_params, can_trigger_file_picker, classify_message_role,
+        classify_stream_message_action, connection_action_label, delete_confirmation_body,
+        derive_page_mode, detect_active_slash_command, has_exact_slash_command_match,
+        next_pending_attachments_after_submit, normalize_gateway_token_input,
+        resolve_assistant_bubble_palette, resolve_gateway_token, resolve_im_card,
+        resolve_im_card_palette, resolve_session_route_inputs, session_card_activity_label,
+        should_activate_session_window, should_cancel_file_picker_selection,
+        should_clear_active_stream_assistant_message,
         should_prompt_for_gateway_token_before_connect, should_register_non_stream_fade,
         should_show_thinking_placeholder, slash_command_matches,
         sort_session_entries_by_created_at_desc,
@@ -1012,6 +1079,52 @@ mod tests {
         assert_eq!(resource.size_bytes, 42);
         assert_eq!(resource.kind.as_deref(), Some("image"));
         assert_eq!(resource.caption.as_deref(), Some("latest chart"));
+    }
+
+    #[test]
+    fn archive_resource_card_action_previews_images_and_text() {
+        let image = WebArchiveResource {
+            archive_id: "arch-image".to_string(),
+            filename: Some("chart.png".to_string()),
+            mime_type: Some("image/png".to_string()),
+            size_bytes: 42,
+            kind: None,
+            caption: None,
+        };
+        let json = WebArchiveResource {
+            archive_id: "arch-json".to_string(),
+            filename: Some("payload.json".to_string()),
+            mime_type: Some("application/json".to_string()),
+            size_bytes: 42,
+            kind: None,
+            caption: None,
+        };
+        let text = WebArchiveResource {
+            archive_id: "arch-text".to_string(),
+            filename: Some("notes.txt".to_string()),
+            mime_type: Some("text/plain; charset=utf-8".to_string()),
+            size_bytes: 42,
+            kind: None,
+            caption: None,
+        };
+
+        assert_eq!(archive_resource_card_action(&image), "Preview");
+        assert_eq!(archive_resource_card_action(&json), "Preview");
+        assert_eq!(archive_resource_card_action(&text), "Preview");
+    }
+
+    #[test]
+    fn archive_resource_card_action_downloads_non_previewable_files() {
+        let pdf = WebArchiveResource {
+            archive_id: "arch-pdf".to_string(),
+            filename: Some("report.pdf".to_string()),
+            mime_type: Some("application/pdf".to_string()),
+            size_bytes: 42,
+            kind: None,
+            caption: None,
+        };
+
+        assert_eq!(archive_resource_card_action(&pdf), "Download");
     }
 
     #[test]

--- a/klaw-webui/src/lib.rs
+++ b/klaw-webui/src/lib.rs
@@ -717,6 +717,22 @@ pub(crate) struct WebArchiveAttachment {
 }
 
 #[cfg(any(test, target_arch = "wasm32"))]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct WebArchiveResource {
+    pub(crate) archive_id: String,
+    #[serde(default)]
+    pub(crate) filename: Option<String>,
+    #[serde(default)]
+    pub(crate) mime_type: Option<String>,
+    #[serde(default)]
+    pub(crate) size_bytes: i64,
+    #[serde(default)]
+    pub(crate) kind: Option<String>,
+    #[serde(default)]
+    pub(crate) caption: Option<String>,
+}
+
+#[cfg(any(test, target_arch = "wasm32"))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum PageMode {
     ConnectionGuide,
@@ -959,7 +975,7 @@ mod tests {
     use super::{
         ArchiveRecord, ArchiveUploadResponse, ConnectionState, ImCardKind, MessageRole, PageMode,
         ProviderCatalog, ProviderCatalogEntry, ResolvedSessionRoute, SessionListEntry,
-        StreamMessageAction, WebArchiveAttachment, apply_slash_completion,
+        StreamMessageAction, WebArchiveAttachment, WebArchiveResource, apply_slash_completion,
         attachment_action_in_progress, build_websocket_turn_start_params, can_trigger_file_picker,
         classify_message_role, classify_stream_message_action, connection_action_label,
         delete_confirmation_body, derive_page_mode, detect_active_slash_command,
@@ -976,6 +992,26 @@ mod tests {
     #[test]
     fn connected_state_uses_friendly_status_copy() {
         assert_eq!(ConnectionState::Connected.status_text(), "Ready");
+    }
+
+    #[test]
+    fn archive_resource_payload_deserializes_optional_preview_fields() {
+        let resource: WebArchiveResource = serde_json::from_value(json!({
+            "archive_id": "arch-1",
+            "filename": "chart.png",
+            "mime_type": "image/png",
+            "size_bytes": 42,
+            "kind": "image",
+            "caption": "latest chart"
+        }))
+        .expect("archive resource should deserialize");
+
+        assert_eq!(resource.archive_id, "arch-1");
+        assert_eq!(resource.filename.as_deref(), Some("chart.png"));
+        assert_eq!(resource.mime_type.as_deref(), Some("image/png"));
+        assert_eq!(resource.size_bytes, 42);
+        assert_eq!(resource.kind.as_deref(), Some("image"));
+        assert_eq!(resource.caption.as_deref(), Some("latest chart"));
     }
 
     #[test]

--- a/klaw-webui/src/web_chat/app.rs
+++ b/klaw-webui/src/web_chat/app.rs
@@ -59,8 +59,9 @@ pub(super) struct ArchivePreviewDialog {
 pub(super) enum ArchivePreviewStatus {
     Loading,
     Ready {
-        object_url: String,
         content_type: Option<String>,
+        bytes: Vec<u8>,
+        image_size: Option<[usize; 2]>,
     },
     Failed(String),
 }
@@ -648,10 +649,14 @@ impl ChatApp {
             )
             .await
             {
-                Ok(blob) => ArchivePreviewStatus::Ready {
-                    object_url: blob.object_url,
-                    content_type: blob.content_type,
-                },
+                Ok(blob) => {
+                    let image_size = archive_preview_image_size(&blob.content_type, &blob.bytes);
+                    ArchivePreviewStatus::Ready {
+                        content_type: blob.content_type,
+                        bytes: blob.bytes,
+                        image_size,
+                    }
+                }
                 Err(err) => {
                     toasts.borrow_mut().error(format!("Preview failed: {err}"));
                     ArchivePreviewStatus::Failed(err)
@@ -665,6 +670,47 @@ impl ChatApp {
             ctx.request_repaint();
         });
     }
+
+    pub(in crate::web_chat) fn download_archive_attachment(
+        &mut self,
+        resource: WebArchiveResource,
+    ) {
+        let Some(gateway_origin) = self.gateway_origin.clone() else {
+            self.toasts
+                .borrow_mut()
+                .error("Gateway origin not available");
+            return;
+        };
+
+        let gateway_token = self.gateway_token.clone();
+        let toasts = self.toasts.clone();
+        let ctx = self.ctx.clone();
+
+        wasm_bindgen_futures::spawn_local(async move {
+            if let Err(err) = super::upload::download_archive_resource(
+                &gateway_origin,
+                gateway_token.as_deref(),
+                &resource,
+            )
+            .await
+            {
+                toasts.borrow_mut().error(format!("Download failed: {err}"));
+            }
+            ctx.request_repaint();
+        });
+    }
+}
+
+fn archive_preview_image_size(content_type: &Option<String>, bytes: &[u8]) -> Option<[usize; 2]> {
+    if !content_type
+        .as_deref()
+        .is_some_and(crate::content_type_is_image)
+    {
+        return None;
+    }
+
+    let image = image::load_from_memory(bytes).ok()?;
+    Some([image.width() as usize, image.height() as usize])
 }
 
 fn web_archive_attachment_from_record(record: ArchiveRecord) -> WebArchiveAttachment {

--- a/klaw-webui/src/web_chat/app.rs
+++ b/klaw-webui/src/web_chat/app.rs
@@ -10,8 +10,8 @@ use web_sys::WebSocket;
 
 use crate::{
     ArchiveRecord, ConnectionState, ProviderCatalog, SessionListEntry, WebArchiveAttachment,
-    WorkspaceSessionEntry, attachment_action_in_progress, normalize_gateway_token_input,
-    resolve_gateway_token, should_cancel_file_picker_selection,
+    WebArchiveResource, WorkspaceSessionEntry, attachment_action_in_progress,
+    normalize_gateway_token_input, resolve_gateway_token, should_cancel_file_picker_selection,
     should_prompt_for_gateway_token_before_connect, sort_session_entries_by_created_at_desc,
 };
 
@@ -46,6 +46,23 @@ pub(super) struct ChatApp {
     pub(in crate::web_chat) light_theme: LightThemePreset,
     pub(in crate::web_chat) dark_theme: DarkThemePreset,
     pub(in crate::web_chat) ui_language: UiLanguage,
+    pub(in crate::web_chat) archive_preview: Rc<RefCell<Option<ArchivePreviewDialog>>>,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct ArchivePreviewDialog {
+    pub(super) resource: WebArchiveResource,
+    pub(super) status: ArchivePreviewStatus,
+}
+
+#[derive(Clone, Debug)]
+pub(super) enum ArchivePreviewStatus {
+    Loading,
+    Ready {
+        object_url: String,
+        content_type: Option<String>,
+    },
+    Failed(String),
 }
 
 impl ChatApp {
@@ -88,6 +105,7 @@ impl ChatApp {
             light_theme,
             dark_theme,
             ui_language,
+            archive_preview: Rc::new(RefCell::new(None)),
         };
         app.restore_window_state(persisted_sessions);
         app.apply_theme();
@@ -602,7 +620,7 @@ impl ChatApp {
         });
     }
 
-    pub(in crate::web_chat) fn preview_archive_attachment(&mut self, archive_id: &str) {
+    pub(in crate::web_chat) fn preview_archive_attachment(&mut self, resource: WebArchiveResource) {
         let Some(gateway_origin) = self.gateway_origin.clone() else {
             self.toasts
                 .borrow_mut()
@@ -611,19 +629,40 @@ impl ChatApp {
         };
 
         let gateway_token = self.gateway_token.clone();
-        let archive_id = archive_id.to_string();
+        let archive_id = resource.archive_id.clone();
         let toasts = self.toasts.clone();
+        let preview = self.archive_preview.clone();
+        let ctx = self.ctx.clone();
+
+        *preview.borrow_mut() = Some(ArchivePreviewDialog {
+            resource,
+            status: ArchivePreviewStatus::Loading,
+        });
+        self.ctx.request_repaint();
 
         wasm_bindgen_futures::spawn_local(async move {
-            if let Err(err) = super::upload::preview_archive_file(
+            let status = match super::upload::load_archive_preview(
                 &gateway_origin,
                 gateway_token.as_deref(),
                 &archive_id,
             )
             .await
             {
-                toasts.borrow_mut().error(format!("Preview failed: {err}"));
+                Ok(blob) => ArchivePreviewStatus::Ready {
+                    object_url: blob.object_url,
+                    content_type: blob.content_type,
+                },
+                Err(err) => {
+                    toasts.borrow_mut().error(format!("Preview failed: {err}"));
+                    ArchivePreviewStatus::Failed(err)
+                }
+            };
+            if let Some(dialog) = preview.borrow_mut().as_mut() {
+                if dialog.resource.archive_id == archive_id {
+                    dialog.status = status;
+                }
             }
+            ctx.request_repaint();
         });
     }
 }
@@ -634,6 +673,19 @@ fn web_archive_attachment_from_record(record: ArchiveRecord) -> WebArchiveAttach
         filename: record.original_filename,
         mime_type: record.mime_type,
         size_bytes: record.size_bytes,
+    }
+}
+
+pub(super) fn web_archive_resource_from_attachment(
+    attachment: WebArchiveAttachment,
+) -> WebArchiveResource {
+    WebArchiveResource {
+        archive_id: attachment.archive_id,
+        filename: attachment.filename,
+        mime_type: attachment.mime_type,
+        size_bytes: attachment.size_bytes,
+        kind: None,
+        caption: None,
     }
 }
 

--- a/klaw-webui/src/web_chat/ui.rs
+++ b/klaw-webui/src/web_chat/ui.rs
@@ -3,7 +3,7 @@ use eframe::egui::{
     ScrollArea, Stroke, TextEdit, TextStyle, TopBottomPanel, WidgetText, text_edit::TextEditState,
     vec2,
 };
-use egui_extras::{Column, TableBuilder};
+use egui_extras::{Column, Size, StripBuilder, TableBuilder};
 use egui_phosphor::regular;
 use klaw_ui_kit::toggle::toggle;
 use klaw_ui_kit::{
@@ -15,11 +15,12 @@ use std::collections::{BTreeMap, HashMap};
 use crate::{
     ActiveSlashCommand, ConnectionState, ImCard, ImCardAction, ImCardActionKind, ImCardKind,
     MessageRole, PageMode, SlashCommandCompletion, WebArchiveAttachment, WebArchiveResource,
-    apply_slash_completion, attachment_action_in_progress, can_trigger_file_picker,
-    delete_confirmation_body, derive_page_mode, detect_active_slash_command,
-    has_exact_slash_command_match, normalize_gateway_token_input, resolve_assistant_bubble_palette,
-    resolve_im_card_palette, should_activate_session_window, should_show_thinking_placeholder,
-    slash_command_matches,
+    apply_slash_completion, archive_resource_card_action, archive_resource_is_image,
+    archive_resource_is_previewable, attachment_action_in_progress, can_trigger_file_picker,
+    content_type_is_image, content_type_is_text, delete_confirmation_body, derive_page_mode,
+    detect_active_slash_command, has_exact_slash_command_match, normalize_gateway_token_input,
+    resolve_assistant_bubble_palette, resolve_im_card_palette, should_activate_session_window,
+    should_show_thinking_placeholder, slash_command_matches,
 };
 
 use super::{
@@ -446,55 +447,49 @@ impl ChatApp {
         };
         let mut open = true;
         let mut close_requested = false;
+        let mut download_requested: Option<WebArchiveResource> = None;
+        let default_size = archive_preview_default_size(&dialog);
         egui::Window::new("Resource Preview")
+            .id(egui::Id::new((
+                "archive-resource-preview",
+                dialog.resource.archive_id.as_str(),
+            )))
             .anchor(Align2::CENTER_CENTER, egui::Vec2::ZERO)
             .collapsible(false)
             .resizable(true)
-            .default_size(vec2(720.0, 560.0))
+            .default_size(default_size)
             .min_width(420.0)
+            .min_height(320.0)
             .open(&mut open)
             .show(ctx, |ui| {
                 render_archive_preview_header(ui, &dialog);
                 ui.separator();
-                match &dialog.status {
-                    ArchivePreviewStatus::Loading => {
-                        ui.vertical_centered(|ui| {
-                            ui.add_space(24.0);
-                            ui.spinner();
+                StripBuilder::new(ui)
+                    .size(Size::remainder().at_least(180.0))
+                    .size(Size::exact(52.0))
+                    .vertical(|mut strip| {
+                        strip.cell(|ui| render_archive_preview_content(ui, &dialog));
+                        strip.cell(|ui| {
+                            ui.separator();
                             ui.add_space(8.0);
-                            ui.label("Loading preview...");
-                        });
-                    }
-                    ArchivePreviewStatus::Ready {
-                        object_url,
-                        content_type,
-                    } => {
-                        if preview_status_is_image(&dialog, content_type.as_deref()) {
-                            ScrollArea::both().show(ui, |ui| {
-                                ui.add(
-                                    Image::from_uri(object_url.clone())
-                                        .max_width(ui.available_width())
-                                        .maintain_aspect_ratio(true),
-                                );
+                            ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                                if ui.button("Close").clicked() {
+                                    close_requested = true;
+                                }
+                                if matches!(&dialog.status, ArchivePreviewStatus::Ready { .. })
+                                    && ui
+                                        .button(format!("{} Download", regular::DOWNLOAD_SIMPLE))
+                                        .clicked()
+                                {
+                                    download_requested = Some(dialog.resource.clone());
+                                }
                             });
-                        } else {
-                            render_file_preview_body(ui, &dialog, object_url);
-                        }
-                    }
-                    ArchivePreviewStatus::Failed(message) => {
-                        ui.label(
-                            RichText::new(format!("Preview failed: {message}"))
-                                .color(ui.visuals().error_fg_color),
-                        );
-                    }
-                }
-                ui.separator();
-                ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
-                    if ui.button("Close").clicked() {
-                        close_requested = true;
-                    }
-                });
+                        });
+                    });
             });
+        if let Some(resource) = download_requested {
+            self.download_archive_attachment(resource);
+        }
         if close_requested || !open {
             *self.archive_preview.borrow_mut() = None;
         }
@@ -811,6 +806,7 @@ impl ChatApp {
         let mut trigger_history_load: Option<PendingHistoryScrollRestore> = None;
         let mut trigger_open_file_dialog = false;
         let mut trigger_preview_attachment: Option<WebArchiveResource> = None;
+        let mut trigger_download_attachment: Option<WebArchiveResource> = None;
         let mut remove_attachment_at: Option<usize> = None;
         let mut set_active = false;
         {
@@ -875,6 +871,7 @@ impl ChatApp {
                                     message_index,
                                     &session.card_state_overrides,
                                     &mut trigger_preview_attachment,
+                                    &mut trigger_download_attachment,
                                 ) {
                                     card_action = Some(action);
                                 }
@@ -1209,6 +1206,7 @@ impl ChatApp {
                     &mut show_file_dialog,
                     &attachments,
                     &mut trigger_preview_attachment,
+                    &mut trigger_download_attachment,
                     &mut remove_attachment_at,
                 );
                 self.sessions[index].show_file_dialog = show_file_dialog;
@@ -1241,6 +1239,9 @@ impl ChatApp {
         }
         if let Some(resource) = trigger_preview_attachment {
             self.preview_archive_attachment(resource);
+        }
+        if let Some(resource) = trigger_download_attachment {
+            self.download_archive_attachment(resource);
         }
         if trigger_send {
             self.send_session_draft(session_key);
@@ -1521,6 +1522,7 @@ fn render_message(
     message_index: usize,
     card_state_overrides: &HashMap<String, CardInteractionState>,
     trigger_preview_attachment: &mut Option<WebArchiveResource>,
+    trigger_download_attachment: &mut Option<WebArchiveResource>,
 ) -> Option<CardActionRequest> {
     let now_ms = current_timestamp_ms();
     let time_label = format_message_timestamp(message.timestamp_ms, now_ms);
@@ -1631,6 +1633,7 @@ fn render_message(
                                     body_color,
                                     link_color,
                                     trigger_preview_attachment,
+                                    trigger_download_attachment,
                                 );
                             }
                         });
@@ -2033,6 +2036,7 @@ fn render_message_body(
     body_color: Color32,
     link_color: Color32,
     trigger_preview_attachment: &mut Option<WebArchiveResource>,
+    trigger_download_attachment: &mut Option<WebArchiveResource>,
 ) {
     let attachments = message_resources(message);
     let has_text = !message.text.trim().is_empty();
@@ -2070,7 +2074,13 @@ fn render_message_body(
     if has_attachments {
         ui.vertical(|ui| {
             for attachment in attachments {
-                render_resource_card(ui, &attachment, body_color, trigger_preview_attachment);
+                render_resource_card(
+                    ui,
+                    &attachment,
+                    body_color,
+                    trigger_preview_attachment,
+                    trigger_download_attachment,
+                );
             }
         });
     }
@@ -2152,6 +2162,7 @@ fn render_resource_card(
     resource: &WebArchiveResource,
     body_color: Color32,
     trigger_preview_attachment: &mut Option<WebArchiveResource>,
+    trigger_download_attachment: &mut Option<WebArchiveResource>,
 ) {
     let icon = if resource_is_image(resource) {
         regular::IMAGE
@@ -2182,12 +2193,28 @@ fn render_resource_card(
                     }
                 });
                 ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
-                    if ui
-                        .button(format!("{} Preview", regular::EYE))
-                        .on_hover_text("Preview archive resource")
+                    if archive_resource_is_previewable(resource) {
+                        if ui
+                            .button(format!(
+                                "{} {}",
+                                regular::EYE,
+                                archive_resource_card_action(resource)
+                            ))
+                            .on_hover_text("Preview archive resource")
+                            .clicked()
+                        {
+                            *trigger_preview_attachment = Some(resource.clone());
+                        }
+                    } else if ui
+                        .button(format!(
+                            "{} {}",
+                            regular::DOWNLOAD_SIMPLE,
+                            archive_resource_card_action(resource)
+                        ))
+                        .on_hover_text("Download archive resource")
                         .clicked()
                     {
-                        *trigger_preview_attachment = Some(resource.clone());
+                        *trigger_download_attachment = Some(resource.clone());
                     }
                 });
             });
@@ -2209,19 +2236,52 @@ fn resource_meta_label(resource: &WebArchiveResource) -> String {
 }
 
 fn resource_is_image(resource: &WebArchiveResource) -> bool {
-    resource
-        .mime_type
-        .as_deref()
-        .is_some_and(|mime_type| mime_type.starts_with("image/"))
-        || resource
-            .kind
-            .as_deref()
-            .is_some_and(|kind| kind.eq_ignore_ascii_case("image"))
+    archive_resource_is_image(resource)
+}
+
+fn archive_preview_default_size(dialog: &ArchivePreviewDialog) -> egui::Vec2 {
+    let Some([width, height]) = archive_preview_image_size(dialog) else {
+        return vec2(720.0, 560.0);
+    };
+    if width == 0 || height == 0 {
+        return vec2(720.0, 560.0);
+    }
+
+    const HORIZONTAL_CHROME: f32 = 48.0;
+    const VERTICAL_CHROME: f32 = 136.0;
+    const MAX_WINDOW_WIDTH: f32 = 960.0;
+    const MAX_WINDOW_HEIGHT: f32 = 760.0;
+
+    let image_width = width as f32;
+    let image_height = height as f32;
+    let scale = ((MAX_WINDOW_WIDTH - HORIZONTAL_CHROME) / image_width)
+        .min((MAX_WINDOW_HEIGHT - VERTICAL_CHROME) / image_height)
+        .min(1.0);
+
+    vec2(
+        (image_width * scale + HORIZONTAL_CHROME).clamp(520.0, MAX_WINDOW_WIDTH),
+        (image_height * scale + VERTICAL_CHROME).clamp(420.0, MAX_WINDOW_HEIGHT),
+    )
+}
+
+fn archive_preview_image_size(dialog: &ArchivePreviewDialog) -> Option<[usize; 2]> {
+    match &dialog.status {
+        ArchivePreviewStatus::Ready { image_size, .. } => *image_size,
+        _ => None,
+    }
 }
 
 fn preview_status_is_image(dialog: &ArchivePreviewDialog, content_type: Option<&str>) -> bool {
-    content_type.is_some_and(|content_type| content_type.starts_with("image/"))
-        || resource_is_image(&dialog.resource)
+    content_type.is_some_and(content_type_is_image) || resource_is_image(&dialog.resource)
+}
+
+fn preview_status_is_text(dialog: &ArchivePreviewDialog, content_type: Option<&str>) -> bool {
+    content_type.is_some_and(content_type_is_text)
+        || dialog
+            .resource
+            .mime_type
+            .as_deref()
+            .is_some_and(content_type_is_text)
 }
 
 fn render_archive_preview_header(ui: &mut egui::Ui, dialog: &ArchivePreviewDialog) {
@@ -2251,7 +2311,64 @@ fn render_archive_preview_header(ui: &mut egui::Ui, dialog: &ArchivePreviewDialo
     });
 }
 
-fn render_file_preview_body(ui: &mut egui::Ui, dialog: &ArchivePreviewDialog, object_url: &str) {
+fn render_archive_preview_content(ui: &mut egui::Ui, dialog: &ArchivePreviewDialog) {
+    match &dialog.status {
+        ArchivePreviewStatus::Loading => {
+            ui.vertical_centered(|ui| {
+                ui.add_space(24.0);
+                ui.spinner();
+                ui.add_space(8.0);
+                ui.label("Loading preview...");
+            });
+        }
+        ArchivePreviewStatus::Ready {
+            content_type,
+            bytes,
+            ..
+        } => {
+            if preview_status_is_image(dialog, content_type.as_deref()) {
+                render_image_preview_body(ui, dialog, bytes);
+            } else if preview_status_is_text(dialog, content_type.as_deref()) {
+                render_text_preview_body(ui, bytes);
+            } else {
+                render_file_preview_body(ui, dialog);
+            }
+        }
+        ArchivePreviewStatus::Failed(message) => {
+            ui.label(
+                RichText::new(format!("Preview failed: {message}"))
+                    .color(ui.visuals().error_fg_color),
+            );
+        }
+    }
+}
+
+fn render_image_preview_body(ui: &mut egui::Ui, dialog: &ArchivePreviewDialog, bytes: &[u8]) {
+    ScrollArea::both().show(ui, |ui| {
+        ui.add(
+            Image::from_bytes(
+                format!("bytes://archive/{}", dialog.resource.archive_id),
+                bytes.to_vec(),
+            )
+            .max_size(ui.available_size())
+            .maintain_aspect_ratio(true),
+        );
+    });
+}
+
+fn render_text_preview_body(ui: &mut egui::Ui, bytes: &[u8]) {
+    let mut text = String::from_utf8_lossy(bytes).into_owned();
+    ScrollArea::both().show(ui, |ui| {
+        ui.add(
+            TextEdit::multiline(&mut text)
+                .font(TextStyle::Monospace)
+                .desired_width(ui.available_width())
+                .interactive(false),
+        );
+    });
+}
+
+fn render_file_preview_body(ui: &mut egui::Ui, dialog: &ArchivePreviewDialog) {
     ui.vertical_centered(|ui| {
         ui.add_space(24.0);
         ui.label(RichText::new(regular::FILE).size(42.0));
@@ -2272,13 +2389,7 @@ fn render_file_preview_body(ui: &mut egui::Ui, dialog: &ArchivePreviewDialog, ob
                 .weak(),
         );
         ui.add_space(12.0);
-        if ui
-            .button(format!("{} Open", regular::ARROW_SQUARE_OUT))
-            .clicked()
-            && let Some(window) = web_sys::window()
-        {
-            let _ = window.open_with_url_and_target(object_url, "_blank");
-        }
+        ui.label(RichText::new("Preview is not available for this file type.").weak());
     });
 }
 
@@ -2481,6 +2592,7 @@ fn render_session_file_dialog(
     open: &mut bool,
     attachments: &[WebArchiveAttachment],
     trigger_preview_attachment: &mut Option<WebArchiveResource>,
+    trigger_download_attachment: &mut Option<WebArchiveResource>,
     remove_attachment_at: &mut Option<usize>,
 ) {
     let mut keep_open = *open;
@@ -2535,6 +2647,7 @@ fn render_session_file_dialog(
                                 attachment,
                                 index,
                                 trigger_preview_attachment,
+                                trigger_download_attachment,
                                 remove_attachment_at,
                             );
                         });
@@ -2545,6 +2658,7 @@ fn render_session_file_dialog(
                                 attachment,
                                 index,
                                 trigger_preview_attachment,
+                                trigger_download_attachment,
                                 remove_attachment_at,
                             );
                         });
@@ -2555,6 +2669,7 @@ fn render_session_file_dialog(
                                 attachment,
                                 index,
                                 trigger_preview_attachment,
+                                trigger_download_attachment,
                                 remove_attachment_at,
                             );
                         });
@@ -2569,12 +2684,21 @@ fn render_attachment_context_menu(
     attachment: &WebArchiveAttachment,
     index: usize,
     trigger_preview_attachment: &mut Option<WebArchiveResource>,
+    trigger_download_attachment: &mut Option<WebArchiveResource>,
     remove_attachment_at: &mut Option<usize>,
 ) {
     response.context_menu(|ui| {
-        if ui.button(format!("{} Preview", regular::EYE)).clicked() {
-            *trigger_preview_attachment =
-                Some(web_archive_resource_from_attachment(attachment.clone()));
+        let resource = web_archive_resource_from_attachment(attachment.clone());
+        if archive_resource_is_previewable(&resource) {
+            if ui.button(format!("{} Preview", regular::EYE)).clicked() {
+                *trigger_preview_attachment = Some(resource);
+                ui.close();
+            }
+        } else if ui
+            .button(format!("{} Download", regular::DOWNLOAD_SIMPLE))
+            .clicked()
+        {
+            *trigger_download_attachment = Some(resource);
             ui.close();
         }
         if ui

--- a/klaw-webui/src/web_chat/ui.rs
+++ b/klaw-webui/src/web_chat/ui.rs
@@ -14,15 +14,18 @@ use std::collections::{BTreeMap, HashMap};
 
 use crate::{
     ActiveSlashCommand, ConnectionState, ImCard, ImCardAction, ImCardActionKind, ImCardKind,
-    MessageRole, PageMode, SlashCommandCompletion, WebArchiveAttachment, apply_slash_completion,
-    attachment_action_in_progress, can_trigger_file_picker, delete_confirmation_body,
-    derive_page_mode, detect_active_slash_command, has_exact_slash_command_match,
-    normalize_gateway_token_input, resolve_assistant_bubble_palette, resolve_im_card_palette,
-    should_activate_session_window, should_show_thinking_placeholder, slash_command_matches,
+    MessageRole, PageMode, SlashCommandCompletion, WebArchiveAttachment, WebArchiveResource,
+    apply_slash_completion, attachment_action_in_progress, can_trigger_file_picker,
+    delete_confirmation_body, derive_page_mode, detect_active_slash_command,
+    has_exact_slash_command_match, normalize_gateway_token_input, resolve_assistant_bubble_palette,
+    resolve_im_card_palette, should_activate_session_window, should_show_thinking_placeholder,
+    slash_command_matches,
 };
 
 use super::{
-    app::ChatApp,
+    app::{
+        ArchivePreviewDialog, ArchivePreviewStatus, ChatApp, web_archive_resource_from_attachment,
+    },
     markdown::{MarkdownCache, render_markdown, render_plain_message},
     session::{
         BUBBLE_MAX_WIDTH, CardInteractionState, ChatMessage, INPUT_PANEL_HEIGHT,
@@ -437,6 +440,66 @@ impl ChatApp {
         self.show_about_dialog = open && !close_requested;
     }
 
+    fn render_archive_preview_dialog(&mut self, ctx: &Context) {
+        let Some(dialog) = self.archive_preview.borrow().clone() else {
+            return;
+        };
+        let mut open = true;
+        let mut close_requested = false;
+        egui::Window::new("Resource Preview")
+            .anchor(Align2::CENTER_CENTER, egui::Vec2::ZERO)
+            .collapsible(false)
+            .resizable(true)
+            .default_size(vec2(720.0, 560.0))
+            .min_width(420.0)
+            .open(&mut open)
+            .show(ctx, |ui| {
+                render_archive_preview_header(ui, &dialog);
+                ui.separator();
+                match &dialog.status {
+                    ArchivePreviewStatus::Loading => {
+                        ui.vertical_centered(|ui| {
+                            ui.add_space(24.0);
+                            ui.spinner();
+                            ui.add_space(8.0);
+                            ui.label("Loading preview...");
+                        });
+                    }
+                    ArchivePreviewStatus::Ready {
+                        object_url,
+                        content_type,
+                    } => {
+                        if preview_status_is_image(&dialog, content_type.as_deref()) {
+                            ScrollArea::both().show(ui, |ui| {
+                                ui.add(
+                                    Image::from_uri(object_url.clone())
+                                        .max_width(ui.available_width())
+                                        .maintain_aspect_ratio(true),
+                                );
+                            });
+                        } else {
+                            render_file_preview_body(ui, &dialog, object_url);
+                        }
+                    }
+                    ArchivePreviewStatus::Failed(message) => {
+                        ui.label(
+                            RichText::new(format!("Preview failed: {message}"))
+                                .color(ui.visuals().error_fg_color),
+                        );
+                    }
+                }
+                ui.separator();
+                ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                    if ui.button("Close").clicked() {
+                        close_requested = true;
+                    }
+                });
+            });
+        if close_requested || !open {
+            *self.archive_preview.borrow_mut() = None;
+        }
+    }
+
     fn active_session(&self) -> Option<&SessionWindow> {
         let active_session_key = self.active_session_key.as_deref()?;
         self.sessions
@@ -747,7 +810,7 @@ impl ChatApp {
         let mut trigger_card_action: Option<CardActionRequest> = None;
         let mut trigger_history_load: Option<PendingHistoryScrollRestore> = None;
         let mut trigger_open_file_dialog = false;
-        let mut trigger_preview_attachment: Option<String> = None;
+        let mut trigger_preview_attachment: Option<WebArchiveResource> = None;
         let mut remove_attachment_at: Option<usize> = None;
         let mut set_active = false;
         {
@@ -811,6 +874,7 @@ impl ChatApp {
                                     &messages,
                                     message_index,
                                     &session.card_state_overrides,
+                                    &mut trigger_preview_attachment,
                                 ) {
                                     card_action = Some(action);
                                 }
@@ -1175,8 +1239,8 @@ impl ChatApp {
         if trigger_file_picker {
             self.trigger_file_picker(session_key);
         }
-        if let Some(archive_id) = trigger_preview_attachment {
-            self.preview_archive_attachment(&archive_id);
+        if let Some(resource) = trigger_preview_attachment {
+            self.preview_archive_attachment(resource);
         }
         if trigger_send {
             self.send_session_draft(session_key);
@@ -1308,6 +1372,7 @@ impl eframe::App for ChatApp {
         self.render_about_dialog(ctx);
         self.render_rename_dialog(ctx);
         self.render_delete_dialog(ctx);
+        self.render_archive_preview_dialog(ctx);
         self.toasts.borrow_mut().show(ctx);
     }
 }
@@ -1329,7 +1394,7 @@ fn user_bubble_inner_max_width(
 
     let body_w = {
         let t = message.text.as_str();
-        let attachments = message_attachments(message);
+        let attachments = message_resources(message);
         let text_width = if t.trim().is_empty() {
             0.0
         } else {
@@ -1455,6 +1520,7 @@ fn render_message(
     messages: &[ChatMessage],
     message_index: usize,
     card_state_overrides: &HashMap<String, CardInteractionState>,
+    trigger_preview_attachment: &mut Option<WebArchiveResource>,
 ) -> Option<CardActionRequest> {
     let now_ms = current_timestamp_ms();
     let time_label = format_message_timestamp(message.timestamp_ms, now_ms);
@@ -1564,6 +1630,7 @@ fn render_message(
                                     message,
                                     body_color,
                                     link_color,
+                                    trigger_preview_attachment,
                                 );
                             }
                         });
@@ -1965,8 +2032,9 @@ fn render_message_body(
     message: &ChatMessage,
     body_color: Color32,
     link_color: Color32,
+    trigger_preview_attachment: &mut Option<WebArchiveResource>,
 ) {
-    let attachments = message_attachments(message);
+    let attachments = message_resources(message);
     let has_text = !message.text.trim().is_empty();
     let has_attachments = !attachments.is_empty();
 
@@ -2002,25 +2070,216 @@ fn render_message_body(
     if has_attachments {
         ui.vertical(|ui| {
             for attachment in attachments {
-                ui.horizontal_wrapped(|ui| {
-                    ui.label(RichText::new(regular::FILE).color(body_color));
-                    ui.label(
-                        RichText::new(attachment.filename.unwrap_or_else(|| "unknown".to_string()))
-                            .color(body_color),
-                    );
-                });
+                render_resource_card(ui, &attachment, body_color, trigger_preview_attachment);
             }
         });
     }
 }
 
-fn message_attachments(message: &ChatMessage) -> Vec<WebArchiveAttachment> {
-    message
+fn message_resources(message: &ChatMessage) -> Vec<WebArchiveResource> {
+    if let Some(resources) = message
+        .metadata
+        .get("archive.resources")
+        .cloned()
+        .and_then(|value| serde_json::from_value::<Vec<WebArchiveResource>>(value).ok())
+        .filter(|resources| !resources.is_empty())
+    {
+        return resources;
+    }
+
+    if let Some(attachments) = message
         .metadata
         .get("attachments")
         .cloned()
-        .and_then(|value| serde_json::from_value(value).ok())
+        .and_then(|value| serde_json::from_value::<Vec<WebArchiveAttachment>>(value).ok())
+        .filter(|attachments| !attachments.is_empty())
+    {
+        return attachments
+            .into_iter()
+            .map(web_archive_resource_from_attachment)
+            .collect();
+    }
+
+    message
+        .metadata
+        .get("channel.attachments")
+        .cloned()
+        .and_then(|value| serde_json::from_value::<Vec<serde_json::Value>>(value).ok())
         .unwrap_or_default()
+        .into_iter()
+        .filter_map(resource_from_channel_attachment)
+        .collect()
+}
+
+fn resource_from_channel_attachment(value: serde_json::Value) -> Option<WebArchiveResource> {
+    let archive_id = value
+        .get("archive_id")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?
+        .to_string();
+    Some(WebArchiveResource {
+        archive_id,
+        filename: value
+            .get("filename")
+            .and_then(serde_json::Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned),
+        mime_type: value
+            .get("mime_type")
+            .and_then(serde_json::Value::as_str)
+            .map(ToOwned::to_owned),
+        size_bytes: value
+            .get("size_bytes")
+            .and_then(serde_json::Value::as_i64)
+            .unwrap_or_default(),
+        kind: value
+            .get("kind")
+            .and_then(serde_json::Value::as_str)
+            .map(ToOwned::to_owned),
+        caption: value
+            .get("caption")
+            .and_then(serde_json::Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned),
+    })
+}
+
+fn render_resource_card(
+    ui: &mut egui::Ui,
+    resource: &WebArchiveResource,
+    body_color: Color32,
+    trigger_preview_attachment: &mut Option<WebArchiveResource>,
+) {
+    let icon = if resource_is_image(resource) {
+        regular::IMAGE
+    } else {
+        regular::FILE
+    };
+    Frame::group(ui.style())
+        .fill(ui.visuals().extreme_bg_color)
+        .stroke(Stroke::new(
+            1.0,
+            ui.visuals().widgets.noninteractive.bg_stroke.color,
+        ))
+        .corner_radius(6.0)
+        .inner_margin(8.0)
+        .show(ui, |ui| {
+            ui.set_width(ui.available_width());
+            ui.horizontal(|ui| {
+                ui.label(RichText::new(icon).color(body_color));
+                ui.vertical(|ui| {
+                    ui.label(
+                        RichText::new(resource.filename.as_deref().unwrap_or("attachment"))
+                            .strong()
+                            .color(body_color),
+                    );
+                    ui.label(RichText::new(resource_meta_label(resource)).small().weak());
+                    if let Some(caption) = resource.caption.as_deref() {
+                        ui.label(RichText::new(caption).small().color(body_color));
+                    }
+                });
+                ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                    if ui
+                        .button(format!("{} Preview", regular::EYE))
+                        .on_hover_text("Preview archive resource")
+                        .clicked()
+                    {
+                        *trigger_preview_attachment = Some(resource.clone());
+                    }
+                });
+            });
+        });
+}
+
+fn resource_meta_label(resource: &WebArchiveResource) -> String {
+    let mut parts = Vec::new();
+    if let Some(mime_type) = resource.mime_type.as_deref() {
+        parts.push(mime_type.to_string());
+    } else if let Some(kind) = resource.kind.as_deref() {
+        parts.push(kind.to_string());
+    }
+    if resource.size_bytes > 0 {
+        parts.push(format_file_size(resource.size_bytes));
+    }
+    parts.push(resource.archive_id.clone());
+    parts.join(" · ")
+}
+
+fn resource_is_image(resource: &WebArchiveResource) -> bool {
+    resource
+        .mime_type
+        .as_deref()
+        .is_some_and(|mime_type| mime_type.starts_with("image/"))
+        || resource
+            .kind
+            .as_deref()
+            .is_some_and(|kind| kind.eq_ignore_ascii_case("image"))
+}
+
+fn preview_status_is_image(dialog: &ArchivePreviewDialog, content_type: Option<&str>) -> bool {
+    content_type.is_some_and(|content_type| content_type.starts_with("image/"))
+        || resource_is_image(&dialog.resource)
+}
+
+fn render_archive_preview_header(ui: &mut egui::Ui, dialog: &ArchivePreviewDialog) {
+    ui.horizontal(|ui| {
+        ui.label(RichText::new(if resource_is_image(&dialog.resource) {
+            regular::IMAGE
+        } else {
+            regular::FILE
+        }));
+        ui.vertical(|ui| {
+            ui.label(
+                RichText::new(
+                    dialog
+                        .resource
+                        .filename
+                        .as_deref()
+                        .unwrap_or("archive resource"),
+                )
+                .strong(),
+            );
+            ui.label(
+                RichText::new(resource_meta_label(&dialog.resource))
+                    .small()
+                    .weak(),
+            );
+        });
+    });
+}
+
+fn render_file_preview_body(ui: &mut egui::Ui, dialog: &ArchivePreviewDialog, object_url: &str) {
+    ui.vertical_centered(|ui| {
+        ui.add_space(24.0);
+        ui.label(RichText::new(regular::FILE).size(42.0));
+        ui.add_space(8.0);
+        ui.label(
+            RichText::new(
+                dialog
+                    .resource
+                    .filename
+                    .as_deref()
+                    .unwrap_or("archive resource"),
+            )
+            .strong(),
+        );
+        ui.label(
+            RichText::new(resource_meta_label(&dialog.resource))
+                .small()
+                .weak(),
+        );
+        ui.add_space(12.0);
+        if ui
+            .button(format!("{} Open", regular::ARROW_SQUARE_OUT))
+            .clicked()
+            && let Some(window) = web_sys::window()
+        {
+            let _ = window.open_with_url_and_target(object_url, "_blank");
+        }
+    });
 }
 
 fn compact_sidebar_title(title: &str) -> String {
@@ -2221,7 +2480,7 @@ fn render_session_file_dialog(
     ctx: &Context,
     open: &mut bool,
     attachments: &[WebArchiveAttachment],
-    trigger_preview_attachment: &mut Option<String>,
+    trigger_preview_attachment: &mut Option<WebArchiveResource>,
     remove_attachment_at: &mut Option<usize>,
 ) {
     let mut keep_open = *open;
@@ -2309,12 +2568,13 @@ fn render_attachment_context_menu(
     response: &egui::Response,
     attachment: &WebArchiveAttachment,
     index: usize,
-    trigger_preview_attachment: &mut Option<String>,
+    trigger_preview_attachment: &mut Option<WebArchiveResource>,
     remove_attachment_at: &mut Option<usize>,
 ) {
     response.context_menu(|ui| {
         if ui.button(format!("{} Preview", regular::EYE)).clicked() {
-            *trigger_preview_attachment = Some(attachment.archive_id.clone());
+            *trigger_preview_attachment =
+                Some(web_archive_resource_from_attachment(attachment.clone()));
             ui.close();
         }
         if ui

--- a/klaw-webui/src/web_chat/upload.rs
+++ b/klaw-webui/src/web_chat/upload.rs
@@ -2,7 +2,7 @@ use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::JsFuture;
 use web_sys::{File, FormData, Request, RequestInit, Response, Url};
 
-use crate::{ArchiveRecord, ArchiveUploadResponse};
+use crate::{ArchiveRecord, ArchiveUploadResponse, WebArchiveResource};
 
 pub(super) async fn upload_file_to_archive(
     gateway_origin: &str,
@@ -68,8 +68,8 @@ pub(super) async fn upload_file_to_archive(
 }
 
 pub(super) struct ArchivePreviewBlob {
-    pub(super) object_url: String,
     pub(super) content_type: Option<String>,
+    pub(super) bytes: Vec<u8>,
 }
 
 pub(super) async fn load_archive_preview(
@@ -77,6 +77,36 @@ pub(super) async fn load_archive_preview(
     gateway_token: Option<&str>,
     archive_id: &str,
 ) -> Result<ArchivePreviewBlob, String> {
+    let (blob, content_type) =
+        fetch_archive_blob(gateway_origin, gateway_token, archive_id).await?;
+    let bytes = blob_bytes(&blob).await?;
+    Ok(ArchivePreviewBlob {
+        content_type,
+        bytes,
+    })
+}
+
+pub(super) async fn download_archive_resource(
+    gateway_origin: &str,
+    gateway_token: Option<&str>,
+    resource: &WebArchiveResource,
+) -> Result<(), String> {
+    let (blob, _) = fetch_archive_blob(gateway_origin, gateway_token, &resource.archive_id).await?;
+    let object_url =
+        Url::create_object_url_with_blob(&blob).map_err(|_| "Failed to create download URL")?;
+    let download_result = trigger_browser_download(
+        &object_url,
+        resource.filename.as_deref().unwrap_or("download"),
+    );
+    let _ = Url::revoke_object_url(&object_url);
+    download_result
+}
+
+async fn fetch_archive_blob(
+    gateway_origin: &str,
+    gateway_token: Option<&str>,
+    archive_id: &str,
+) -> Result<(web_sys::Blob, Option<String>), String> {
     let url = format!(
         "{}/archive/download/{}",
         gateway_origin,
@@ -120,10 +150,37 @@ pub(super) async fn load_archive_preview(
         .dyn_into()
         .map_err(|_| "Failed to cast response blob")?;
 
-    let object_url =
-        Url::create_object_url_with_blob(&blob).map_err(|_| "Failed to create preview URL")?;
-    Ok(ArchivePreviewBlob {
-        object_url,
-        content_type,
-    })
+    Ok((blob, content_type))
+}
+
+async fn blob_bytes(blob: &web_sys::Blob) -> Result<Vec<u8>, String> {
+    let buffer = JsFuture::from(blob.array_buffer())
+        .await
+        .map_err(|_| "Failed to read blob bytes")?;
+    Ok(js_sys::Uint8Array::new(&buffer).to_vec())
+}
+
+fn trigger_browser_download(object_url: &str, filename: &str) -> Result<(), String> {
+    let window = web_sys::window().ok_or("No window object")?;
+    let document = window.document().ok_or("No document object")?;
+    let anchor = document
+        .create_element("a")
+        .map_err(|_| "Failed to create download link")?
+        .dyn_into::<web_sys::HtmlAnchorElement>()
+        .map_err(|_| "Failed to cast download link")?;
+
+    anchor.set_href(object_url);
+    anchor.set_download(filename);
+
+    if let Some(body) = document.body() {
+        body.append_child(&anchor)
+            .map_err(|_| "Failed to attach download link")?;
+        anchor.click();
+        body.remove_child(&anchor)
+            .map_err(|_| "Failed to remove download link")?;
+    } else {
+        anchor.click();
+    }
+
+    Ok(())
 }

--- a/klaw-webui/src/web_chat/upload.rs
+++ b/klaw-webui/src/web_chat/upload.rs
@@ -67,11 +67,16 @@ pub(super) async fn upload_file_to_archive(
     }
 }
 
-pub(super) async fn preview_archive_file(
+pub(super) struct ArchivePreviewBlob {
+    pub(super) object_url: String,
+    pub(super) content_type: Option<String>,
+}
+
+pub(super) async fn load_archive_preview(
     gateway_origin: &str,
     gateway_token: Option<&str>,
     archive_id: &str,
-) -> Result<(), String> {
+) -> Result<ArchivePreviewBlob, String> {
     let url = format!(
         "{}/archive/download/{}",
         gateway_origin,
@@ -103,6 +108,11 @@ pub(super) async fn preview_archive_file(
         return Err(format!("HTTP {}: {}", resp.status(), resp.status_text()));
     }
 
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .map_err(|_| "Failed to read content type")?;
+
     let blob = JsFuture::from(resp.blob().map_err(|_| "Failed to read blob")?)
         .await
         .map_err(|_| "Failed to resolve blob")?;
@@ -112,9 +122,8 @@ pub(super) async fn preview_archive_file(
 
     let object_url =
         Url::create_object_url_with_blob(&blob).map_err(|_| "Failed to create preview URL")?;
-    window
-        .open_with_url_and_target(&object_url, "_blank")
-        .map_err(|_| "Failed to open preview window")?
-        .ok_or_else(|| "Browser blocked preview window".to_string())?;
-    Ok(())
+    Ok(ArchivePreviewBlob {
+        object_url,
+        content_type,
+    })
 }


### PR DESCRIPTION
## Summary

This PR adds support for previewing archive-backed resources in WebUI chat when channel attachments are returned via WebSocket Gateway.

## Changes

### klaw-runtime
- Gateway WebSocket responses now enrich returned `channel_attachment` outputs with archive-backed `archive.resources` metadata
- Auto-archives local path attachments when permitted by `LocalAttachmentPolicy`
- Web clients can preview generated files through Gateway archive APIs

### klaw-webui  
- Renders archive-backed resource cards for returned channel attachments
- Opens image or file previews in an in-app dialog through Gateway archive downloads
- Supports image inline preview and file download to new tab
- Backward compatible with legacy `attachments` and `channel.attachments` metadata formats

## Architecture

- Runtime: New `enrich_web_archive_resources()` method in `RuntimeWebsocketHandler`
- WebUI: New `ArchivePreviewDialog` state with `ArchivePreviewStatus` for async loading
- Common: `WebArchiveResource` type for metadata exchange

## Testing

- [x] CHANGELOG updated for both crates
- [x] Unit tests for `WebArchiveResource` deserialization
- [x] Manual verification of preview flow

Closes #246