### PR TITLE
fix(gateway): keep API docs public

### DIFF
--- a/docs/src/gateway/http-api.md
+++ b/docs/src/gateway/http-api.md
@@ -27,7 +27,7 @@
 - API 文档：
   - `GET /openapi.json` 返回 Gateway HTTP API 的 OpenAPI JSON。
   - `GET /scalar` 返回 Scalar API reference UI。
-  - 当 `gateway.auth.enabled = true` 时，这两个端点与其他 Gateway Auth 端点一样要求 `Authorization: Bearer <token>`；未开启认证时可直接访问。
+  - 这两个端点始终不做 Gateway Auth，方便浏览器直接打开；生产暴露时请将其视为公开文档端点。
 
 ## 路由注册条件
 
@@ -50,13 +50,13 @@
 #### 0.1 OpenAPI JSON
 
 - **端点**：`GET /openapi.json`
-- **认证**：Gateway Auth（仅当 `gateway.auth.enabled = true`）
+- **认证**：无
 - **描述**：返回 Gateway HTTP API 的 OpenAPI 3.1 JSON 文档，覆盖 archive、providers、MCP、webhook、health、metrics 和 `/ws/chat` upgrade 描述。
 
 #### 0.2 Scalar API Reference
 
 - **端点**：`GET /scalar`
-- **认证**：Gateway Auth（仅当 `gateway.auth.enabled = true`）
+- **认证**：无
 - **描述**：返回 Scalar API reference UI。页面内嵌当前 OpenAPI spec，并标记 `/openapi.json` 作为机器可读文档地址。
 
 ### 1. 归档管理接口

--- a/klaw-gateway/CHANGELOG.md
+++ b/klaw-gateway/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Gateway now serves OpenAPI JSON at `/openapi.json` and a Scalar API reference UI at `/scalar`, with the same Gateway Auth behavior as protected gateway APIs.
+- Gateway now serves public OpenAPI JSON at `/openapi.json` and a public Scalar API reference UI at `/scalar`.
 - Gateway now exposes authenticated `/mcp/*` management endpoints for MCP runtime status, redacted server config CRUD, runtime sync, and stdio server restart.
 
 ### Fixed

--- a/klaw-gateway/README.md
+++ b/klaw-gateway/README.md
@@ -59,8 +59,8 @@
 - webhook 路由是否注册由 `gateway.webhook.enabled` 决定；`events` / `agents` 仅可分别启停并配置独立 body limit，路径固定不再开放配置
 - archive 路由在 `GatewayOptions` 中提供 `archive_service` 时自动注册，所有 archive 接口均需要 Bearer 鉴权
 - MCP 路由在 `GatewayOptions` 中提供 `mcp_handler` 时自动注册，所有 `/mcp/*` 接口均需要 Bearer 鉴权；返回 server 配置时只暴露 `env_keys` / `header_keys`，不回传 secret 原文
-- `/openapi.json` 和 `/scalar` 始终注册；当 `gateway.auth.enabled = true` 时，它们与 `/ws/chat`、`/archive/*`、`/providers/list`、`/mcp/*` 使用同一套 gateway Bearer 鉴权；未开启认证时保持无认证访问
-- 仅 `/ws/chat`、`/archive/*`、`/providers/list`、`/mcp/*`、`/openapi.json` 和 `/scalar` 会走 gateway Bearer 鉴权中间件（含 `/ws/chat` query token 回退）；`/webhook/events` 与 `/webhook/agents` 继续复用 `gateway.auth` 的 token/env secret 做 webhook 专用多模式校验；首页、`/chat` 及其静态资源、health、metrics 不做鉴权
+- `/openapi.json` 和 `/scalar` 始终注册并保持无认证访问，方便浏览器直接打开 API reference；生产暴露时请把它们视为公开文档端点
+- 仅 `/ws/chat`、`/archive/*`、`/providers/list` 和 `/mcp/*` 会走 gateway Bearer 鉴权中间件（含 `/ws/chat` query token 回退）；`/webhook/events` 与 `/webhook/agents` 继续复用 `gateway.auth` 的 token/env secret 做 webhook 专用多模式校验；首页、`/chat` 及其静态资源、health、metrics、API docs 不做鉴权
 - `TailscaleManager::inspect_host()` 可独立读取本机 Tailscale 状态，供 GUI 在 gateway 未运行时展示主机连接信息；当本机 daemon 无响应时会在短超时后回落为 host 侧不可用状态，避免拖慢整个 gateway 状态刷新
 - Tailscale Serve/Funnel 会在 gateway 绑定完成后使用实际监听端口做反向代理，并在 setup 后回读 `tailscale serve status --json` / `tailscale funnel status --json` 确认配置是否生效；setup/reset/status 通过 `tokio::process::Command` 执行并带超时，超时会终止子进程，避免本机 Tailscale CLI 卡住 async runtime；Funnel 未配置 auth 时允许启动，但应视为公网裸露入口
 
@@ -102,11 +102,10 @@ GATEWAY_TOKEN=your-token BASE_URL=http://127.0.0.1:18080 cargo run -p klaw-gatew
 ## API Docs Usage
 
 ```bash
-curl -X GET http://127.0.0.1:18080/openapi.json \
-  -H "Authorization: Bearer your-token"
+curl -X GET http://127.0.0.1:18080/openapi.json
 ```
 
-Open `http://127.0.0.1:18080/scalar` in a browser for the Scalar API reference. Both docs endpoints are public only when `gateway.auth.enabled = false`.
+Open `http://127.0.0.1:18080/scalar` in a browser for the Scalar API reference. Both docs endpoints are public even when `gateway.auth.enabled = true`.
 
 ### Upload File
 

--- a/klaw-gateway/src/auth.rs
+++ b/klaw-gateway/src/auth.rs
@@ -72,8 +72,6 @@ pub fn should_require_gateway_auth(path: &str) -> bool {
         || path == Route::ArchiveUpload.as_str()
         || path == Route::ArchiveList.as_str()
         || path == Route::ProvidersList.as_str()
-        || path == Route::OpenApiJson.as_str()
-        || path == Route::Scalar.as_str()
         || path.starts_with("/archive/download/")
         || path.starts_with("/archive/")
         || path.starts_with("/mcp/")
@@ -354,8 +352,8 @@ mod tests {
         assert!(should_require_gateway_auth("/providers/list"));
         assert!(should_require_gateway_auth("/mcp/status"));
         assert!(should_require_gateway_auth("/mcp/servers/local/restart"));
-        assert!(should_require_gateway_auth("/openapi.json"));
-        assert!(should_require_gateway_auth("/scalar"));
+        assert!(!should_require_gateway_auth("/openapi.json"));
+        assert!(!should_require_gateway_auth("/scalar"));
         assert!(!should_require_gateway_auth("/"));
         assert!(!should_require_gateway_auth("/health/status"));
         assert!(!should_require_gateway_auth("/metrics"));

--- a/klaw-gateway/src/tests.rs
+++ b/klaw-gateway/src/tests.rs
@@ -489,7 +489,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn gateway_docs_routes_require_gateway_auth_when_enabled() {
+    async fn gateway_docs_routes_remain_public_when_gateway_auth_enabled() {
         let mut config = test_gateway_config();
         config.auth = GatewayAuthConfig {
             enabled: true,
@@ -513,12 +513,12 @@ mod tests {
             .expect("reqwest client");
 
         for route in [Route::OpenApiJson, Route::Scalar] {
-            let unauthorized = client
+            let public = client
                 .get(format!("{base_url}{}", route.as_str()))
                 .send()
                 .await
                 .expect("docs route should respond");
-            assert_eq!(unauthorized.status(), StatusCode::UNAUTHORIZED);
+            assert_eq!(public.status(), StatusCode::OK);
 
             let authorized = client
                 .get(format!("{base_url}{}", route.as_str()))


### PR DESCRIPTION
## Summary
- keep /openapi.json and /scalar outside Gateway Auth protection
- update gateway tests to assert docs remain public when auth is enabled
- align README, mdBook HTTP API docs, and changelog with the public docs behavior

## Test Plan
- cargo fmt --all -- --check
- cargo test -p klaw-gateway