### PR TITLE
fix(ci): add libxdo dependency to container builds

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -59,6 +59,7 @@ jobs:
             libpango1.0-dev \
             libssl-dev \
             libudev-dev \
+            libxdo-dev \
             pkg-config
 
       - name: Install Rust toolchain

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update \
         libpango1.0-dev \
         libssl-dev \
         libudev-dev \
+        libxdo-dev \
         pkg-config \
     && rm -rf /var/lib/apt/lists/*
 
@@ -49,6 +50,7 @@ RUN apt-get update \
         libssl3 \
         libx11-6 \
         libxcb1 \
+        libxdo3 \
         libxkbcommon0 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update \
         libssl3 \
         libx11-6 \
         libxcb1 \
+        libxdo3 \
         libxkbcommon0 \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
- Add `libxdo-dev` to the build stage and `libxdo3` to the runtime stage in both `Dockerfile` and `docker/Dockerfile`
- Add `libxdo-dev` to the CI workflow's native dependency list in `.github/workflows/container-image.yml`
- Fixes missing library error when the GUI/egui backend links against libxdo for input simulation support

## Test plan
- [ ] Verify `docker build` completes without libxdo linker errors
- [ ] Verify GHCR workflow `container-image` runs successfully end-to-end
- [ ] Confirm the runtime image starts without missing `libxdo.so` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)