### PR TITLE
feat(gateway): add OpenAPI and Scalar docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4585,6 +4585,8 @@ dependencies = [
  "tokio-tungstenite",
  "tracing",
  "urlencoding",
+ "utoipa",
+ "utoipa-scalar",
  "uuid",
 ]
 
@@ -9803,6 +9805,42 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "utoipa"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bde15df68e80b16c7d16b9616e80770ad158988daa56a27dccd1e55558b0160"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba0b99ee52df3028635d93840c797102da61f8a7bb3cf751032455895b52ef8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "utoipa-scalar"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59559e1509172f6b26c1cdbc7247c4ddd1ac6560fe94b584f81ee489b141f719"
+dependencies = [
+ "axum 0.8.8",
+ "serde",
+ "serde_json",
+ "utoipa",
+]
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,8 @@ async-trait = "0.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 schemars = { version = "1", features = ["derive"] }
+utoipa = { version = "5", features = ["axum_extras"] }
+utoipa-scalar = { version = "0.3", features = ["axum"] }
 thiserror = "2"
 tokio = { version = "1", features = ["sync", "time", "macros", "rt", "signal", "process"] }
 tokio-util = { version = "0.7", features = ["compat"] }

--- a/docs/src/gateway/http-api.md
+++ b/docs/src/gateway/http-api.md
@@ -14,6 +14,7 @@
 - 归档模型与服务：`klaw-archive/src/model.rs`、`klaw-archive/src/service.rs`
 - 健康注册表：`klaw-observability/src/health.rs`
 - 路由常量：`klaw-gateway/src/routes.rs`
+- OpenAPI/Scalar 文档：`klaw-gateway/src/openapi.rs`
 - Gateway 配置结构：`klaw-config/src/lib.rs`
 
 ## 概述
@@ -23,6 +24,10 @@
 - 认证方式：
   - **Gateway Auth**：保护 `/ws/chat`、`/archive/*`、`/providers/list`、`/mcp/*` 等路径，使用 `gateway.auth.token` 或 `gateway.auth.env_key` 配置的 Bearer Token。
   - **Webhook Auth**：保护 `/webhook/events` 和 `/webhook/agents`，支持多种验证模式（Bearer Token、GitHub HMAC、GitLab Token/签名），同样使用 `gateway.auth` 配置的密钥。
+- API 文档：
+  - `GET /openapi.json` 返回 Gateway HTTP API 的 OpenAPI JSON。
+  - `GET /scalar` 返回 Scalar API reference UI。
+  - 当 `gateway.auth.enabled = true` 时，这两个端点与其他 Gateway Auth 端点一样要求 `Authorization: Bearer <token>`；未开启认证时可直接访问。
 
 ## 路由注册条件
 
@@ -34,9 +39,25 @@
 - `/webhook/events`：仅当 `gateway.webhook.enabled = true` 且 `gateway.webhook.events.enabled = true` 时注册
 - `/webhook/agents`：仅当 `gateway.webhook.enabled = true` 且 `gateway.webhook.agents.enabled = true` 时注册
 
+`/openapi.json` 和 `/scalar` 始终注册。OpenAPI 首版覆盖 Gateway HTTP API；`/ws/chat` 只作为 WebSocket upgrade 入口描述，内部 JSON-RPC v1 协议仍以 WebSocket 协议文档为准。
+
 未注册的路由返回 `404 Not Found`。
 
 ## API 端点列表
+
+### 0. API 文档接口
+
+#### 0.1 OpenAPI JSON
+
+- **端点**：`GET /openapi.json`
+- **认证**：Gateway Auth（仅当 `gateway.auth.enabled = true`）
+- **描述**：返回 Gateway HTTP API 的 OpenAPI 3.1 JSON 文档，覆盖 archive、providers、MCP、webhook、health、metrics 和 `/ws/chat` upgrade 描述。
+
+#### 0.2 Scalar API Reference
+
+- **端点**：`GET /scalar`
+- **认证**：Gateway Auth（仅当 `gateway.auth.enabled = true`）
+- **描述**：返回 Scalar API reference UI。页面内嵌当前 OpenAPI spec，并标记 `/openapi.json` 作为机器可读文档地址。
 
 ### 1. 归档管理接口
 

--- a/klaw-gateway/CHANGELOG.md
+++ b/klaw-gateway/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Gateway now serves OpenAPI JSON at `/openapi.json` and a Scalar API reference UI at `/scalar`, with the same Gateway Auth behavior as protected gateway APIs.
 - Gateway now exposes authenticated `/mcp/*` management endpoints for MCP runtime status, redacted server config CRUD, runtime sync, and stdio server restart.
 
 ### Fixed

--- a/klaw-gateway/Cargo.toml
+++ b/klaw-gateway/Cargo.toml
@@ -24,6 +24,8 @@ strum = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["net", "sync"] }
 tracing = { workspace = true }
+utoipa = { workspace = true }
+utoipa-scalar = { workspace = true }
 urlencoding = { workspace = true }
 uuid = { workspace = true }
 

--- a/klaw-gateway/README.md
+++ b/klaw-gateway/README.md
@@ -24,6 +24,9 @@
   - `DELETE /mcp/servers/:id`: 删除 MCP server 配置并立即同步 runtime
   - `POST /mcp/sync`: 按磁盘最新配置同步 MCP runtime
   - `POST /mcp/servers/:id/restart`: 重启 stdio MCP server
+- 暴露 API 文档接口：
+  - `GET /openapi.json`: 获取 Gateway HTTP API 的 OpenAPI JSON
+  - `GET /scalar`: 打开 Scalar API reference UI
 - `/ws/chat` 仅支持 v1 JSON-RPC 形态 agent 协议，覆盖 initialize、session/thread 方法、turn/item 生命周期、结构化 content/tool/approval payload、取消与 server request 闭环
 - webhook 请求会进入独立的 `webhook:*` 执行 session；若提供 `base_session_key`，最终回复会路由回目标 IM 会话当前 active session
 - 按 `session_key` 维护房间广播通道
@@ -56,7 +59,8 @@
 - webhook 路由是否注册由 `gateway.webhook.enabled` 决定；`events` / `agents` 仅可分别启停并配置独立 body limit，路径固定不再开放配置
 - archive 路由在 `GatewayOptions` 中提供 `archive_service` 时自动注册，所有 archive 接口均需要 Bearer 鉴权
 - MCP 路由在 `GatewayOptions` 中提供 `mcp_handler` 时自动注册，所有 `/mcp/*` 接口均需要 Bearer 鉴权；返回 server 配置时只暴露 `env_keys` / `header_keys`，不回传 secret 原文
-- 仅 `/ws/chat`、`/archive/*`、`/providers/list` 和 `/mcp/*` 会走 gateway Bearer 鉴权中间件（含 `/ws/chat` query token 回退）；`/webhook/events` 与 `/webhook/agents` 继续复用 `gateway.auth` 的 token/env secret 做 webhook 专用多模式校验；首页、`/chat` 及其静态资源、health、metrics 不做鉴权
+- `/openapi.json` 和 `/scalar` 始终注册；当 `gateway.auth.enabled = true` 时，它们与 `/ws/chat`、`/archive/*`、`/providers/list`、`/mcp/*` 使用同一套 gateway Bearer 鉴权；未开启认证时保持无认证访问
+- 仅 `/ws/chat`、`/archive/*`、`/providers/list`、`/mcp/*`、`/openapi.json` 和 `/scalar` 会走 gateway Bearer 鉴权中间件（含 `/ws/chat` query token 回退）；`/webhook/events` 与 `/webhook/agents` 继续复用 `gateway.auth` 的 token/env secret 做 webhook 专用多模式校验；首页、`/chat` 及其静态资源、health、metrics 不做鉴权
 - `TailscaleManager::inspect_host()` 可独立读取本机 Tailscale 状态，供 GUI 在 gateway 未运行时展示主机连接信息；当本机 daemon 无响应时会在短超时后回落为 host 侧不可用状态，避免拖慢整个 gateway 状态刷新
 - Tailscale Serve/Funnel 会在 gateway 绑定完成后使用实际监听端口做反向代理，并在 setup 后回读 `tailscale serve status --json` / `tailscale funnel status --json` 确认配置是否生效；setup/reset/status 通过 `tokio::process::Command` 执行并带超时，超时会终止子进程，避免本机 Tailscale CLI 卡住 async runtime；Funnel 未配置 auth 时允许启动，但应视为公网裸露入口
 
@@ -94,6 +98,15 @@ GATEWAY_TOKEN=your-token BASE_URL=http://127.0.0.1:18080 cargo run -p klaw-gatew
 ```
 
 ## Archive API Usage
+
+## API Docs Usage
+
+```bash
+curl -X GET http://127.0.0.1:18080/openapi.json \
+  -H "Authorization: Bearer your-token"
+```
+
+Open `http://127.0.0.1:18080/scalar` in a browser for the Scalar API reference. Both docs endpoints are public only when `gateway.auth.enabled = false`.
 
 ### Upload File
 

--- a/klaw-gateway/src/auth.rs
+++ b/klaw-gateway/src/auth.rs
@@ -72,6 +72,8 @@ pub fn should_require_gateway_auth(path: &str) -> bool {
         || path == Route::ArchiveUpload.as_str()
         || path == Route::ArchiveList.as_str()
         || path == Route::ProvidersList.as_str()
+        || path == Route::OpenApiJson.as_str()
+        || path == Route::Scalar.as_str()
         || path.starts_with("/archive/download/")
         || path.starts_with("/archive/")
         || path.starts_with("/mcp/")
@@ -352,6 +354,8 @@ mod tests {
         assert!(should_require_gateway_auth("/providers/list"));
         assert!(should_require_gateway_auth("/mcp/status"));
         assert!(should_require_gateway_auth("/mcp/servers/local/restart"));
+        assert!(should_require_gateway_auth("/openapi.json"));
+        assert!(should_require_gateway_auth("/scalar"));
         assert!(!should_require_gateway_auth("/"));
         assert!(!should_require_gateway_auth("/health/status"));
         assert!(!should_require_gateway_auth("/metrics"));

--- a/klaw-gateway/src/lib.rs
+++ b/klaw-gateway/src/lib.rs
@@ -6,6 +6,7 @@ mod error;
 mod handlers;
 mod home;
 mod mcp;
+mod openapi;
 mod protocol;
 mod providers;
 mod routes;

--- a/klaw-gateway/src/openapi.rs
+++ b/klaw-gateway/src/openapi.rs
@@ -1,0 +1,564 @@
+#![allow(dead_code)]
+
+use crate::routes::Route;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::BTreeMap;
+use utoipa::{IntoParams, OpenApi, ToSchema};
+use utoipa_scalar::{Scalar, Servable};
+
+#[derive(OpenApi)]
+#[openapi(
+    info(
+        title = "Klaw Gateway API",
+        version = env!("CARGO_PKG_VERSION"),
+        description = "HTTP management APIs exposed by the Klaw gateway."
+    ),
+    paths(
+        openapi_json_docs,
+        scalar_docs,
+        ws_chat_docs,
+        webhook_events_docs,
+        webhook_agents_docs,
+        archive_upload_docs,
+        archive_download_docs,
+        archive_list_docs,
+        archive_get_docs,
+        providers_list_docs,
+        mcp_status_docs,
+        mcp_list_servers_docs,
+        mcp_create_server_docs,
+        mcp_get_server_docs,
+        mcp_update_server_docs,
+        mcp_delete_server_docs,
+        mcp_sync_docs,
+        mcp_restart_server_docs,
+        health_live_docs,
+        health_ready_docs,
+        health_status_docs,
+        metrics_docs
+    ),
+    components(schemas(
+        ErrorResponse,
+        HealthStatusResponse,
+        HealthComponent,
+        ArchiveRecordSchema,
+        ArchiveUploadResponseSchema,
+        ArchiveListQuerySchema,
+        ArchiveListResponseSchema,
+        ArchiveGetResponseSchema,
+        ProviderInfoSchema,
+        ProvidersListResponseSchema,
+        GatewayWebhookPayloadSchema,
+        GatewayWebhookResponseSchema,
+        GatewayWebhookAgentQuerySchema,
+        GatewayWebhookAgentResponseSchema,
+        GatewayMcpServerConfigViewSchema,
+        GatewayMcpServerUpsertRequestSchema,
+        GatewayMcpRuntimeSnapshotSchema,
+        GatewayMcpServerStatusViewSchema,
+        GatewayMcpServerDetailViewSchema,
+        McpStatusResponseSchema,
+        McpServersResponseSchema,
+        McpServerResponseSchema
+    )),
+    tags(
+        (name = "docs", description = "OpenAPI and Scalar documentation endpoints"),
+        (name = "websocket", description = "Gateway WebSocket upgrade endpoint"),
+        (name = "webhook", description = "Webhook ingestion endpoints"),
+        (name = "archive", description = "Archive upload, lookup, and download endpoints"),
+        (name = "providers", description = "Model provider discovery endpoints"),
+        (name = "mcp", description = "MCP management endpoints"),
+        (name = "health", description = "Health and metrics endpoints")
+    )
+)]
+struct GatewayApiDoc;
+
+pub(crate) async fn openapi_json_handler() -> Json<utoipa::openapi::OpenApi> {
+    Json(gateway_openapi())
+}
+
+pub(crate) fn scalar_router() -> Scalar<utoipa::openapi::OpenApi> {
+    Scalar::with_url(Route::Scalar.as_str(), gateway_openapi()).custom_html(SCALAR_HTML)
+}
+
+fn gateway_openapi() -> utoipa::openapi::OpenApi {
+    GatewayApiDoc::openapi()
+}
+
+const SCALAR_HTML: &str = r#"<!doctype html>
+<html>
+<head>
+    <title>Klaw Gateway API</title>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <meta name="openapi-url" content="/openapi.json"/>
+</head>
+<body>
+<script id="api-reference" type="application/json">
+    $spec
+</script>
+<script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+</body>
+</html>
+"#;
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+struct ErrorResponse {
+    success: bool,
+    error: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+struct HealthStatusResponse {
+    status: String,
+    components: Vec<HealthComponent>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+struct HealthComponent {
+    name: String,
+    status: String,
+    message: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+struct ArchiveRecordSchema {
+    id: String,
+    source_kind: String,
+    media_kind: String,
+    mime_type: Option<String>,
+    extension: Option<String>,
+    original_filename: Option<String>,
+    content_sha256: String,
+    size_bytes: i64,
+    storage_rel_path: String,
+    session_key: Option<String>,
+    channel: Option<String>,
+    chat_id: Option<String>,
+    message_id: Option<String>,
+    metadata_json: String,
+    created_at_ms: i64,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+struct ArchiveUploadResponseSchema {
+    success: bool,
+    record: Option<ArchiveRecordSchema>,
+    error: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema, IntoParams)]
+struct ArchiveListQuerySchema {
+    session_key: Option<String>,
+    chat_id: Option<String>,
+    source_kind: Option<String>,
+    media_kind: Option<String>,
+    filename: Option<String>,
+    limit: Option<i64>,
+    offset: Option<i64>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+struct ArchiveListResponseSchema {
+    success: bool,
+    records: Vec<ArchiveRecordSchema>,
+    error: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+struct ArchiveGetResponseSchema {
+    success: bool,
+    record: Option<ArchiveRecordSchema>,
+    error: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+struct ProviderInfoSchema {
+    id: String,
+    name: Option<String>,
+    base_url: String,
+    wire_api: String,
+    default_model: String,
+    stream: bool,
+    has_api_key: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+struct ProvidersListResponseSchema {
+    success: bool,
+    providers: Vec<ProviderInfoSchema>,
+    default_provider: Option<String>,
+    error: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+struct GatewayWebhookPayloadSchema {
+    source: String,
+    event_type: String,
+    content: String,
+    base_session_key: Option<String>,
+    session_key: Option<String>,
+    chat_id: Option<String>,
+    sender_id: Option<String>,
+    payload: Option<Value>,
+    metadata: Option<BTreeMap<String, Value>>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+struct GatewayWebhookResponseSchema {
+    event_id: String,
+    status: String,
+    session_key: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema, IntoParams)]
+struct GatewayWebhookAgentQuerySchema {
+    hook_id: String,
+    base_session_key: Option<String>,
+    session_key: Option<String>,
+    chat_id: Option<String>,
+    sender_id: Option<String>,
+    provider: Option<String>,
+    model: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+struct GatewayWebhookAgentResponseSchema {
+    request_id: String,
+    status: String,
+    hook_id: String,
+    session_key: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+struct GatewayMcpServerConfigViewSchema {
+    id: String,
+    enabled: bool,
+    #[schema(example = "stdio")]
+    mode: String,
+    tool_timeout_seconds: u64,
+    command: Option<String>,
+    args: Vec<String>,
+    cwd: Option<String>,
+    url: Option<String>,
+    /// Environment variable names only. Secret values are never returned.
+    env_keys: Vec<String>,
+    /// Header names only. Secret values are never returned.
+    header_keys: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+struct GatewayMcpServerUpsertRequestSchema {
+    id: Option<String>,
+    enabled: Option<bool>,
+    #[schema(example = "stdio")]
+    mode: String,
+    tool_timeout_seconds: Option<u64>,
+    command: Option<String>,
+    args: Option<Vec<String>>,
+    env: Option<BTreeMap<String, String>>,
+    cwd: Option<String>,
+    url: Option<String>,
+    headers: Option<BTreeMap<String, String>>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+struct GatewayMcpRuntimeSnapshotSchema {
+    statuses: Vec<GatewayMcpServerStatusViewSchema>,
+    details: Vec<GatewayMcpServerDetailViewSchema>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+struct GatewayMcpServerStatusViewSchema {
+    id: String,
+    #[schema(example = "stdio")]
+    mode: String,
+    enabled: bool,
+    state: String,
+    last_error: Option<String>,
+    tool_count: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+struct GatewayMcpServerDetailViewSchema {
+    id: String,
+    tools_list_response: Option<Value>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+struct McpStatusResponseSchema {
+    success: bool,
+    runtime: Option<GatewayMcpRuntimeSnapshotSchema>,
+    error: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+struct McpServersResponseSchema {
+    success: bool,
+    servers: Vec<GatewayMcpServerConfigViewSchema>,
+    runtime: Option<GatewayMcpRuntimeSnapshotSchema>,
+    error: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+struct McpServerResponseSchema {
+    success: bool,
+    server: Option<GatewayMcpServerConfigViewSchema>,
+    status: Option<GatewayMcpServerStatusViewSchema>,
+    detail: Option<GatewayMcpServerDetailViewSchema>,
+    runtime: Option<GatewayMcpRuntimeSnapshotSchema>,
+    error: Option<String>,
+}
+
+#[utoipa::path(
+    get,
+    path = "/openapi.json",
+    tag = "docs",
+    responses((status = 200, description = "Gateway OpenAPI document"))
+)]
+fn openapi_json_docs() {}
+
+#[utoipa::path(
+    get,
+    path = "/scalar",
+    tag = "docs",
+    responses((status = 200, description = "Scalar API reference UI", content_type = "text/html"))
+)]
+fn scalar_docs() {}
+
+#[utoipa::path(
+    get,
+    path = "/ws/chat",
+    tag = "websocket",
+    responses((status = 101, description = "WebSocket upgrade for the Gateway chat protocol"))
+)]
+fn ws_chat_docs() {}
+
+#[utoipa::path(
+    post,
+    path = "/webhook/events",
+    tag = "webhook",
+    request_body = GatewayWebhookPayloadSchema,
+    responses(
+        (status = 202, description = "Webhook event accepted", body = GatewayWebhookResponseSchema),
+        (status = 400, description = "Invalid webhook payload", body = ErrorResponse),
+        (status = 401, description = "Invalid webhook auth", body = String)
+    )
+)]
+fn webhook_events_docs() {}
+
+#[utoipa::path(
+    post,
+    path = "/webhook/agents",
+    tag = "webhook",
+    params(GatewayWebhookAgentQuerySchema),
+    request_body = Value,
+    responses(
+        (status = 202, description = "Webhook agent request accepted", body = GatewayWebhookAgentResponseSchema),
+        (status = 400, description = "Invalid webhook agent payload", body = String),
+        (status = 401, description = "Invalid webhook auth", body = String)
+    )
+)]
+fn webhook_agents_docs() {}
+
+#[utoipa::path(
+    post,
+    path = "/archive/upload",
+    tag = "archive",
+    request_body(content_type = "multipart/form-data"),
+    responses(
+        (status = 200, description = "Archive file uploaded", body = ArchiveUploadResponseSchema),
+        (status = 400, description = "Invalid upload", body = ArchiveUploadResponseSchema),
+        (status = 503, description = "Archive service unavailable", body = ArchiveUploadResponseSchema)
+    )
+)]
+fn archive_upload_docs() {}
+
+#[utoipa::path(
+    get,
+    path = "/archive/download/{id}",
+    tag = "archive",
+    params(("id" = String, Path, description = "Archive record id")),
+    responses(
+        (status = 200, description = "Archive file bytes", content_type = "application/octet-stream"),
+        (status = 404, description = "Archive file not found", body = ErrorResponse),
+        (status = 503, description = "Archive service unavailable", body = ErrorResponse)
+    )
+)]
+fn archive_download_docs() {}
+
+#[utoipa::path(
+    get,
+    path = "/archive/list",
+    tag = "archive",
+    params(ArchiveListQuerySchema),
+    responses(
+        (status = 200, description = "Archive records", body = ArchiveListResponseSchema),
+        (status = 503, description = "Archive service unavailable", body = ArchiveListResponseSchema)
+    )
+)]
+fn archive_list_docs() {}
+
+#[utoipa::path(
+    get,
+    path = "/archive/{id}",
+    tag = "archive",
+    params(("id" = String, Path, description = "Archive record id")),
+    responses(
+        (status = 200, description = "Archive record", body = ArchiveGetResponseSchema),
+        (status = 404, description = "Archive record not found", body = ArchiveGetResponseSchema),
+        (status = 503, description = "Archive service unavailable", body = ArchiveGetResponseSchema)
+    )
+)]
+fn archive_get_docs() {}
+
+#[utoipa::path(
+    get,
+    path = "/providers/list",
+    tag = "providers",
+    responses(
+        (status = 200, description = "Configured providers", body = ProvidersListResponseSchema),
+        (status = 503, description = "Providers service unavailable", body = ProvidersListResponseSchema)
+    )
+)]
+fn providers_list_docs() {}
+
+#[utoipa::path(
+    get,
+    path = "/mcp/status",
+    tag = "mcp",
+    responses(
+        (status = 200, description = "MCP runtime snapshot", body = McpStatusResponseSchema),
+        (status = 503, description = "MCP service unavailable", body = McpStatusResponseSchema)
+    )
+)]
+fn mcp_status_docs() {}
+
+#[utoipa::path(
+    get,
+    path = "/mcp/servers",
+    tag = "mcp",
+    responses(
+        (status = 200, description = "Redacted MCP server configs and runtime snapshot", body = McpServersResponseSchema),
+        (status = 503, description = "MCP service unavailable", body = McpStatusResponseSchema)
+    )
+)]
+fn mcp_list_servers_docs() {}
+
+#[utoipa::path(
+    post,
+    path = "/mcp/servers",
+    tag = "mcp",
+    request_body = GatewayMcpServerUpsertRequestSchema,
+    responses(
+        (status = 200, description = "Created MCP server and synchronized runtime", body = McpServerResponseSchema),
+        (status = 400, description = "Invalid MCP server config", body = McpStatusResponseSchema),
+        (status = 409, description = "MCP server id already exists", body = McpStatusResponseSchema),
+        (status = 503, description = "MCP service unavailable", body = McpStatusResponseSchema)
+    )
+)]
+fn mcp_create_server_docs() {}
+
+#[utoipa::path(
+    get,
+    path = "/mcp/servers/{id}",
+    tag = "mcp",
+    params(("id" = String, Path, description = "MCP server id")),
+    responses(
+        (status = 200, description = "Redacted MCP server config and runtime detail", body = McpServerResponseSchema),
+        (status = 404, description = "MCP server not found", body = McpStatusResponseSchema),
+        (status = 503, description = "MCP service unavailable", body = McpStatusResponseSchema)
+    )
+)]
+fn mcp_get_server_docs() {}
+
+#[utoipa::path(
+    put,
+    path = "/mcp/servers/{id}",
+    tag = "mcp",
+    params(("id" = String, Path, description = "Existing MCP server id to replace")),
+    request_body = GatewayMcpServerUpsertRequestSchema,
+    responses(
+        (status = 200, description = "Updated MCP server and synchronized runtime", body = McpServerResponseSchema),
+        (status = 400, description = "Invalid MCP server config", body = McpStatusResponseSchema),
+        (status = 404, description = "MCP server not found", body = McpStatusResponseSchema),
+        (status = 409, description = "Renamed MCP server id already exists", body = McpStatusResponseSchema),
+        (status = 503, description = "MCP service unavailable", body = McpStatusResponseSchema)
+    )
+)]
+fn mcp_update_server_docs() {}
+
+#[utoipa::path(
+    delete,
+    path = "/mcp/servers/{id}",
+    tag = "mcp",
+    params(("id" = String, Path, description = "MCP server id")),
+    responses(
+        (status = 200, description = "Deleted MCP server and synchronized runtime", body = McpStatusResponseSchema),
+        (status = 404, description = "MCP server not found", body = McpStatusResponseSchema),
+        (status = 503, description = "MCP service unavailable", body = McpStatusResponseSchema)
+    )
+)]
+fn mcp_delete_server_docs() {}
+
+#[utoipa::path(
+    post,
+    path = "/mcp/sync",
+    tag = "mcp",
+    responses(
+        (status = 200, description = "MCP runtime synchronized from disk config", body = McpStatusResponseSchema),
+        (status = 503, description = "MCP service unavailable or busy", body = McpStatusResponseSchema)
+    )
+)]
+fn mcp_sync_docs() {}
+
+#[utoipa::path(
+    post,
+    path = "/mcp/servers/{id}/restart",
+    tag = "mcp",
+    params(("id" = String, Path, description = "MCP server id")),
+    responses(
+        (status = 200, description = "Restarted stdio MCP server and returned runtime snapshot", body = McpStatusResponseSchema),
+        (status = 400, description = "Server cannot be restarted", body = McpStatusResponseSchema),
+        (status = 404, description = "MCP server not found", body = McpStatusResponseSchema),
+        (status = 503, description = "MCP service unavailable or busy", body = McpStatusResponseSchema)
+    )
+)]
+fn mcp_restart_server_docs() {}
+
+#[utoipa::path(
+    get,
+    path = "/health/live",
+    tag = "health",
+    responses((status = 200, description = "Gateway is live", body = String, content_type = "text/plain"))
+)]
+fn health_live_docs() {}
+
+#[utoipa::path(
+    get,
+    path = "/health/ready",
+    tag = "health",
+    responses((status = 200, description = "Gateway is ready", body = String, content_type = "text/plain"))
+)]
+fn health_ready_docs() {}
+
+#[utoipa::path(
+    get,
+    path = "/health/status",
+    tag = "health",
+    responses((status = 200, description = "Gateway health status", body = HealthStatusResponse))
+)]
+fn health_status_docs() {}
+
+#[utoipa::path(
+    get,
+    path = "/metrics",
+    tag = "health",
+    responses(
+        (status = 200, description = "Prometheus metrics", body = String, content_type = "text/plain"),
+        (status = 404, description = "Prometheus metrics are not enabled", body = String, content_type = "text/plain")
+    )
+)]
+fn metrics_docs() {}

--- a/klaw-gateway/src/routes.rs
+++ b/klaw-gateway/src/routes.rs
@@ -50,6 +50,10 @@ pub enum Route {
     HealthStatus,
     #[strum(serialize = "/metrics")]
     Metrics,
+    #[strum(serialize = "/openapi.json")]
+    OpenApiJson,
+    #[strum(serialize = "/scalar")]
+    Scalar,
 }
 
 impl Route {

--- a/klaw-gateway/src/runtime.rs
+++ b/klaw-gateway/src/runtime.rs
@@ -12,6 +12,7 @@ use crate::{
         mcp_get_server_handler, mcp_list_servers_handler, mcp_restart_server_handler,
         mcp_status_handler, mcp_sync_handler, mcp_update_server_handler,
     },
+    openapi::{openapi_json_handler, scalar_router},
     providers::providers_list_handler,
     routes::Route,
     state::{
@@ -253,7 +254,9 @@ fn build_router(
         .route(Route::HealthLive.as_str(), get(health_live_handler))
         .route(Route::HealthReady.as_str(), get(health_ready_handler))
         .route(Route::HealthStatus.as_str(), get(health_status_handler))
-        .route(Route::Metrics.as_str(), get(metrics_handler));
+        .route(Route::Metrics.as_str(), get(metrics_handler))
+        .route(Route::OpenApiJson.as_str(), get(openapi_json_handler))
+        .merge(scalar_router());
 
     if config.webhook.enabled {
         if config.webhook.events.enabled {

--- a/klaw-gateway/src/tests.rs
+++ b/klaw-gateway/src/tests.rs
@@ -422,6 +422,117 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn gateway_docs_routes_expose_openapi_and_scalar_without_auth() {
+        let config = test_gateway_config();
+        let handle = match spawn_gateway_with_options(&config, GatewayOptions::default()).await {
+            Ok(handle) => handle,
+            Err(crate::GatewayError::Bind(err))
+                if err.kind() == std::io::ErrorKind::PermissionDenied =>
+            {
+                return;
+            }
+            Err(err) => panic!("gateway should start: {err}"),
+        };
+
+        let base_url = format!("http://127.0.0.1:{}", handle.info().actual_port);
+        let client = reqwest::Client::builder()
+            .no_proxy()
+            .build()
+            .expect("reqwest client");
+
+        let openapi: serde_json::Value = client
+            .get(format!("{base_url}{}", Route::OpenApiJson.as_str()))
+            .send()
+            .await
+            .expect("openapi should respond")
+            .json()
+            .await
+            .expect("openapi json");
+        assert_eq!(
+            openapi.pointer("/openapi").and_then(|value| value.as_str()),
+            Some("3.1.0")
+        );
+        for path in [
+            "/mcp/status",
+            "/mcp/servers",
+            "/archive/upload",
+            "/providers/list",
+            "/webhook/events",
+            "/health/status",
+        ] {
+            assert!(
+                openapi
+                    .pointer(&format!("/paths/{}", path.replace('/', "~1")))
+                    .is_some(),
+                "OpenAPI document should include {path}"
+            );
+        }
+
+        let scalar = client
+            .get(format!("{base_url}{}", Route::Scalar.as_str()))
+            .send()
+            .await
+            .expect("scalar should respond");
+        assert_eq!(scalar.status(), StatusCode::OK);
+        let content_type = scalar
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default()
+            .to_string();
+        let html = scalar.text().await.expect("scalar html");
+        assert!(content_type.starts_with("text/html"));
+        assert!(html.contains("Klaw Gateway API"));
+        assert!(html.contains("/openapi.json"));
+
+        handle.shutdown().await.expect("gateway should stop");
+    }
+
+    #[tokio::test]
+    async fn gateway_docs_routes_require_gateway_auth_when_enabled() {
+        let mut config = test_gateway_config();
+        config.auth = GatewayAuthConfig {
+            enabled: true,
+            token: Some("secret-token".to_string()),
+            env_key: None,
+        };
+        let handle = match spawn_gateway_with_options(&config, GatewayOptions::default()).await {
+            Ok(handle) => handle,
+            Err(crate::GatewayError::Bind(err))
+                if err.kind() == std::io::ErrorKind::PermissionDenied =>
+            {
+                return;
+            }
+            Err(err) => panic!("gateway should start: {err}"),
+        };
+
+        let base_url = format!("http://127.0.0.1:{}", handle.info().actual_port);
+        let client = reqwest::Client::builder()
+            .no_proxy()
+            .build()
+            .expect("reqwest client");
+
+        for route in [Route::OpenApiJson, Route::Scalar] {
+            let unauthorized = client
+                .get(format!("{base_url}{}", route.as_str()))
+                .send()
+                .await
+                .expect("docs route should respond");
+            assert_eq!(unauthorized.status(), StatusCode::UNAUTHORIZED);
+
+            let authorized = client
+                .get(format!("{base_url}{}", route.as_str()))
+                .bearer_auth("secret-token")
+                .send()
+                .await
+                .expect("docs route should respond with auth");
+            assert_eq!(authorized.status(), StatusCode::OK);
+        }
+
+        handle.shutdown().await.expect("gateway should stop");
+    }
+
+    #[tokio::test]
     async fn spawn_gateway_uses_actual_random_port() {
         let config = GatewayConfig {
             enabled: true,
@@ -810,6 +921,8 @@ mod tests {
             Route::McpServerRestart.as_str(),
             "/mcp/servers/{id}/restart"
         );
+        assert_eq!(Route::OpenApiJson.as_str(), "/openapi.json");
+        assert_eq!(Route::Scalar.as_str(), "/scalar");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add utoipa-generated OpenAPI for gateway HTTP APIs at /openapi.json
- add Scalar API reference UI at /scalar
- protect docs routes with Gateway Auth when enabled
- document docs endpoints and update gateway API docs/changelog

## Notes
- This is a stacked PR on top of codex/add-mcp-management-api because /mcp/* is not on main yet and this OpenAPI work documents those endpoints.
- Closes #253

## Test Plan
- cargo fmt --all -- --check
- cargo test -p klaw-gateway