### PR TITLE
ci(ghcr): add manual container image workflow for GHCR

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 .git
 .gitignore
+.github
 .DS_Store
 .crush
 .superpowers

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -1,0 +1,109 @@
+name: container-image
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Image tag. Defaults to the Cargo workspace version."
+        required: false
+        type: string
+      push_latest:
+        description: "Also publish the latest tag."
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  WASM_TARGET: wasm32-unknown-unknown
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve image metadata
+        id: meta
+        shell: bash
+        run: |
+          VERSION="$(awk -F' *= *' '/^version = / {gsub(/"/,"",$2); print $2; exit}' Cargo.toml)"
+          TAG="${{ inputs.tag }}"
+          if [[ -z "$TAG" ]]; then
+            TAG="$VERSION"
+          fi
+          IMAGE="ghcr.io/${GITHUB_REPOSITORY,,}"
+          {
+            echo "version=$VERSION"
+            echo "tag=$TAG"
+            echo "image=$IMAGE"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Install native build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential \
+            ca-certificates \
+            clang \
+            cmake \
+            libasound2-dev \
+            libatk1.0-dev \
+            libcairo2-dev \
+            libgdk-pixbuf-2.0-dev \
+            libgtk-3-dev \
+            libpango1.0-dev \
+            libssl-dev \
+            libudev-dev \
+            pkg-config
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ env.WASM_TARGET }}
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install wasm-bindgen CLI
+        run: |
+          WASM_BINDGEN_VERSION="$(awk -F' *= *' '/^wasm-bindgen = / {gsub(/"/,"",$2); print $2; exit}' Cargo.toml)"
+          cargo install wasm-bindgen-cli --version "$WASM_BINDGEN_VERSION" --locked
+
+      - name: Build WebUI WASM assets
+        run: make webui-wasm
+
+      - name: Build klaw binary
+        run: cargo build --release -p klaw-cli
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        shell: bash
+        run: |
+          TAGS=(
+            "-t" "${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.tag }}"
+            "-t" "${{ steps.meta.outputs.image }}:sha-${GITHUB_SHA::12}"
+          )
+          if [[ "${{ inputs.push_latest }}" == "true" ]]; then
+            TAGS+=("-t" "${{ steps.meta.outputs.image }}:latest")
+          fi
+
+          docker buildx build \
+            --push \
+            --file docker/Dockerfile \
+            --build-arg KLAW_BINARY=target/release/klaw \
+            "${TAGS[@]}" \
+            .

--- a/README.md
+++ b/README.md
@@ -194,9 +194,10 @@ Build a container image from source, including the embedded WebUI WASM assets:
 docker build -t klaw:latest .
 ```
 
-Package a locally compiled binary into the runtime image:
+Package a locally compiled binary into the runtime image. This is also the path used by the manual GHCR workflow: build WebUI assets and the release binary first, then copy `target/release/klaw` into the image.
 
 ```bash
+make webui-wasm
 cargo build --release -p klaw-cli
 docker build -f docker/Dockerfile \
   --build-arg KLAW_BINARY=target/release/klaw \
@@ -217,6 +218,8 @@ enabled = true
 listen_ip = "0.0.0.0"
 listen_port = 18080
 ```
+
+The `container-image` GitHub Actions workflow is manual-only (`workflow_dispatch`). It publishes to GHCR as `ghcr.io/<owner>/<repo>:<tag>`, plus `sha-<short-sha>` and optionally `latest`.
 
 ## macOS Packaging
 


### PR DESCRIPTION
Add a workflow_dispatch-only GitHub Actions workflow that builds the CLI and WebUI WASM assets, then publishes a multi-tag image to GHCR (ghcr.io/<owner>/<repo>:<tag>, sha-<short-sha>, optional latest).

Also update .dockerignore to exclude .github from the build context, and expand the README container section with the make webui-wasm prerequisite and a note about the GHCR workflow.